### PR TITLE
Change names of DAPA Tutorial notebooks

### DIFF
--- a/notebooks/contributions/DAPA/DAPA_Tutorial_1_-_Cube_-_Sentinel-2.ipynb
+++ b/notebooks/contributions/DAPA/DAPA_Tutorial_1_-_Cube_-_Sentinel-2.ipynb
@@ -1530,7 +1530,7 @@
    "description": "Cube retrieval based on DAPA experimental interface",
    "id": "9bf6b605-ee7b-4fc2-bade-99ba57bc6d92",
    "license": null,
-   "name": "OGC Testbed 16 DAPA: Tutorial #1 - Cube - Sentinel-2",
+   "name": "DAPA Tutorial #1: Cube - Sentinel-2 - OGC Testbed 16",
    "requirements": [],
    "tags": [
     "DAPA"

--- a/notebooks/contributions/DAPA/DAPA_Tutorial_2_-_Area_-_Sentinel-2.ipynb
+++ b/notebooks/contributions/DAPA/DAPA_Tutorial_2_-_Area_-_Sentinel-2.ipynb
@@ -883,7 +883,7 @@
    "description": "Area calculation based on DAPA experimental interface",
    "id": "75ce9790-2d64-4471-b407-b762c4839356",
    "license": null,
-   "name": "OGC Testbed 16 DAPA: Tutorial #2 - Area - Sentinel-2",
+   "name": "DAPA Tutorial #2: Area - Sentinel-2 - OGC Testbed 16",
    "requirements": [
     "eoxhub"
    ],

--- a/notebooks/contributions/DAPA/DAPA_Tutorial_3_-_Timeseries_-_Sentinel-2.ipynb
+++ b/notebooks/contributions/DAPA/DAPA_Tutorial_3_-_Timeseries_-_Sentinel-2.ipynb
@@ -1083,7 +1083,7 @@
    "description": "Timeseries extraction based on DAPA experimental interface",
    "id": "6cf1d7e1-ad61-4dac-8dd0-e2bfedb6e343",
    "license": null,
-   "name": "OGC Testbed 16 DAPA: Tutorial #3 - Timeseries - Sentinel-2",
+   "name": "DAPA Tutorial #3: Timeseries - Sentinel-2 - OGC Testbed 16",
    "requirements": [],
    "tags": [
     "DAPA"

--- a/notebooks/contributions/DAPA/DAPA_Tutorial_4_-_Value_-_Sentinel-2.ipynb
+++ b/notebooks/contributions/DAPA/DAPA_Tutorial_4_-_Value_-_Sentinel-2.ipynb
@@ -668,7 +668,7 @@
    "description": "Value extraction based on DAPA experimental interface",
    "id": "95e1bd19-f57f-491f-afb2-1b10fb2efed1",
    "license": null,
-   "name": "OGC Testbed 16 DAPA: Tutorial #4 - Value - Sentinel-2",
+   "name": "DAPA Tutorial #4: Value - Sentinel-2 - OGC Testbed 16",
    "requirements": [],
    "tags": [
     "DAPA"


### PR DESCRIPTION
New names of the DAPA Tutorial notebooks - as discussed via mail.