### PR TITLE
minor changes in xcube notebooks for Marketplace

### DIFF
--- a/notebooks/curated/EDC_Sentinel_Hub-Data-access.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-Data-access.ipynb
@@ -148,15 +148,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "0fee4a78",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:20.079395Z",
-     "iopub.status.busy": "2022-02-23T14:00:20.078980Z",
-     "iopub.status.idle": "2022-02-23T14:00:23.019039Z",
-     "shell.execute_reply": "2022-02-23T14:00:23.018352Z"
-    },
     "papermill": {
      "duration": 2.980104,
      "end_time": "2022-02-23T14:00:23.021140",
@@ -189,15 +183,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "ca17a3b7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:23.089727Z",
-     "iopub.status.busy": "2022-02-23T14:00:23.089066Z",
-     "iopub.status.idle": "2022-02-23T14:00:23.824648Z",
-     "shell.execute_reply": "2022-02-23T14:00:23.823829Z"
-    },
     "papermill": {
      "duration": 0.771708,
      "end_time": "2022-02-23T14:00:23.826725",
@@ -210,6 +198,59 @@
    "outputs": [],
    "source": [
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "358b64b2-5eb4-4f17-ad46-5e0334197bb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xcube\n",
+    "import xcube_sh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c9f362cd-d16a-406d-adfd-f2ea2484a1f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.9.5'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "xcube_sh.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "65f0a992-a00c-464a-9e5a-b33055fa2cac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.11.2'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "xcube.__version__\n"
    ]
   },
   {
@@ -232,15 +273,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "2168ea3f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:23.964414Z",
-     "iopub.status.busy": "2022-02-23T14:00:23.963788Z",
-     "iopub.status.idle": "2022-02-23T14:00:23.968568Z",
-     "shell.execute_reply": "2022-02-23T14:00:23.967758Z"
-    },
     "papermill": {
      "duration": 0.041409,
      "end_time": "2022-02-23T14:00:23.970482",
@@ -279,15 +314,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "99bd54fa",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:24.122387Z",
-     "iopub.status.busy": "2022-02-23T14:00:24.121696Z",
-     "iopub.status.idle": "2022-02-23T14:00:24.128480Z",
-     "shell.execute_reply": "2022-02-23T14:00:24.127692Z"
-    },
     "papermill": {
      "duration": 0.044481,
      "end_time": "2022-02-23T14:00:24.130589",
@@ -304,23 +333,23 @@
        "coordinates": [
         [
          [
-          11.0,
+          11,
           54.27
          ],
          [
-          11.0,
+          11,
           54.6
          ],
          [
-          10.0,
+          10,
           54.6
          ],
          [
-          10.0,
+          10,
           54.27
          ],
          [
-          11.0,
+          11,
           54.27
          ]
         ]
@@ -366,15 +395,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "024b7b12",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:24.276569Z",
-     "iopub.status.busy": "2022-02-23T14:00:24.275753Z",
-     "iopub.status.idle": "2022-02-23T14:00:24.279848Z",
-     "shell.execute_reply": "2022-02-23T14:00:24.279028Z"
-    },
     "papermill": {
      "duration": 0.045287,
      "end_time": "2022-02-23T14:00:24.282047",
@@ -409,15 +432,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "be3a38e5",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:24.426129Z",
-     "iopub.status.busy": "2022-02-23T14:00:24.425557Z",
-     "iopub.status.idle": "2022-02-23T14:00:24.434463Z",
-     "shell.execute_reply": "2022-02-23T14:00:24.433551Z"
-    },
     "papermill": {
      "duration": 0.046215,
      "end_time": "2022-02-23T14:00:24.436363",
@@ -427,21 +444,12 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cube_config = CubeConfig(dataset_name='S2L2A',\n",
     "                         band_names=['B04', 'B05', 'B06', 'B11', 'SCL', 'CLD'],\n",
     "                         tile_size=[512, 512],\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         spatial_res=spatial_res,\n",
     "                         time_range=['2018-05-14', '2018-07-31'],\n",
     "                         time_period='2D')"
@@ -466,15 +474,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "ce99eff6",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:24.584470Z",
-     "iopub.status.busy": "2022-02-23T14:00:24.583656Z",
-     "iopub.status.idle": "2022-02-23T14:00:24.588928Z",
-     "shell.execute_reply": "2022-02-23T14:00:24.587718Z"
-    },
     "papermill": {
      "duration": 0.044142,
      "end_time": "2022-02-23T14:00:24.591148",
@@ -508,15 +510,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "3df69e80",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:24.739285Z",
-     "iopub.status.busy": "2022-02-23T14:00:24.738711Z",
-     "iopub.status.idle": "2022-02-23T14:00:24.939459Z",
-     "shell.execute_reply": "2022-02-23T14:00:24.938745Z"
-    },
     "papermill": {
      "duration": 0.239149,
      "end_time": "2022-02-23T14:00:24.941741",
@@ -533,15 +529,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "3eb0cb62",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:25.016516Z",
-     "iopub.status.busy": "2022-02-23T14:00:25.015605Z",
-     "iopub.status.idle": "2022-02-23T14:00:25.135522Z",
-     "shell.execute_reply": "2022-02-23T14:00:25.134637Z"
-    },
     "papermill": {
      "duration": 0.160274,
      "end_time": "2022-02-23T14:00:25.140274",
@@ -925,7 +915,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:00:24.838492\n",
+       "    date_created:              2022-06-23T08:24:46.307410\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -934,7 +924,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-d42e8258-badf-4d7c-8074-74968ccb3d5e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d42e8258-badf-4d7c-8074-74968ccb3d5e' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-f9872932-4191-432e-97d9-c10db4ed4f65' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f9872932-4191-432e-97d9-c10db4ed4f65' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-4aecf052-0d7a-4a95-ab49-757b9b031a12' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4aecf052-0d7a-4a95-ab49-757b9b031a12' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0f01d417-8616-487a-9102-9ca12505e20b' class='xr-var-data-in' type='checkbox'><label for='data-0f01d417-8616-487a-9102-9ca12505e20b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-c3054486-a046-42d5-abf0-825e811498c6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c3054486-a046-42d5-abf0-825e811498c6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f898b86b-2487-43b1-8236-95f2a3ef52fd' class='xr-var-data-in' type='checkbox'><label for='data-f898b86b-2487-43b1-8236-95f2a3ef52fd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-e2a945e0-c2a4-4bf6-9a82-d2ab01cfbd85' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e2a945e0-c2a4-4bf6-9a82-d2ab01cfbd85' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5b023506-dc2f-4ae4-b508-6bee5a1863d5' class='xr-var-data-in' type='checkbox'><label for='data-5b023506-dc2f-4ae4-b508-6bee5a1863d5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-35a4d8cd-f77d-4e9c-b116-beb1881f89e5' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-35a4d8cd-f77d-4e9c-b116-beb1881f89e5' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-8ca415f6-26db-46b0-9264-9761125f79ee' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8ca415f6-26db-46b0-9264-9761125f79ee' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-17c58e3a-99f5-4df9-9897-75512b395773' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-17c58e3a-99f5-4df9-9897-75512b395773' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-47f55a9d-be42-4fd1-b446-f3eb7f09fd57' class='xr-var-data-in' type='checkbox'><label for='data-47f55a9d-be42-4fd1-b446-f3eb7f09fd57' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-92dfbdf1-2c5f-4cd0-ae4d-6c1111ee923d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-92dfbdf1-2c5f-4cd0-ae4d-6c1111ee923d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1fc78439-ca16-4a49-b63f-59f5231e4f17' class='xr-var-data-in' type='checkbox'><label for='data-1fc78439-ca16-4a49-b63f-59f5231e4f17' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-2452a99a-6812-4d3c-a5af-9da49ed524a3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2452a99a-6812-4d3c-a5af-9da49ed524a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-68967322-dc1d-4397-85f9-6d777c2db732' class='xr-var-data-in' type='checkbox'><label for='data-68967322-dc1d-4397-85f9-6d777c2db732' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -954,7 +944,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-b46ba613-4cb6-45ac-8b33-6859e9f114a0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b46ba613-4cb6-45ac-8b33-6859e9f114a0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4b8ea7f8-fb0c-453b-b108-a3e64b14a069' class='xr-var-data-in' type='checkbox'><label for='data-4b8ea7f8-fb0c-453b-b108-a3e64b14a069' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-baf7a8df-efdc-42c5-986f-aa8145a74d60' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-baf7a8df-efdc-42c5-986f-aa8145a74d60' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-49d2faa7-6af9-4523-bc0d-f4219e44cde6' class='xr-var-data-in' type='checkbox'><label for='data-49d2faa7-6af9-4523-bc0d-f4219e44cde6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1011,7 +1001,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-edba72e0-81f7-45ef-9177-3d1239945b77' class='xr-section-summary-in' type='checkbox'  checked><label for='section-edba72e0-81f7-45ef-9177-3d1239945b77' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-8687c491-7be7-4613-9f70-d9941fa200b0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8687c491-7be7-4613-9f70-d9941fa200b0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f896a538-9dfb-4128-8f0b-956e06c623de' class='xr-var-data-in' type='checkbox'><label for='data-f896a538-9dfb-4128-8f0b-956e06c623de' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6ad39bd4-5855-4717-ad66-33b3314caec5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6ad39bd4-5855-4717-ad66-33b3314caec5' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-751ad877-53a6-4285-ae3d-5cffb20735b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-751ad877-53a6-4285-ae3d-5cffb20735b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-33aa4ab3-0385-49c1-baf9-6c8df24b3ed1' class='xr-var-data-in' type='checkbox'><label for='data-33aa4ab3-0385-49c1-baf9-6c8df24b3ed1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1153,7 +1143,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-20bb62be-a109-48ce-bb7a-8d9966e83dd6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-20bb62be-a109-48ce-bb7a-8d9966e83dd6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cd683e09-1003-4e3f-9219-22867f041244' class='xr-var-data-in' type='checkbox'><label for='data-cd683e09-1003-4e3f-9219-22867f041244' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-30fdd886-1684-482f-b696-4ae506b3b73a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-30fdd886-1684-482f-b696-4ae506b3b73a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a3d48363-2a1e-468d-8acc-284504801908' class='xr-var-data-in' type='checkbox'><label for='data-a3d48363-2a1e-468d-8acc-284504801908' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1295,7 +1285,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-43c2fade-26e0-4eb0-a0a8-3ac652ec469c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-43c2fade-26e0-4eb0-a0a8-3ac652ec469c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-60b748dd-8eed-4f73-b907-af82c1e689da' class='xr-var-data-in' type='checkbox'><label for='data-60b748dd-8eed-4f73-b907-af82c1e689da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c4039e9d-f0ac-4da3-8539-ac4b4e53e8f6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c4039e9d-f0ac-4da3-8539-ac4b4e53e8f6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e9831ca9-80b6-4b8e-bc24-693b8d2326c7' class='xr-var-data-in' type='checkbox'><label for='data-e9831ca9-80b6-4b8e-bc24-693b8d2326c7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1437,7 +1427,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e8868df8-2568-4e60-9e7f-cb3ea47b72d1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e8868df8-2568-4e60-9e7f-cb3ea47b72d1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-54af4c51-859f-4378-aeb6-af1b94f86ac6' class='xr-var-data-in' type='checkbox'><label for='data-54af4c51-859f-4378-aeb6-af1b94f86ac6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-9ec5b760-5562-4018-bce3-b7c388842b30' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9ec5b760-5562-4018-bce3-b7c388842b30' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0168cd99-d9d8-407c-bede-a110c85b4bd8' class='xr-var-data-in' type='checkbox'><label for='data-0168cd99-d9d8-407c-bede-a110c85b4bd8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1579,7 +1569,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-397a5228-c9d9-4662-b17e-73a3a15f59bc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-397a5228-c9d9-4662-b17e-73a3a15f59bc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0a277ff-bd54-4b40-a5ef-8d6f3d18a643' class='xr-var-data-in' type='checkbox'><label for='data-e0a277ff-bd54-4b40-a5ef-8d6f3d18a643' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-eddda55d-1cad-4bdb-824c-e37141444506' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eddda55d-1cad-4bdb-824c-e37141444506' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bef096fc-bcc7-4367-b550-1fa17c1cb49a' class='xr-var-data-in' type='checkbox'><label for='data-bef096fc-bcc7-4367-b550-1fa17c1cb49a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1721,7 +1711,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-32a06864-ff8e-43e4-b745-b780e39889c4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-32a06864-ff8e-43e4-b745-b780e39889c4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5faca646-a44c-41a6-9319-f60a6e4d01d5' class='xr-var-data-in' type='checkbox'><label for='data-5faca646-a44c-41a6-9319-f60a6e4d01d5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-21ff8663-8b0b-4b73-9685-7e253cdc4057' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-21ff8663-8b0b-4b73-9685-7e253cdc4057' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ac25d76b-b5fe-4b22-a8d8-2dd6c3242281' class='xr-var-data-in' type='checkbox'><label for='data-ac25d76b-b5fe-4b22-a8d8-2dd6c3242281' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1863,7 +1853,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-a6b429e2-4670-43b4-aeb3-72bb23ca6504' class='xr-section-summary-in' type='checkbox'  ><label for='section-a6b429e2-4670-43b4-aeb3-72bb23ca6504' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:00:24.838492</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-7889ac36-b8b4-40ce-ab97-7a8e9b9ab458' class='xr-section-summary-in' type='checkbox'  ><label for='section-7889ac36-b8b4-40ce-ab97-7a8e9b9ab458' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:24:46.307410</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1885,7 +1875,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:00:24.838492\n",
+       "    date_created:              2022-06-23T08:24:46.307410\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -1897,7 +1887,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1925,15 +1915,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "5ffa39f2",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:25.297306Z",
-     "iopub.status.busy": "2022-02-23T14:00:25.296675Z",
-     "iopub.status.idle": "2022-02-23T14:00:25.302779Z",
-     "shell.execute_reply": "2022-02-23T14:00:25.301958Z"
-    },
     "papermill": {
      "duration": 0.047511,
      "end_time": "2022-02-23T14:00:25.305130",
@@ -1950,10 +1934,10 @@
        "<html><p>No requests made yet.</p></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f2bc8edec40>"
+       "<xcube_sh.observers._RequestStats at 0x7f9c77c9d5b0>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1981,15 +1965,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "aded591a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:25.467188Z",
-     "iopub.status.busy": "2022-02-23T14:00:25.466686Z",
-     "iopub.status.idle": "2022-02-23T14:00:25.762480Z",
-     "shell.execute_reply": "2022-02-23T14:00:25.761796Z"
-    },
     "papermill": {
      "duration": 0.339647,
      "end_time": "2022-02-23T14:00:25.764339",
@@ -2003,10 +1981,10 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7f2bc8ef8c40>]"
+       "[<matplotlib.lines.Line2D at 0x7f9c77c42340>]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2029,15 +2007,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "74836cf9",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:25.844485Z",
-     "iopub.status.busy": "2022-02-23T14:00:25.842609Z",
-     "iopub.status.idle": "2022-02-23T14:00:25.870217Z",
-     "shell.execute_reply": "2022-02-23T14:00:25.869398Z"
-    },
     "papermill": {
      "duration": 0.069578,
      "end_time": "2022-02-23T14:00:25.872430",
@@ -2403,7 +2375,7 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray &#x27;B04&#x27; (time: 40, lat: 2048, lon: 5632)&gt;\n",
-       "dask.array&lt;open_dataset-72df06b46f30fad6dc158f795783eb35B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
+       "dask.array&lt;open_dataset-dc378ac14da942ea3a52cd7b803ee4f3B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2417,7 +2389,7 @@
        "    bandwidth:     31.0\n",
        "    bandwidth_a:   31\n",
        "    bandwidth_b:   31\n",
-       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-75902fe6-d33b-4a26-9b57-a824f26ceb53' class='xr-array-in' type='checkbox' checked><label for='section-75902fe6-d33b-4a26-9b57-a824f26ceb53' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-4a735b7a-fa92-47c8-8996-a0a152842a94' class='xr-array-in' type='checkbox' checked><label for='section-4a735b7a-fa92-47c8-8996-a0a152842a94' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2559,7 +2531,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-439ca38f-b56c-475c-b2f3-bb71e049e3fe' class='xr-section-summary-in' type='checkbox'  checked><label for='section-439ca38f-b56c-475c-b2f3-bb71e049e3fe' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-d24afcdc-8f46-4327-a7af-d357620dc392' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d24afcdc-8f46-4327-a7af-d357620dc392' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-be854667-d3c6-429b-a93d-4a3d83d003e6' class='xr-var-data-in' type='checkbox'><label for='data-be854667-d3c6-429b-a93d-4a3d83d003e6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-8396c2d4-c791-43f8-a449-4b73602c79e1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8396c2d4-c791-43f8-a449-4b73602c79e1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e5d2ed77-e964-4718-adaf-113f4261dbb7' class='xr-var-data-in' type='checkbox'><label for='data-e5d2ed77-e964-4718-adaf-113f4261dbb7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-13e3e778-f24b-45ae-8514-5cd55ab65369' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-13e3e778-f24b-45ae-8514-5cd55ab65369' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eeb14c9c-4f50-43ee-abc8-1d889a431277' class='xr-var-data-in' type='checkbox'><label for='data-eeb14c9c-4f50-43ee-abc8-1d889a431277' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-4e0f36bc-1ea4-46e6-af43-f5be8cbf1c87' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4e0f36bc-1ea4-46e6-af43-f5be8cbf1c87' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-b47d6522-9f1f-4d9a-bc4e-4bbc73e49b11' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b47d6522-9f1f-4d9a-bc4e-4bbc73e49b11' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7da24f37-570c-4dac-bc4d-a8fcf0a5ecc1' class='xr-var-data-in' type='checkbox'><label for='data-7da24f37-570c-4dac-bc4d-a8fcf0a5ecc1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-63452e22-c8c8-4390-9274-8badaede4f09' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-63452e22-c8c8-4390-9274-8badaede4f09' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e906f9ff-19f9-4d91-8506-23fd48df71c0' class='xr-var-data-in' type='checkbox'><label for='data-e906f9ff-19f9-4d91-8506-23fd48df71c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-582f2812-bedd-4a1e-8f64-da69dd29e294' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-582f2812-bedd-4a1e-8f64-da69dd29e294' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0cac7501-316f-4f1c-831b-28b47ef5bc43' class='xr-var-data-in' type='checkbox'><label for='data-0cac7501-316f-4f1c-831b-28b47ef5bc43' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2579,11 +2551,11 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d221d733-6ac9-496a-83b3-8a13050b05ab' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d221d733-6ac9-496a-83b3-8a13050b05ab' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-72bfda17-5e46-49f0-a22f-fd42459e7309' class='xr-section-summary-in' type='checkbox'  checked><label for='section-72bfda17-5e46-49f0-a22f-fd42459e7309' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'B04' (time: 40, lat: 2048, lon: 5632)>\n",
-       "dask.array<open_dataset-72df06b46f30fad6dc158f795783eb35B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
+       "dask.array<open_dataset-dc378ac14da942ea3a52cd7b803ee4f3B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2600,7 +2572,7 @@
        "    resolution:    10"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2611,15 +2583,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "05e245fa",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:25.965433Z",
-     "iopub.status.busy": "2022-02-23T14:00:25.965016Z",
-     "iopub.status.idle": "2022-02-23T14:00:48.694510Z",
-     "shell.execute_reply": "2022-02-23T14:00:48.693616Z"
-    },
     "papermill": {
      "duration": 22.795338,
      "end_time": "2022-02-23T14:00:48.707323",
@@ -2633,10 +2599,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f2bc82d3d00>"
+       "<matplotlib.image.AxesImage at 0x7f9c752a3280>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2676,15 +2642,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "8e1819df",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:48.939441Z",
-     "iopub.status.busy": "2022-02-23T14:00:48.938795Z",
-     "iopub.status.idle": "2022-02-23T14:00:48.946867Z",
-     "shell.execute_reply": "2022-02-23T14:00:48.946012Z"
-    },
     "papermill": {
      "duration": 0.06546,
      "end_time": "2022-02-23T14:00:48.949257",
@@ -2698,13 +2658,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>280.23 ms</td></tr><tr><td>Request duration max:</td><td>898.11 ms</td></tr><tr><td>Request duration median:</td><td>441.58 ms</td></tr><tr><td>Request duration mean:</td><td>484.47 ms</td></tr><tr><td>Request duration std:</td><td>147.21 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>348.08 ms</td></tr><tr><td>Request duration max:</td><td>2103.30 ms</td></tr><tr><td>Request duration median:</td><td>483.02 ms</td></tr><tr><td>Request duration mean:</td><td>588.38 ms</td></tr><tr><td>Request duration std:</td><td>292.82 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f2bc83a0880>"
+       "<xcube_sh.observers._RequestStats at 0x7f9c77c9dbb0>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2750,15 +2710,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "1a59ff33",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:49.285994Z",
-     "iopub.status.busy": "2022-02-23T14:00:49.285471Z",
-     "iopub.status.idle": "2022-02-23T14:00:49.292827Z",
-     "shell.execute_reply": "2022-02-23T14:00:49.291927Z"
-    },
     "papermill": {
      "duration": 0.067348,
      "end_time": "2022-02-23T14:00:49.294718",
@@ -2773,8 +2727,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n",
       "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/pandas/core/tools/timedeltas.py:148: FutureWarning: Units 'M', 'Y' and 'y' do not represent unambiguous timedelta values and will be removed in a future version.\n",
       "  return _coerce_scalar_to_timedelta_type(arg, unit=unit, errors=errors)\n"
      ]
@@ -2784,7 +2736,7 @@
     "cube_config = CubeConfig(dataset_name='S2L2A',\n",
     "                         band_names=['B04', 'B05', 'B06', 'B11', 'SCL', 'CLD'],\n",
     "                         tile_size=[512, 512],\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         spatial_res=spatial_res,\n",
     "                         time_range=['2018-05-14', '2018-07-31'],                         \n",
     "                         time_tolerance='30M')"
@@ -2792,15 +2744,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "ead19c93",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:49.416368Z",
-     "iopub.status.busy": "2022-02-23T14:00:49.415659Z",
-     "iopub.status.idle": "2022-02-23T14:00:49.843307Z",
-     "shell.execute_reply": "2022-02-23T14:00:49.842372Z"
-    },
     "papermill": {
      "duration": 0.487549,
      "end_time": "2022-02-23T14:00:49.846764",
@@ -3184,7 +3130,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-02-23T14:00:49.747063\n",
+       "    date_created:            2022-06-23T08:25:16.427255\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -3192,7 +3138,7 @@
        "    geospatial_lat_min:      54.27\n",
        "    geospatial_lon_max:      11.01376\n",
        "    geospatial_lat_max:      54.63864\n",
-       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-991be49a-83dd-4d20-950d-172be45ceb74' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-991be49a-83dd-4d20-950d-172be45ceb74' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-f0a7419f-139e-4f50-bc96-6e6719a51a2c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f0a7419f-139e-4f50-bc96-6e6719a51a2c' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-d7468d94-a18c-48c5-8809-722c76921f74' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d7468d94-a18c-48c5-8809-722c76921f74' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0f4ed72a-56bf-46f8-9f3e-e22137f7d7f1' class='xr-var-data-in' type='checkbox'><label for='data-0f4ed72a-56bf-46f8-9f3e-e22137f7d7f1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-0b0f3f7b-e53c-4f10-9dda-8b0904fdecaa' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0b0f3f7b-e53c-4f10-9dda-8b0904fdecaa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dc48ffa2-45fa-4f91-a8cb-89aa3c06f689' class='xr-var-data-in' type='checkbox'><label for='data-dc48ffa2-45fa-4f91-a8cb-89aa3c06f689' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-24497ab2-3482-4cac-81e0-48c0373854ef' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-24497ab2-3482-4cac-81e0-48c0373854ef' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-31c57f2a-a2a6-45e3-9c49-228950209992' class='xr-var-data-in' type='checkbox'><label for='data-31c57f2a-a2a6-45e3-9c49-228950209992' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
+       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1d68125a-36fc-449c-ac64-cea65d9f24dd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1d68125a-36fc-449c-ac64-cea65d9f24dd' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-eae1d4ea-1e74-45e6-ae25-90942ac7b959' class='xr-section-summary-in' type='checkbox'  checked><label for='section-eae1d4ea-1e74-45e6-ae25-90942ac7b959' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-31d87830-6166-4b74-9ba5-9b0a02b23be7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-31d87830-6166-4b74-9ba5-9b0a02b23be7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b713be2e-39f4-49d3-b100-206a6eb3da3f' class='xr-var-data-in' type='checkbox'><label for='data-b713be2e-39f4-49d3-b100-206a6eb3da3f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-421360d8-5276-45ef-b14d-48fd2462d76d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-421360d8-5276-45ef-b14d-48fd2462d76d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1207a676-d605-42d1-b530-5af1fb0d532d' class='xr-var-data-in' type='checkbox'><label for='data-1207a676-d605-42d1-b530-5af1fb0d532d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-117eff4e-41bc-4af8-b716-ed28521bb112' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-117eff4e-41bc-4af8-b716-ed28521bb112' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fded62ca-bf66-49c9-983c-a5f2a89b8da8' class='xr-var-data-in' type='checkbox'><label for='data-fded62ca-bf66-49c9-983c-a5f2a89b8da8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
        "       &#x27;2018-05-18T10:40:24.000000000&#x27;, &#x27;2018-05-20T10:34:58.000000000&#x27;,\n",
        "       &#x27;2018-05-22T10:20:25.000000000&#x27;, &#x27;2018-05-23T10:41:24.000000000&#x27;,\n",
        "       &#x27;2018-05-25T10:30:24.000000000&#x27;, &#x27;2018-05-28T10:40:23.000000000&#x27;,\n",
@@ -3214,7 +3160,7 @@
        "       &#x27;2018-07-19T10:30:20.000000000&#x27;, &#x27;2018-07-21T10:20:24.000000000&#x27;,\n",
        "       &#x27;2018-07-22T10:40:20.000000000&#x27;, &#x27;2018-07-24T10:30:23.000000000&#x27;,\n",
        "       &#x27;2018-07-26T10:21:50.000000000&#x27;, &#x27;2018-07-27T10:40:23.000000000&#x27;,\n",
-       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-32f44a67-1388-4bea-a801-a75765b4a201' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-32f44a67-1388-4bea-a801-a75765b4a201' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a6dc075a-c563-4bb0-954d-26cbd59a26d8' class='xr-var-data-in' type='checkbox'><label for='data-a6dc075a-c563-4bb0-954d-26cbd59a26d8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-04045704-4648-4418-9413-993361c114be' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-04045704-4648-4418-9413-993361c114be' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6a94332f-e306-4d7e-8cf2-e2f9c14320a5' class='xr-var-data-in' type='checkbox'><label for='data-6a94332f-e306-4d7e-8cf2-e2f9c14320a5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3271,7 +3217,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-278a4cbf-d901-44e5-b5c3-3a39d1c4b091' class='xr-section-summary-in' type='checkbox'  checked><label for='section-278a4cbf-d901-44e5-b5c3-3a39d1c4b091' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-35095b10-8dd3-4720-9894-6cb6ed7ac6ee' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-35095b10-8dd3-4720-9894-6cb6ed7ac6ee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a9c7c296-56ff-4ff9-9b7c-356f2680600d' class='xr-var-data-in' type='checkbox'><label for='data-a9c7c296-56ff-4ff9-9b7c-356f2680600d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-fed0c77b-203d-4ecc-a83f-1bc1a153f1be' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fed0c77b-203d-4ecc-a83f-1bc1a153f1be' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-11ac71f0-2f4c-4295-ac3a-fa7fde6b8374' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-11ac71f0-2f4c-4295-ac3a-fa7fde6b8374' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e5ebc7db-0ac4-44a8-98ca-2cffff2deff8' class='xr-var-data-in' type='checkbox'><label for='data-e5ebc7db-0ac4-44a8-98ca-2cffff2deff8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3413,7 +3359,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-8fabcc5b-3efc-43d0-b8e7-81d850fd8f52' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8fabcc5b-3efc-43d0-b8e7-81d850fd8f52' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-37415c39-eff3-428f-9824-0ee4f6c01b50' class='xr-var-data-in' type='checkbox'><label for='data-37415c39-eff3-428f-9824-0ee4f6c01b50' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a4dbfaa3-7851-4f31-825e-5f352093284a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a4dbfaa3-7851-4f31-825e-5f352093284a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a7ea6ef9-1b28-4f94-b9f7-005348563d46' class='xr-var-data-in' type='checkbox'><label for='data-a7ea6ef9-1b28-4f94-b9f7-005348563d46' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3555,7 +3501,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-2cef0ef7-ec7f-4da6-b8a0-d6dfc6883cf1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2cef0ef7-ec7f-4da6-b8a0-d6dfc6883cf1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bfd1d21d-3411-4757-8d92-79be1126afff' class='xr-var-data-in' type='checkbox'><label for='data-bfd1d21d-3411-4757-8d92-79be1126afff' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-136b4865-22d3-4209-a85d-5194506aa225' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-136b4865-22d3-4209-a85d-5194506aa225' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85f31a32-e55c-4f02-a32c-1246577c178b' class='xr-var-data-in' type='checkbox'><label for='data-85f31a32-e55c-4f02-a32c-1246577c178b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3697,7 +3643,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-b9e3ebd3-d373-403b-a626-6be7f2e1718d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b9e3ebd3-d373-403b-a626-6be7f2e1718d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-250e97c4-29c5-48bf-829b-1b4ad2e1f9d9' class='xr-var-data-in' type='checkbox'><label for='data-250e97c4-29c5-48bf-829b-1b4ad2e1f9d9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ec12cba6-6adc-4703-a7de-3ec3a2fe10d3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ec12cba6-6adc-4703-a7de-3ec3a2fe10d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-df3226fd-b409-44d1-b40c-f6e42287beeb' class='xr-var-data-in' type='checkbox'><label for='data-df3226fd-b409-44d1-b40c-f6e42287beeb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3839,7 +3785,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c85c2abf-ee79-41c5-a238-a126450ce216' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c85c2abf-ee79-41c5-a238-a126450ce216' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-41b26f25-7c31-4842-a849-2a67b0804c09' class='xr-var-data-in' type='checkbox'><label for='data-41b26f25-7c31-4842-a849-2a67b0804c09' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-491350a7-9869-427b-9dd6-28202e0e1000' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-491350a7-9869-427b-9dd6-28202e0e1000' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b9112952-036d-4053-a87d-6ecb9a9addc4' class='xr-var-data-in' type='checkbox'><label for='data-b9112952-036d-4053-a87d-6ecb9a9addc4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3981,7 +3927,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-0f3f58e1-4a4f-4882-983a-f486f8ac3410' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0f3f58e1-4a4f-4882-983a-f486f8ac3410' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fd679657-3d76-4188-aa37-91a0007f33d8' class='xr-var-data-in' type='checkbox'><label for='data-fd679657-3d76-4188-aa37-91a0007f33d8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-81ade05e-1cdb-4274-b418-a82b936945bc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-81ade05e-1cdb-4274-b418-a82b936945bc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ae039ba6-5c27-4674-b89e-626039f784d6' class='xr-var-data-in' type='checkbox'><label for='data-ae039ba6-5c27-4674-b89e-626039f784d6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4123,7 +4069,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-90657e8e-18db-49aa-9f97-7f902be5b4a1' class='xr-section-summary-in' type='checkbox'  ><label for='section-90657e8e-18db-49aa-9f97-7f902be5b4a1' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:00:49.747063</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-1ed4cea9-10ab-439f-a457-d3bfe59634ab' class='xr-section-summary-in' type='checkbox'  ><label for='section-1ed4cea9-10ab-439f-a457-d3bfe59634ab' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:25:16.427255</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -4145,7 +4091,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{'program': 'xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-02-23T14:00:49.747063\n",
+       "    date_created:            2022-06-23T08:25:16.427255\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -4156,7 +4102,7 @@
        "    processing_level:        L2A"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4168,15 +4114,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "c6d85a2e",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:49.965082Z",
-     "iopub.status.busy": "2022-02-23T14:00:49.964529Z",
-     "iopub.status.idle": "2022-02-23T14:00:50.262692Z",
-     "shell.execute_reply": "2022-02-23T14:00:50.261974Z"
-    },
     "papermill": {
      "duration": 0.35941,
      "end_time": "2022-02-23T14:00:50.264509",
@@ -4190,10 +4130,10 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7f2bba1db730>]"
+       "[<matplotlib.lines.Line2D at 0x7f9c74d70d90>]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -4236,15 +4176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "85ebab6f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:50.505849Z",
-     "iopub.status.busy": "2022-02-23T14:00:50.505195Z",
-     "iopub.status.idle": "2022-02-23T14:00:50.510655Z",
-     "shell.execute_reply": "2022-02-23T14:00:50.509715Z"
-    },
     "papermill": {
      "duration": 0.066725,
      "end_time": "2022-02-23T14:00:50.512671",
@@ -4285,15 +4219,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "b3fb4702",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:50.755649Z",
-     "iopub.status.busy": "2022-02-23T14:00:50.755123Z",
-     "iopub.status.idle": "2022-02-23T14:00:50.783732Z",
-     "shell.execute_reply": "2022-02-23T14:00:50.782937Z"
-    },
     "papermill": {
      "duration": 0.091864,
      "end_time": "2022-02-23T14:00:50.785659",
@@ -4374,15 +4302,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "5581adc8",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:50.911323Z",
-     "iopub.status.busy": "2022-02-23T14:00:50.911029Z",
-     "iopub.status.idle": "2022-02-23T14:00:50.918277Z",
-     "shell.execute_reply": "2022-02-23T14:00:50.917448Z"
-    },
     "papermill": {
      "duration": 0.07064,
      "end_time": "2022-02-23T14:00:50.921214",
@@ -4392,22 +4314,13 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cube_config = CubeConfig(dataset_name='S2L2A',\n",
     "                         band_names=['B04', 'B05', 'B06', 'B11', 'SCL', 'CLD'],\n",
     "                         tile_size=[512, 512],\n",
     "                         crs='http://www.opengis.net/def/crs/EPSG/0/3857',\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         spatial_res=spatial_res,\n",
     "                         time_range=['2018-05-01', '2018-05-10'],                         \n",
     "                         time_period='1D')"
@@ -4415,15 +4328,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "03c76662",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:51.060437Z",
-     "iopub.status.busy": "2022-02-23T14:00:51.059558Z",
-     "iopub.status.idle": "2022-02-23T14:00:51.222158Z",
-     "shell.execute_reply": "2022-02-23T14:00:51.221449Z"
-    },
     "papermill": {
      "duration": 0.228095,
      "end_time": "2022-02-23T14:00:51.225590",
@@ -4808,17 +4715,17 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:00:51.158064\n",
+       "    date_created:              2022-06-23T08:25:17.771627\n",
        "    time_coverage_start:       2018-05-01T00:00:00+00:00\n",
        "    time_coverage_end:         2018-05-11T00:00:00+00:00\n",
        "    time_coverage_duration:    P10DT0H0M0S\n",
        "    time_coverage_resolution:  P1DT0H0M0S\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-95f5dac4-aa52-4174-a9a4-6ec585122233' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-95f5dac4-aa52-4174-a9a4-6ec585122233' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 10</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-6f128a14-f36f-4e38-9941-618c5f4ef641' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6f128a14-f36f-4e38-9941-618c5f4ef641' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-01T12:00:00 ... 2018-05-...</div><input id='attrs-9858ba47-407a-4642-b016-169ed3efb020' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9858ba47-407a-4642-b016-169ed3efb020' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d05d7a78-5565-4e73-960d-a08d7434132e' class='xr-var-data-in' type='checkbox'><label for='data-d05d7a78-5565-4e73-960d-a08d7434132e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-01T12:00:00.000000000&#x27;, &#x27;2018-05-02T12:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c2c1bc09-42f3-4f0e-a585-e757358a58c0' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c2c1bc09-42f3-4f0e-a585-e757358a58c0' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 10</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0a6b4a6c-c770-4ebe-91e8-b56277091a8f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0a6b4a6c-c770-4ebe-91e8-b56277091a8f' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-01T12:00:00 ... 2018-05-...</div><input id='attrs-eb22fe18-d219-4682-b93f-2286c115986a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eb22fe18-d219-4682-b93f-2286c115986a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6586022-22bc-4c68-9e7b-cce215151291' class='xr-var-data-in' type='checkbox'><label for='data-e6586022-22bc-4c68-9e7b-cce215151291' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-01T12:00:00.000000000&#x27;, &#x27;2018-05-02T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-03T12:00:00.000000000&#x27;, &#x27;2018-05-04T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-05T12:00:00.000000000&#x27;, &#x27;2018-05-06T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-07T12:00:00.000000000&#x27;, &#x27;2018-05-08T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-09T12:00:00.000000000&#x27;, &#x27;2018-05-10T12:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(10, 2), meta=np.ndarray&gt;</div><input id='attrs-ee6747e8-ae93-4654-b7a1-909f90c07c44' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee6747e8-ae93-4654-b7a1-909f90c07c44' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dcf67b26-cd7a-4e7c-874f-355f9ffa0de0' class='xr-var-data-in' type='checkbox'><label for='data-dcf67b26-cd7a-4e7c-874f-355f9ffa0de0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(10, 2), meta=np.ndarray&gt;</div><input id='attrs-ccf58985-0f94-4f02-a619-29eb33b344eb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ccf58985-0f94-4f02-a619-29eb33b344eb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-386bfeb8-d0ae-48c8-b564-4058c501f2f4' class='xr-var-data-in' type='checkbox'><label for='data-386bfeb8-d0ae-48c8-b564-4058c501f2f4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4875,9 +4782,9 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-3246ac70-d28a-4c84-aa13-e0ead81575f6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3246ac70-d28a-4c84-aa13-e0ead81575f6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cee6d8b4-7445-4c1f-bf92-f0f93d77a361' class='xr-var-data-in' type='checkbox'><label for='data-cee6d8b4-7445-4c1f-bf92-f0f93d77a361' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
-       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-898587ad-dde2-48da-9ea6-9bb77ef3fb9a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-898587ad-dde2-48da-9ea6-9bb77ef3fb9a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8a4a1707-e59d-4da3-9989-2860e7011c1b' class='xr-var-data-in' type='checkbox'><label for='data-8a4a1707-e59d-4da3-9989-2860e7011c1b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
-       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7b107699-9267-4da9-8ec1-0d0d8c758c71' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7b107699-9267-4da9-8ec1-0d0d8c758c71' class='xr-section-summary' >Data variables: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-75a819e8-4481-429e-8b07-c9973d8285a9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-75a819e8-4481-429e-8b07-c9973d8285a9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-60f8cbce-4ec1-449c-b68c-cdb65c1acad0' class='xr-var-data-in' type='checkbox'><label for='data-60f8cbce-4ec1-449c-b68c-cdb65c1acad0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-4bf96e94-f58f-4d17-b9b1-ffcb7eebe7a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4bf96e94-f58f-4d17-b9b1-ffcb7eebe7a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-30bb04c5-124d-4038-97d3-4e32d05e9b11' class='xr-var-data-in' type='checkbox'><label for='data-30bb04c5-124d-4038-97d3-4e32d05e9b11' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
+       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-876b38a1-5fc5-48c5-9364-e444a59cf82c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-876b38a1-5fc5-48c5-9364-e444a59cf82c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-11a31300-3804-42f6-8119-5f1d047449a6' class='xr-var-data-in' type='checkbox'><label for='data-11a31300-3804-42f6-8119-5f1d047449a6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
+       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d7178610-19b5-4fc4-9be6-ba1a50d259bb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d7178610-19b5-4fc4-9be6-ba1a50d259bb' class='xr-section-summary' >Data variables: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-2a1cd4cb-0d30-49fa-85f3-fe6806ea7089' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2a1cd4cb-0d30-49fa-85f3-fe6806ea7089' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-972a1128-511b-455f-9163-b559b5547a5c' class='xr-var-data-in' type='checkbox'><label for='data-972a1128-511b-455f-9163-b559b5547a5c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4975,7 +4882,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-121da4f7-d171-403b-a5d7-7d0ca045e775' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-121da4f7-d171-403b-a5d7-7d0ca045e775' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4b68803f-6ca4-4df1-bc92-2741bad62be4' class='xr-var-data-in' type='checkbox'><label for='data-4b68803f-6ca4-4df1-bc92-2741bad62be4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-75670c87-5583-416d-9f35-1806c5f5154b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-75670c87-5583-416d-9f35-1806c5f5154b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ce4ee1a8-d7a2-4950-b77a-fad1c9323ef9' class='xr-var-data-in' type='checkbox'><label for='data-ce4ee1a8-d7a2-4950-b77a-fad1c9323ef9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5073,7 +4980,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-f78f5f93-c6b3-4e71-a460-20b925793171' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f78f5f93-c6b3-4e71-a460-20b925793171' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f0791220-2fc9-4154-b903-d576bd29a604' class='xr-var-data-in' type='checkbox'><label for='data-f0791220-2fc9-4154-b903-d576bd29a604' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-f6baed9c-73f8-48ce-9d2e-c0684f98545d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f6baed9c-73f8-48ce-9d2e-c0684f98545d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9ca8eb31-a8a8-4894-8dd3-11fe0160cd6e' class='xr-var-data-in' type='checkbox'><label for='data-9ca8eb31-a8a8-4894-8dd3-11fe0160cd6e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5171,7 +5078,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-e554606e-3a83-4255-a0e9-a47ae0fd19e4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e554606e-3a83-4255-a0e9-a47ae0fd19e4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-aa22ea60-57b4-4d24-bb45-c3010fa5843f' class='xr-var-data-in' type='checkbox'><label for='data-aa22ea60-57b4-4d24-bb45-c3010fa5843f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-6a4d29e8-8b44-42f0-8eaf-6c15c6a4979b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6a4d29e8-8b44-42f0-8eaf-6c15c6a4979b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eaa970a4-d1e0-47cf-80a4-4a6ebe7bdd7b' class='xr-var-data-in' type='checkbox'><label for='data-eaa970a4-d1e0-47cf-80a4-4a6ebe7bdd7b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5269,7 +5176,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-9126d695-5ef0-4908-9a26-152a05e9407a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9126d695-5ef0-4908-9a26-152a05e9407a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7f2ac587-06f8-404c-b47a-6e1be92395dc' class='xr-var-data-in' type='checkbox'><label for='data-7f2ac587-06f8-404c-b47a-6e1be92395dc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-f6a20dd6-57d1-444e-b569-972859bd2bc9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f6a20dd6-57d1-444e-b569-972859bd2bc9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6aee57be-543e-45fd-b6e0-b6ce11ee7b21' class='xr-var-data-in' type='checkbox'><label for='data-6aee57be-543e-45fd-b6e0-b6ce11ee7b21' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5367,7 +5274,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-6ca467af-b9fc-4cba-9496-af11a376843a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6ca467af-b9fc-4cba-9496-af11a376843a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8b247b7e-9960-4dd8-8fbc-134b1ca721b0' class='xr-var-data-in' type='checkbox'><label for='data-8b247b7e-9960-4dd8-8fbc-134b1ca721b0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-6c465964-5c16-4932-a89f-4f3d73be2c84' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6c465964-5c16-4932-a89f-4f3d73be2c84' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8ccc65fb-feed-4a8c-918c-c160c8aeadf2' class='xr-var-data-in' type='checkbox'><label for='data-8ccc65fb-feed-4a8c-918c-c160c8aeadf2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5465,7 +5372,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-acd7ee2b-7679-4a8f-a0c5-50d05f9c8125' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-acd7ee2b-7679-4a8f-a0c5-50d05f9c8125' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-64b516c4-2262-4220-86b7-0e69e7f1da6e' class='xr-var-data-in' type='checkbox'><label for='data-64b516c4-2262-4220-86b7-0e69e7f1da6e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a9600f88-75d6-4aa4-8f0f-563ebbf30936' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a9600f88-75d6-4aa4-8f0f-563ebbf30936' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-01T00:00:00+00:00&#x27;, &#x27;2018-05-10T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;1 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:00:51.158064</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-05-11T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P10DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1DT0H0M0S</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-2d7f1cc4-bc8f-48ad-8e8b-6c4b0499227a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2d7f1cc4-bc8f-48ad-8e8b-6c4b0499227a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0fdf908e-0650-4e8b-8db4-b57c10462716' class='xr-var-data-in' type='checkbox'><label for='data-0fdf908e-0650-4e8b-8db4-b57c10462716' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cc2b0ebe-6e8e-447f-95dc-b1fc5e099596' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cc2b0ebe-6e8e-447f-95dc-b1fc5e099596' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-01T00:00:00+00:00&#x27;, &#x27;2018-05-10T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;1 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:25:17.771627</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-05-11T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P10DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1DT0H0M0S</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -5488,7 +5395,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:00:51.158064\n",
+       "    date_created:              2022-06-23T08:25:17.771627\n",
        "    time_coverage_start:       2018-05-01T00:00:00+00:00\n",
        "    time_coverage_end:         2018-05-11T00:00:00+00:00\n",
        "    time_coverage_duration:    P10DT0H0M0S\n",
@@ -5496,7 +5403,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5508,15 +5415,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "b82aaef7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:51.354729Z",
-     "iopub.status.busy": "2022-02-23T14:00:51.354138Z",
-     "iopub.status.idle": "2022-02-23T14:00:52.682765Z",
-     "shell.execute_reply": "2022-02-23T14:00:52.682022Z"
-    },
     "papermill": {
      "duration": 1.400576,
      "end_time": "2022-02-23T14:00:52.690101",
@@ -5530,10 +5431,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f2bba10eaf0>"
+       "<matplotlib.image.AxesImage at 0x7f9c74d08040>"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -5553,13 +5454,21 @@
    "source": [
     "cube.B04.isel(time=5).plot.imshow(vmin=0, vmax=0.18, cmap='Greys_r', figsize=(16, 10))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e859299-3503-4b9c-90fc-707e46f39861",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "EDC 2022.02 (Python3)",
    "language": "python",
-   "name": "python3"
+   "name": "edc"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/curated/EDC_Sentinel_Hub-Data-access.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-Data-access.ipynb
@@ -6,16 +6,16 @@
    "id": "1c8303f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:19.646339Z",
-     "iopub.status.busy": "2022-02-23T14:00:19.645698Z",
-     "iopub.status.idle": "2022-02-23T14:00:19.830800Z",
-     "shell.execute_reply": "2022-02-23T14:00:19.829803Z"
+     "iopub.execute_input": "2022-06-23T10:15:57.783951Z",
+     "iopub.status.busy": "2022-06-23T10:15:57.783199Z",
+     "iopub.status.idle": "2022-06-23T10:16:47.980025Z",
+     "shell.execute_reply": "2022-06-23T10:16:47.979556Z"
     },
     "papermill": {
-     "duration": 0.222231,
-     "end_time": "2022-02-23T14:00:19.833173",
+     "duration": 50.254775,
+     "end_time": "2022-06-23T10:16:48.015276",
      "exception": false,
-     "start_time": "2022-02-23T14:00:19.610942",
+     "start_time": "2022-06-23T10:15:57.760501",
      "status": "completed"
     },
     "tags": []
@@ -55,16 +55,16 @@
    "id": "e1789874",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:19.906651Z",
-     "iopub.status.busy": "2022-02-23T14:00:19.905936Z",
-     "iopub.status.idle": "2022-02-23T14:00:19.915941Z",
-     "shell.execute_reply": "2022-02-23T14:00:19.915156Z"
+     "iopub.execute_input": "2022-06-23T10:16:48.060850Z",
+     "iopub.status.busy": "2022-06-23T10:16:48.060569Z",
+     "iopub.status.idle": "2022-06-23T10:16:48.067474Z",
+     "shell.execute_reply": "2022-06-23T10:16:48.066936Z"
     },
     "papermill": {
-     "duration": 0.044674,
-     "end_time": "2022-02-23T14:00:19.917866",
+     "duration": 0.032258,
+     "end_time": "2022-06-23T10:16:48.073431",
      "exception": false,
-     "start_time": "2022-02-23T14:00:19.873192",
+     "start_time": "2022-06-23T10:16:48.041173",
      "status": "completed"
     },
     "tags": []
@@ -128,10 +128,10 @@
    "id": "d363fbc3",
    "metadata": {
     "papermill": {
-     "duration": 0.03393,
-     "end_time": "2022-02-23T14:00:20.005397",
+     "duration": 0.021909,
+     "end_time": "2022-06-23T10:16:48.116246",
      "exception": false,
-     "start_time": "2022-02-23T14:00:19.971467",
+     "start_time": "2022-06-23T10:16:48.094337",
      "status": "completed"
     },
     "tags": []
@@ -148,14 +148,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "0fee4a78",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:48.159241Z",
+     "iopub.status.busy": "2022-06-23T10:16:48.158965Z",
+     "iopub.status.idle": "2022-06-23T10:16:49.742698Z",
+     "shell.execute_reply": "2022-06-23T10:16:49.742144Z"
+    },
     "papermill": {
-     "duration": 2.980104,
-     "end_time": "2022-02-23T14:00:23.021140",
+     "duration": 1.609403,
+     "end_time": "2022-06-23T10:16:49.745025",
      "exception": false,
-     "start_time": "2022-02-23T14:00:20.041036",
+     "start_time": "2022-06-23T10:16:48.135622",
      "status": "completed"
     },
     "tags": []
@@ -183,14 +189,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "ca17a3b7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:49.802581Z",
+     "iopub.status.busy": "2022-06-23T10:16:49.802276Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.042376Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.041856Z"
+    },
     "papermill": {
-     "duration": 0.771708,
-     "end_time": "2022-02-23T14:00:23.826725",
+     "duration": 1.268639,
+     "end_time": "2022-06-23T10:16:51.044105",
      "exception": false,
-     "start_time": "2022-02-23T14:00:23.055017",
+     "start_time": "2022-06-23T10:16:49.775466",
      "status": "completed"
     },
     "tags": []
@@ -202,9 +214,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "358b64b2-5eb4-4f17-ad46-5e0334197bb0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.087059Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.086782Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.094205Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.093495Z"
+    },
+    "papermill": {
+     "duration": 0.030933,
+     "end_time": "2022-06-23T10:16:51.096963",
+     "exception": false,
+     "start_time": "2022-06-23T10:16:51.066030",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import xcube\n",
@@ -213,17 +240,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "c9f362cd-d16a-406d-adfd-f2ea2484a1f4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.143462Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.143188Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.147490Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.146963Z"
+    },
+    "papermill": {
+     "duration": 0.026552,
+     "end_time": "2022-06-23T10:16:51.148946",
+     "exception": false,
+     "start_time": "2022-06-23T10:16:51.122394",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'0.9.5'"
+       "'0.9.3'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,17 +276,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "65f0a992-a00c-464a-9e5a-b33055fa2cac",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.196983Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.196666Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.201340Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.200759Z"
+    },
+    "papermill": {
+     "duration": 0.03211,
+     "end_time": "2022-06-23T10:16:51.202880",
+     "exception": false,
+     "start_time": "2022-06-23T10:16:51.170770",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'0.11.2'"
+       "'0.10.1'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,10 +315,10 @@
    "id": "813125a9",
    "metadata": {
     "papermill": {
-     "duration": 0.03366,
-     "end_time": "2022-02-23T14:00:23.894206",
+     "duration": 0.020127,
+     "end_time": "2022-06-23T10:16:51.243669",
      "exception": false,
-     "start_time": "2022-02-23T14:00:23.860546",
+     "start_time": "2022-06-23T10:16:51.223542",
      "status": "completed"
     },
     "tags": []
@@ -273,14 +330,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "2168ea3f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.285256Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.284891Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.291803Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.287619Z"
+    },
     "papermill": {
-     "duration": 0.041409,
-     "end_time": "2022-02-23T14:00:23.970482",
+     "duration": 0.030318,
+     "end_time": "2022-06-23T10:16:51.294040",
      "exception": false,
-     "start_time": "2022-02-23T14:00:23.929073",
+     "start_time": "2022-06-23T10:16:51.263722",
      "status": "completed"
     },
     "tags": []
@@ -300,10 +363,10 @@
    "id": "88e698e0",
    "metadata": {
     "papermill": {
-     "duration": 0.047621,
-     "end_time": "2022-02-23T14:00:24.052394",
+     "duration": 0.022444,
+     "end_time": "2022-06-23T10:16:51.338763",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.004773",
+     "start_time": "2022-06-23T10:16:51.316319",
      "status": "completed"
     },
     "tags": []
@@ -314,14 +377,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "99bd54fa",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.380660Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.380113Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.384852Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.384407Z"
+    },
     "papermill": {
-     "duration": 0.044481,
-     "end_time": "2022-02-23T14:00:24.130589",
+     "duration": 0.027489,
+     "end_time": "2022-06-23T10:16:51.386147",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.086108",
+     "start_time": "2022-06-23T10:16:51.358658",
      "status": "completed"
     },
     "tags": []
@@ -333,23 +402,23 @@
        "coordinates": [
         [
          [
-          11,
+          11.0,
           54.27
          ],
          [
-          11,
+          11.0,
           54.6
          ],
          [
-          10,
+          10.0,
           54.6
          ],
          [
-          10,
+          10.0,
           54.27
          ],
          [
-          11,
+          11.0,
           54.27
          ]
         ]
@@ -378,10 +447,10 @@
    "id": "1cb38568",
    "metadata": {
     "papermill": {
-     "duration": 0.033965,
-     "end_time": "2022-02-23T14:00:24.202617",
+     "duration": 0.020937,
+     "end_time": "2022-06-23T10:16:51.436268",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.168652",
+     "start_time": "2022-06-23T10:16:51.415331",
      "status": "completed"
     },
     "tags": []
@@ -395,14 +464,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "024b7b12",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.478333Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.478060Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.480998Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.480526Z"
+    },
     "papermill": {
-     "duration": 0.045287,
-     "end_time": "2022-02-23T14:00:24.282047",
+     "duration": 0.025599,
+     "end_time": "2022-06-23T10:16:51.482267",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.236760",
+     "start_time": "2022-06-23T10:16:51.456668",
      "status": "completed"
     },
     "tags": []
@@ -417,10 +492,10 @@
    "id": "565d1566",
    "metadata": {
     "papermill": {
-     "duration": 0.038188,
-     "end_time": "2022-02-23T14:00:24.355288",
+     "duration": 0.020733,
+     "end_time": "2022-06-23T10:16:51.531172",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.317100",
+     "start_time": "2022-06-23T10:16:51.510439",
      "status": "completed"
     },
     "tags": []
@@ -432,14 +507,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "be3a38e5",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.577336Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.577065Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.581624Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.581022Z"
+    },
     "papermill": {
-     "duration": 0.046215,
-     "end_time": "2022-02-23T14:00:24.436363",
+     "duration": 0.027948,
+     "end_time": "2022-06-23T10:16:51.583465",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.390148",
+     "start_time": "2022-06-23T10:16:51.555517",
      "status": "completed"
     },
     "tags": []
@@ -460,10 +541,10 @@
    "id": "2a3ed3ce",
    "metadata": {
     "papermill": {
-     "duration": 0.03434,
-     "end_time": "2022-02-23T14:00:24.510095",
+     "duration": 0.020802,
+     "end_time": "2022-06-23T10:16:51.637832",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.475755",
+     "start_time": "2022-06-23T10:16:51.617030",
      "status": "completed"
     },
     "tags": []
@@ -474,14 +555,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "ce99eff6",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.680972Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.680695Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.683727Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.683235Z"
+    },
     "papermill": {
-     "duration": 0.044142,
-     "end_time": "2022-02-23T14:00:24.591148",
+     "duration": 0.026732,
+     "end_time": "2022-06-23T10:16:51.685095",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.547006",
+     "start_time": "2022-06-23T10:16:51.658363",
      "status": "completed"
     },
     "tags": []
@@ -496,10 +583,10 @@
    "id": "bdc6e0bc",
    "metadata": {
     "papermill": {
-     "duration": 0.040105,
-     "end_time": "2022-02-23T14:00:24.667915",
+     "duration": 0.021024,
+     "end_time": "2022-06-23T10:16:51.733747",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.627810",
+     "start_time": "2022-06-23T10:16:51.712723",
      "status": "completed"
     },
     "tags": []
@@ -510,14 +597,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "3df69e80",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:51.776716Z",
+     "iopub.status.busy": "2022-06-23T10:16:51.776434Z",
+     "iopub.status.idle": "2022-06-23T10:16:51.991098Z",
+     "shell.execute_reply": "2022-06-23T10:16:51.990616Z"
+    },
     "papermill": {
-     "duration": 0.239149,
-     "end_time": "2022-02-23T14:00:24.941741",
+     "duration": 0.238916,
+     "end_time": "2022-06-23T10:16:51.993511",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.702592",
+     "start_time": "2022-06-23T10:16:51.754595",
      "status": "completed"
     },
     "tags": []
@@ -529,14 +622,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "3eb0cb62",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:52.041912Z",
+     "iopub.status.busy": "2022-06-23T10:16:52.041603Z",
+     "iopub.status.idle": "2022-06-23T10:16:52.106744Z",
+     "shell.execute_reply": "2022-06-23T10:16:52.105953Z"
+    },
     "papermill": {
-     "duration": 0.160274,
-     "end_time": "2022-02-23T14:00:25.140274",
+     "duration": 0.091641,
+     "end_time": "2022-06-23T10:16:52.111179",
      "exception": false,
-     "start_time": "2022-02-23T14:00:24.980000",
+     "start_time": "2022-06-23T10:16:52.019538",
      "status": "completed"
     },
     "tags": []
@@ -915,7 +1014,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:24:46.307410\n",
+       "    date_created:              2022-06-23T10:16:51.857271\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -924,7 +1023,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-35a4d8cd-f77d-4e9c-b116-beb1881f89e5' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-35a4d8cd-f77d-4e9c-b116-beb1881f89e5' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-8ca415f6-26db-46b0-9264-9761125f79ee' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8ca415f6-26db-46b0-9264-9761125f79ee' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-17c58e3a-99f5-4df9-9897-75512b395773' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-17c58e3a-99f5-4df9-9897-75512b395773' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-47f55a9d-be42-4fd1-b446-f3eb7f09fd57' class='xr-var-data-in' type='checkbox'><label for='data-47f55a9d-be42-4fd1-b446-f3eb7f09fd57' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-92dfbdf1-2c5f-4cd0-ae4d-6c1111ee923d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-92dfbdf1-2c5f-4cd0-ae4d-6c1111ee923d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1fc78439-ca16-4a49-b63f-59f5231e4f17' class='xr-var-data-in' type='checkbox'><label for='data-1fc78439-ca16-4a49-b63f-59f5231e4f17' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-2452a99a-6812-4d3c-a5af-9da49ed524a3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2452a99a-6812-4d3c-a5af-9da49ed524a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-68967322-dc1d-4397-85f9-6d777c2db732' class='xr-var-data-in' type='checkbox'><label for='data-68967322-dc1d-4397-85f9-6d777c2db732' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2c6a1efd-517a-48bc-a0c9-014580307a76' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2c6a1efd-517a-48bc-a0c9-014580307a76' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-317acae0-03b2-44bd-8e75-fb288e83b294' class='xr-section-summary-in' type='checkbox'  checked><label for='section-317acae0-03b2-44bd-8e75-fb288e83b294' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-9c69defa-a2d7-4dc8-a9b8-4b9fe2b41807' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9c69defa-a2d7-4dc8-a9b8-4b9fe2b41807' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0672ae36-efcb-45ba-aaba-2c4395bdd78e' class='xr-var-data-in' type='checkbox'><label for='data-0672ae36-efcb-45ba-aaba-2c4395bdd78e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-b67f584e-20a4-4940-ba61-691696ab1f41' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b67f584e-20a4-4940-ba61-691696ab1f41' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9aa18a83-ee1a-421d-812c-68bd64122416' class='xr-var-data-in' type='checkbox'><label for='data-9aa18a83-ee1a-421d-812c-68bd64122416' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-4134a955-ac38-4483-91ca-6e21cb8ae32b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4134a955-ac38-4483-91ca-6e21cb8ae32b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b6232cb3-944b-4006-a810-cec9377daff0' class='xr-var-data-in' type='checkbox'><label for='data-b6232cb3-944b-4006-a810-cec9377daff0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -944,7 +1043,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-baf7a8df-efdc-42c5-986f-aa8145a74d60' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-baf7a8df-efdc-42c5-986f-aa8145a74d60' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-49d2faa7-6af9-4523-bc0d-f4219e44cde6' class='xr-var-data-in' type='checkbox'><label for='data-49d2faa7-6af9-4523-bc0d-f4219e44cde6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-6b3a9324-e735-4023-8330-022d917fe1b4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6b3a9324-e735-4023-8330-022d917fe1b4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a78bd039-19c2-47d6-bbe7-15bb2fb70cb9' class='xr-var-data-in' type='checkbox'><label for='data-a78bd039-19c2-47d6-bbe7-15bb2fb70cb9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1001,7 +1100,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6ad39bd4-5855-4717-ad66-33b3314caec5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6ad39bd4-5855-4717-ad66-33b3314caec5' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-751ad877-53a6-4285-ae3d-5cffb20735b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-751ad877-53a6-4285-ae3d-5cffb20735b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-33aa4ab3-0385-49c1-baf9-6c8df24b3ed1' class='xr-var-data-in' type='checkbox'><label for='data-33aa4ab3-0385-49c1-baf9-6c8df24b3ed1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-fd3d2ba3-6cb7-4aaf-bc1e-127612fa78fc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fd3d2ba3-6cb7-4aaf-bc1e-127612fa78fc' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-1dcfb3c7-71fe-472c-8d3c-2a3a739a65d7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1dcfb3c7-71fe-472c-8d3c-2a3a739a65d7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c194549d-1451-4ec1-a269-d529cb81ef1c' class='xr-var-data-in' type='checkbox'><label for='data-c194549d-1451-4ec1-a269-d529cb81ef1c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1143,7 +1242,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-30fdd886-1684-482f-b696-4ae506b3b73a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-30fdd886-1684-482f-b696-4ae506b3b73a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a3d48363-2a1e-468d-8acc-284504801908' class='xr-var-data-in' type='checkbox'><label for='data-a3d48363-2a1e-468d-8acc-284504801908' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-470f6209-185b-447f-9296-169e9ea55225' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-470f6209-185b-447f-9296-169e9ea55225' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-39d95b47-ccea-4e2b-b7e4-064acfcf4f32' class='xr-var-data-in' type='checkbox'><label for='data-39d95b47-ccea-4e2b-b7e4-064acfcf4f32' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1285,7 +1384,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c4039e9d-f0ac-4da3-8539-ac4b4e53e8f6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c4039e9d-f0ac-4da3-8539-ac4b4e53e8f6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e9831ca9-80b6-4b8e-bc24-693b8d2326c7' class='xr-var-data-in' type='checkbox'><label for='data-e9831ca9-80b6-4b8e-bc24-693b8d2326c7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-52caac8d-da42-47c8-8e08-ecc32835f118' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-52caac8d-da42-47c8-8e08-ecc32835f118' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4e4ec642-c132-4a54-93ee-fbd48cb1b57e' class='xr-var-data-in' type='checkbox'><label for='data-4e4ec642-c132-4a54-93ee-fbd48cb1b57e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1427,7 +1526,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-9ec5b760-5562-4018-bce3-b7c388842b30' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9ec5b760-5562-4018-bce3-b7c388842b30' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0168cd99-d9d8-407c-bede-a110c85b4bd8' class='xr-var-data-in' type='checkbox'><label for='data-0168cd99-d9d8-407c-bede-a110c85b4bd8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a81d7ca4-7a88-45b2-b0c2-a2a47f70d841' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a81d7ca4-7a88-45b2-b0c2-a2a47f70d841' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4547b195-5b9c-4fb5-ad09-acd88cec6739' class='xr-var-data-in' type='checkbox'><label for='data-4547b195-5b9c-4fb5-ad09-acd88cec6739' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1569,7 +1668,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-eddda55d-1cad-4bdb-824c-e37141444506' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eddda55d-1cad-4bdb-824c-e37141444506' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bef096fc-bcc7-4367-b550-1fa17c1cb49a' class='xr-var-data-in' type='checkbox'><label for='data-bef096fc-bcc7-4367-b550-1fa17c1cb49a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-da694bb7-fbe9-4624-8666-c3d7c780ac74' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-da694bb7-fbe9-4624-8666-c3d7c780ac74' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0c3961e6-01e9-4613-a1f1-f9d25b166c16' class='xr-var-data-in' type='checkbox'><label for='data-0c3961e6-01e9-4613-a1f1-f9d25b166c16' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1711,7 +1810,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-21ff8663-8b0b-4b73-9685-7e253cdc4057' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-21ff8663-8b0b-4b73-9685-7e253cdc4057' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ac25d76b-b5fe-4b22-a8d8-2dd6c3242281' class='xr-var-data-in' type='checkbox'><label for='data-ac25d76b-b5fe-4b22-a8d8-2dd6c3242281' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-eba537df-dab0-4741-8eb0-195bfd0d9d94' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eba537df-dab0-4741-8eb0-195bfd0d9d94' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-152ddd09-93f9-4470-87a5-85ba1488937c' class='xr-var-data-in' type='checkbox'><label for='data-152ddd09-93f9-4470-87a5-85ba1488937c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1853,7 +1952,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-7889ac36-b8b4-40ce-ab97-7a8e9b9ab458' class='xr-section-summary-in' type='checkbox'  ><label for='section-7889ac36-b8b4-40ce-ab97-7a8e9b9ab458' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:24:46.307410</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-b280605d-b83c-4cb3-a218-872b806b0f13' class='xr-section-summary-in' type='checkbox'  ><label for='section-b280605d-b83c-4cb3-a218-872b806b0f13' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:16:51.857271</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1875,7 +1974,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:24:46.307410\n",
+       "    date_created:              2022-06-23T10:16:51.857271\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -1887,7 +1986,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1901,10 +2000,10 @@
    "id": "fb82c57f",
    "metadata": {
     "papermill": {
-     "duration": 0.039532,
-     "end_time": "2022-02-23T14:00:25.218640",
+     "duration": 0.023208,
+     "end_time": "2022-06-23T10:16:52.158147",
      "exception": false,
-     "start_time": "2022-02-23T14:00:25.179108",
+     "start_time": "2022-06-23T10:16:52.134939",
      "status": "completed"
     },
     "tags": []
@@ -1915,14 +2014,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "5ffa39f2",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:52.215966Z",
+     "iopub.status.busy": "2022-06-23T10:16:52.215689Z",
+     "iopub.status.idle": "2022-06-23T10:16:52.219894Z",
+     "shell.execute_reply": "2022-06-23T10:16:52.219384Z"
+    },
     "papermill": {
-     "duration": 0.047511,
-     "end_time": "2022-02-23T14:00:25.305130",
+     "duration": 0.032966,
+     "end_time": "2022-06-23T10:16:52.221399",
      "exception": false,
-     "start_time": "2022-02-23T14:00:25.257619",
+     "start_time": "2022-06-23T10:16:52.188433",
      "status": "completed"
     },
     "tags": []
@@ -1934,10 +2039,10 @@
        "<html><p>No requests made yet.</p></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f9c77c9d5b0>"
+       "<xcube_sh.observers._RequestStats at 0x7f0e9f7d1790>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1951,10 +2056,10 @@
    "id": "b01861ce",
    "metadata": {
     "papermill": {
-     "duration": 0.038306,
-     "end_time": "2022-02-23T14:00:25.385252",
+     "duration": 0.030337,
+     "end_time": "2022-06-23T10:16:52.275391",
      "exception": false,
-     "start_time": "2022-02-23T14:00:25.346946",
+     "start_time": "2022-06-23T10:16:52.245054",
      "status": "completed"
     },
     "tags": []
@@ -1965,14 +2070,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "aded591a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:52.327654Z",
+     "iopub.status.busy": "2022-06-23T10:16:52.327378Z",
+     "iopub.status.idle": "2022-06-23T10:16:52.615835Z",
+     "shell.execute_reply": "2022-06-23T10:16:52.615205Z"
+    },
     "papermill": {
-     "duration": 0.339647,
-     "end_time": "2022-02-23T14:00:25.764339",
+     "duration": 0.315138,
+     "end_time": "2022-06-23T10:16:52.617387",
      "exception": false,
-     "start_time": "2022-02-23T14:00:25.424692",
+     "start_time": "2022-06-23T10:16:52.302249",
      "status": "completed"
     },
     "tags": []
@@ -1981,10 +2092,10 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7f9c77c42340>]"
+       "[<matplotlib.lines.Line2D at 0x7f0e9f559c40>]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2007,14 +2118,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "74836cf9",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:52.668802Z",
+     "iopub.status.busy": "2022-06-23T10:16:52.668528Z",
+     "iopub.status.idle": "2022-06-23T10:16:52.696511Z",
+     "shell.execute_reply": "2022-06-23T10:16:52.695869Z"
+    },
     "papermill": {
-     "duration": 0.069578,
-     "end_time": "2022-02-23T14:00:25.872430",
+     "duration": 0.055971,
+     "end_time": "2022-06-23T10:16:52.698455",
      "exception": false,
-     "start_time": "2022-02-23T14:00:25.802852",
+     "start_time": "2022-06-23T10:16:52.642484",
      "status": "completed"
     },
     "tags": []
@@ -2375,7 +2492,7 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray &#x27;B04&#x27; (time: 40, lat: 2048, lon: 5632)&gt;\n",
-       "dask.array&lt;open_dataset-dc378ac14da942ea3a52cd7b803ee4f3B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
+       "dask.array&lt;open_dataset-ff6732e8e40de61569ccf94d348b4bd5B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2389,7 +2506,7 @@
        "    bandwidth:     31.0\n",
        "    bandwidth_a:   31\n",
        "    bandwidth_b:   31\n",
-       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-4a735b7a-fa92-47c8-8996-a0a152842a94' class='xr-array-in' type='checkbox' checked><label for='section-4a735b7a-fa92-47c8-8996-a0a152842a94' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-f4467019-e1b5-4a3f-b0dd-0b0fd2e98d62' class='xr-array-in' type='checkbox' checked><label for='section-f4467019-e1b5-4a3f-b0dd-0b0fd2e98d62' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2531,7 +2648,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-4e0f36bc-1ea4-46e6-af43-f5be8cbf1c87' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4e0f36bc-1ea4-46e6-af43-f5be8cbf1c87' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-b47d6522-9f1f-4d9a-bc4e-4bbc73e49b11' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b47d6522-9f1f-4d9a-bc4e-4bbc73e49b11' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7da24f37-570c-4dac-bc4d-a8fcf0a5ecc1' class='xr-var-data-in' type='checkbox'><label for='data-7da24f37-570c-4dac-bc4d-a8fcf0a5ecc1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-63452e22-c8c8-4390-9274-8badaede4f09' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-63452e22-c8c8-4390-9274-8badaede4f09' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e906f9ff-19f9-4d91-8506-23fd48df71c0' class='xr-var-data-in' type='checkbox'><label for='data-e906f9ff-19f9-4d91-8506-23fd48df71c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-582f2812-bedd-4a1e-8f64-da69dd29e294' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-582f2812-bedd-4a1e-8f64-da69dd29e294' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0cac7501-316f-4f1c-831b-28b47ef5bc43' class='xr-var-data-in' type='checkbox'><label for='data-0cac7501-316f-4f1c-831b-28b47ef5bc43' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-ed5ac4d0-8447-45c8-8979-eea283b9badf' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ed5ac4d0-8447-45c8-8979-eea283b9badf' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-55ceb4aa-a606-4554-b24e-f006c13c31a3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-55ceb4aa-a606-4554-b24e-f006c13c31a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6f5ffecf-f794-4e20-aaff-347b8cd68fed' class='xr-var-data-in' type='checkbox'><label for='data-6f5ffecf-f794-4e20-aaff-347b8cd68fed' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-405b0909-d3c9-489d-a2ed-736423db1c5c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-405b0909-d3c9-489d-a2ed-736423db1c5c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-33c54d28-e733-4699-8670-1ea784441fd3' class='xr-var-data-in' type='checkbox'><label for='data-33c54d28-e733-4699-8670-1ea784441fd3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-6f58a78d-c3e3-4adf-a3cd-2ff38eadf214' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6f58a78d-c3e3-4adf-a3cd-2ff38eadf214' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-42b403f4-d227-49be-9280-fb0ba8d2ee13' class='xr-var-data-in' type='checkbox'><label for='data-42b403f4-d227-49be-9280-fb0ba8d2ee13' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2551,11 +2668,11 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-72bfda17-5e46-49f0-a22f-fd42459e7309' class='xr-section-summary-in' type='checkbox'  checked><label for='section-72bfda17-5e46-49f0-a22f-fd42459e7309' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f6bedae8-0e09-41fd-a432-1dd52e280136' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f6bedae8-0e09-41fd-a432-1dd52e280136' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'B04' (time: 40, lat: 2048, lon: 5632)>\n",
-       "dask.array<open_dataset-dc378ac14da942ea3a52cd7b803ee4f3B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
+       "dask.array<open_dataset-ff6732e8e40de61569ccf94d348b4bd5B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2572,7 +2689,7 @@
        "    resolution:    10"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2583,14 +2700,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "05e245fa",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:52.752932Z",
+     "iopub.status.busy": "2022-06-23T10:16:52.752662Z",
+     "iopub.status.idle": "2022-06-23T10:17:16.824169Z",
+     "shell.execute_reply": "2022-06-23T10:17:16.823610Z"
+    },
     "papermill": {
-     "duration": 22.795338,
-     "end_time": "2022-02-23T14:00:48.707323",
+     "duration": 24.110548,
+     "end_time": "2022-06-23T10:17:16.836443",
      "exception": false,
-     "start_time": "2022-02-23T14:00:25.911985",
+     "start_time": "2022-06-23T10:16:52.725895",
      "status": "completed"
     },
     "tags": []
@@ -2599,10 +2722,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f9c752a3280>"
+       "<matplotlib.image.AxesImage at 0x7f0e9d5cf7f0>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2628,10 +2751,10 @@
    "id": "7e10ca0d",
    "metadata": {
     "papermill": {
-     "duration": 0.057923,
-     "end_time": "2022-02-23T14:00:48.829706",
+     "duration": 0.041164,
+     "end_time": "2022-06-23T10:17:16.918809",
      "exception": false,
-     "start_time": "2022-02-23T14:00:48.771783",
+     "start_time": "2022-06-23T10:17:16.877645",
      "status": "completed"
     },
     "tags": []
@@ -2642,14 +2765,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "8e1819df",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:17.000699Z",
+     "iopub.status.busy": "2022-06-23T10:17:17.000425Z",
+     "iopub.status.idle": "2022-06-23T10:17:17.005677Z",
+     "shell.execute_reply": "2022-06-23T10:17:17.005056Z"
+    },
     "papermill": {
-     "duration": 0.06546,
-     "end_time": "2022-02-23T14:00:48.949257",
+     "duration": 0.048657,
+     "end_time": "2022-06-23T10:17:17.007069",
      "exception": false,
-     "start_time": "2022-02-23T14:00:48.883797",
+     "start_time": "2022-06-23T10:17:16.958412",
      "status": "completed"
     },
     "tags": []
@@ -2658,13 +2787,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>348.08 ms</td></tr><tr><td>Request duration max:</td><td>2103.30 ms</td></tr><tr><td>Request duration median:</td><td>483.02 ms</td></tr><tr><td>Request duration mean:</td><td>588.38 ms</td></tr><tr><td>Request duration std:</td><td>292.82 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>308.87 ms</td></tr><tr><td>Request duration max:</td><td>1275.69 ms</td></tr><tr><td>Request duration median:</td><td>451.64 ms</td></tr><tr><td>Request duration mean:</td><td>518.20 ms</td></tr><tr><td>Request duration std:</td><td>218.46 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f9c77c9dbb0>"
+       "<xcube_sh.observers._RequestStats at 0x7f0e9f489a90>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2678,10 +2807,10 @@
    "id": "994cf3f2",
    "metadata": {
     "papermill": {
-     "duration": 0.054869,
-     "end_time": "2022-02-23T14:00:49.059557",
+     "duration": 0.040048,
+     "end_time": "2022-06-23T10:17:17.087185",
      "exception": false,
-     "start_time": "2022-02-23T14:00:49.004688",
+     "start_time": "2022-06-23T10:17:17.047137",
      "status": "completed"
     },
     "tags": []
@@ -2695,10 +2824,10 @@
    "id": "9b1a2c6f",
    "metadata": {
     "papermill": {
-     "duration": 0.057414,
-     "end_time": "2022-02-23T14:00:49.171169",
+     "duration": 0.0452,
+     "end_time": "2022-06-23T10:17:17.184294",
      "exception": false,
-     "start_time": "2022-02-23T14:00:49.113755",
+     "start_time": "2022-06-23T10:17:17.139094",
      "status": "completed"
     },
     "tags": []
@@ -2710,14 +2839,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "1a59ff33",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:17.274120Z",
+     "iopub.status.busy": "2022-06-23T10:17:17.273836Z",
+     "iopub.status.idle": "2022-06-23T10:17:17.278772Z",
+     "shell.execute_reply": "2022-06-23T10:17:17.278269Z"
+    },
     "papermill": {
-     "duration": 0.067348,
-     "end_time": "2022-02-23T14:00:49.294718",
+     "duration": 0.051566,
+     "end_time": "2022-06-23T10:17:17.280234",
      "exception": false,
-     "start_time": "2022-02-23T14:00:49.227370",
+     "start_time": "2022-06-23T10:17:17.228668",
      "status": "completed"
     },
     "tags": []
@@ -2744,14 +2879,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "ead19c93",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:17.367915Z",
+     "iopub.status.busy": "2022-06-23T10:17:17.367627Z",
+     "iopub.status.idle": "2022-06-23T10:17:17.603205Z",
+     "shell.execute_reply": "2022-06-23T10:17:17.602662Z"
+    },
     "papermill": {
-     "duration": 0.487549,
-     "end_time": "2022-02-23T14:00:49.846764",
+     "duration": 0.280739,
+     "end_time": "2022-06-23T10:17:17.606264",
      "exception": false,
-     "start_time": "2022-02-23T14:00:49.359215",
+     "start_time": "2022-06-23T10:17:17.325525",
      "status": "completed"
     },
     "tags": []
@@ -3130,7 +3271,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-06-23T08:25:16.427255\n",
+       "    date_created:            2022-06-23T10:17:17.528546\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -3138,7 +3279,7 @@
        "    geospatial_lat_min:      54.27\n",
        "    geospatial_lon_max:      11.01376\n",
        "    geospatial_lat_max:      54.63864\n",
-       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1d68125a-36fc-449c-ac64-cea65d9f24dd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1d68125a-36fc-449c-ac64-cea65d9f24dd' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-eae1d4ea-1e74-45e6-ae25-90942ac7b959' class='xr-section-summary-in' type='checkbox'  checked><label for='section-eae1d4ea-1e74-45e6-ae25-90942ac7b959' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-31d87830-6166-4b74-9ba5-9b0a02b23be7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-31d87830-6166-4b74-9ba5-9b0a02b23be7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b713be2e-39f4-49d3-b100-206a6eb3da3f' class='xr-var-data-in' type='checkbox'><label for='data-b713be2e-39f4-49d3-b100-206a6eb3da3f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-421360d8-5276-45ef-b14d-48fd2462d76d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-421360d8-5276-45ef-b14d-48fd2462d76d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1207a676-d605-42d1-b530-5af1fb0d532d' class='xr-var-data-in' type='checkbox'><label for='data-1207a676-d605-42d1-b530-5af1fb0d532d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-117eff4e-41bc-4af8-b716-ed28521bb112' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-117eff4e-41bc-4af8-b716-ed28521bb112' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fded62ca-bf66-49c9-983c-a5f2a89b8da8' class='xr-var-data-in' type='checkbox'><label for='data-fded62ca-bf66-49c9-983c-a5f2a89b8da8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
+       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-4a1f4b54-7e51-477f-870a-b50bfa3a5d0f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-4a1f4b54-7e51-477f-870a-b50bfa3a5d0f' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-cb0b166e-6fa6-4ac1-8936-c0446f7387f9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cb0b166e-6fa6-4ac1-8936-c0446f7387f9' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-4b4fe486-f926-4297-ac50-8822026b5cdf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4b4fe486-f926-4297-ac50-8822026b5cdf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-82335cb2-baf8-46e1-a133-98d5bf908789' class='xr-var-data-in' type='checkbox'><label for='data-82335cb2-baf8-46e1-a133-98d5bf908789' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-15e05d7a-1556-45e5-b99f-0e68f792baf5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-15e05d7a-1556-45e5-b99f-0e68f792baf5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-192fb6b3-dded-421c-8cab-2bb515ff782d' class='xr-var-data-in' type='checkbox'><label for='data-192fb6b3-dded-421c-8cab-2bb515ff782d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-678f0142-b140-4b83-adcf-5a3a68868615' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-678f0142-b140-4b83-adcf-5a3a68868615' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8e570d47-9a2b-4d73-a575-5723438ad074' class='xr-var-data-in' type='checkbox'><label for='data-8e570d47-9a2b-4d73-a575-5723438ad074' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
        "       &#x27;2018-05-18T10:40:24.000000000&#x27;, &#x27;2018-05-20T10:34:58.000000000&#x27;,\n",
        "       &#x27;2018-05-22T10:20:25.000000000&#x27;, &#x27;2018-05-23T10:41:24.000000000&#x27;,\n",
        "       &#x27;2018-05-25T10:30:24.000000000&#x27;, &#x27;2018-05-28T10:40:23.000000000&#x27;,\n",
@@ -3160,7 +3301,7 @@
        "       &#x27;2018-07-19T10:30:20.000000000&#x27;, &#x27;2018-07-21T10:20:24.000000000&#x27;,\n",
        "       &#x27;2018-07-22T10:40:20.000000000&#x27;, &#x27;2018-07-24T10:30:23.000000000&#x27;,\n",
        "       &#x27;2018-07-26T10:21:50.000000000&#x27;, &#x27;2018-07-27T10:40:23.000000000&#x27;,\n",
-       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-04045704-4648-4418-9413-993361c114be' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-04045704-4648-4418-9413-993361c114be' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6a94332f-e306-4d7e-8cf2-e2f9c14320a5' class='xr-var-data-in' type='checkbox'><label for='data-6a94332f-e306-4d7e-8cf2-e2f9c14320a5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-aae4c35e-4f5d-4b87-bf45-efab9552b1ef' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aae4c35e-4f5d-4b87-bf45-efab9552b1ef' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-92b52aff-f8eb-454d-8c2d-9b276e311807' class='xr-var-data-in' type='checkbox'><label for='data-92b52aff-f8eb-454d-8c2d-9b276e311807' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3217,7 +3358,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-fed0c77b-203d-4ecc-a83f-1bc1a153f1be' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fed0c77b-203d-4ecc-a83f-1bc1a153f1be' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-11ac71f0-2f4c-4295-ac3a-fa7fde6b8374' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-11ac71f0-2f4c-4295-ac3a-fa7fde6b8374' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e5ebc7db-0ac4-44a8-98ca-2cffff2deff8' class='xr-var-data-in' type='checkbox'><label for='data-e5ebc7db-0ac4-44a8-98ca-2cffff2deff8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-237cc2f2-9278-4db5-8f16-cc4a691ba37d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-237cc2f2-9278-4db5-8f16-cc4a691ba37d' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-208da492-ea3d-4385-b4cb-55325f2f7c34' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-208da492-ea3d-4385-b4cb-55325f2f7c34' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a4a98ba4-ee86-4af9-9dbe-a37e64090a44' class='xr-var-data-in' type='checkbox'><label for='data-a4a98ba4-ee86-4af9-9dbe-a37e64090a44' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3359,7 +3500,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a4dbfaa3-7851-4f31-825e-5f352093284a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a4dbfaa3-7851-4f31-825e-5f352093284a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a7ea6ef9-1b28-4f94-b9f7-005348563d46' class='xr-var-data-in' type='checkbox'><label for='data-a7ea6ef9-1b28-4f94-b9f7-005348563d46' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c184e8ed-8f71-4568-9290-5e1bc909e5e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c184e8ed-8f71-4568-9290-5e1bc909e5e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9dce85c9-33b6-41f4-b36b-8f3e27be4010' class='xr-var-data-in' type='checkbox'><label for='data-9dce85c9-33b6-41f4-b36b-8f3e27be4010' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3501,7 +3642,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-136b4865-22d3-4209-a85d-5194506aa225' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-136b4865-22d3-4209-a85d-5194506aa225' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85f31a32-e55c-4f02-a32c-1246577c178b' class='xr-var-data-in' type='checkbox'><label for='data-85f31a32-e55c-4f02-a32c-1246577c178b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-01c75d98-295e-4117-9b3d-af2a28cd9f33' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-01c75d98-295e-4117-9b3d-af2a28cd9f33' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3c5e9862-d84f-496c-91c4-8b4f0dc2f70b' class='xr-var-data-in' type='checkbox'><label for='data-3c5e9862-d84f-496c-91c4-8b4f0dc2f70b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3643,7 +3784,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ec12cba6-6adc-4703-a7de-3ec3a2fe10d3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ec12cba6-6adc-4703-a7de-3ec3a2fe10d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-df3226fd-b409-44d1-b40c-f6e42287beeb' class='xr-var-data-in' type='checkbox'><label for='data-df3226fd-b409-44d1-b40c-f6e42287beeb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-23ba9d28-70b7-4b03-9c8c-6031f4904983' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-23ba9d28-70b7-4b03-9c8c-6031f4904983' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9ab57be6-d817-4a92-8e4d-06781ee9171b' class='xr-var-data-in' type='checkbox'><label for='data-9ab57be6-d817-4a92-8e4d-06781ee9171b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3785,7 +3926,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-491350a7-9869-427b-9dd6-28202e0e1000' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-491350a7-9869-427b-9dd6-28202e0e1000' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b9112952-036d-4053-a87d-6ecb9a9addc4' class='xr-var-data-in' type='checkbox'><label for='data-b9112952-036d-4053-a87d-6ecb9a9addc4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-76d58818-b0f3-458e-aca9-0387087de792' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-76d58818-b0f3-458e-aca9-0387087de792' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-17420d01-cc5a-4419-8c81-83e0e04fe629' class='xr-var-data-in' type='checkbox'><label for='data-17420d01-cc5a-4419-8c81-83e0e04fe629' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3927,7 +4068,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-81ade05e-1cdb-4274-b418-a82b936945bc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-81ade05e-1cdb-4274-b418-a82b936945bc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ae039ba6-5c27-4674-b89e-626039f784d6' class='xr-var-data-in' type='checkbox'><label for='data-ae039ba6-5c27-4674-b89e-626039f784d6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-dde33e67-f378-4081-bf99-3ddf9f7fda73' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dde33e67-f378-4081-bf99-3ddf9f7fda73' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7626e9b7-4bf4-4028-bb82-013ba8afd27b' class='xr-var-data-in' type='checkbox'><label for='data-7626e9b7-4bf4-4028-bb82-013ba8afd27b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4069,7 +4210,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-1ed4cea9-10ab-439f-a457-d3bfe59634ab' class='xr-section-summary-in' type='checkbox'  ><label for='section-1ed4cea9-10ab-439f-a457-d3bfe59634ab' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:25:16.427255</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-2c86d9cc-cd97-4628-ab32-1c6de45daf56' class='xr-section-summary-in' type='checkbox'  ><label for='section-2c86d9cc-cd97-4628-ab32-1c6de45daf56' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:17:17.528546</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -4091,7 +4232,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{'program': 'xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-06-23T08:25:16.427255\n",
+       "    date_created:            2022-06-23T10:17:17.528546\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -4102,7 +4243,7 @@
        "    processing_level:        L2A"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4114,14 +4255,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "c6d85a2e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:17.694523Z",
+     "iopub.status.busy": "2022-06-23T10:17:17.694248Z",
+     "iopub.status.idle": "2022-06-23T10:17:17.971852Z",
+     "shell.execute_reply": "2022-06-23T10:17:17.971245Z"
+    },
     "papermill": {
-     "duration": 0.35941,
-     "end_time": "2022-02-23T14:00:50.264509",
+     "duration": 0.323961,
+     "end_time": "2022-06-23T10:17:17.973670",
      "exception": false,
-     "start_time": "2022-02-23T14:00:49.905099",
+     "start_time": "2022-06-23T10:17:17.649709",
      "status": "completed"
     },
     "tags": []
@@ -4130,10 +4277,10 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7f9c74d70d90>]"
+       "[<matplotlib.lines.Line2D at 0x7f0e9d271e50>]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -4159,10 +4306,10 @@
    "id": "6ed019c1",
    "metadata": {
     "papermill": {
-     "duration": 0.05901,
-     "end_time": "2022-02-23T14:00:50.382457",
+     "duration": 0.044331,
+     "end_time": "2022-06-23T10:17:18.067210",
      "exception": false,
-     "start_time": "2022-02-23T14:00:50.323447",
+     "start_time": "2022-06-23T10:17:18.022879",
      "status": "completed"
     },
     "tags": []
@@ -4176,14 +4323,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "85ebab6f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:18.158744Z",
+     "iopub.status.busy": "2022-06-23T10:17:18.158465Z",
+     "iopub.status.idle": "2022-06-23T10:17:18.162331Z",
+     "shell.execute_reply": "2022-06-23T10:17:18.161639Z"
+    },
     "papermill": {
-     "duration": 0.066725,
-     "end_time": "2022-02-23T14:00:50.512671",
+     "duration": 0.050328,
+     "end_time": "2022-06-23T10:17:18.163728",
      "exception": false,
-     "start_time": "2022-02-23T14:00:50.445946",
+     "start_time": "2022-06-23T10:17:18.113400",
      "status": "completed"
     },
     "tags": []
@@ -4205,10 +4358,10 @@
    "id": "974940e3",
    "metadata": {
     "papermill": {
-     "duration": 0.057823,
-     "end_time": "2022-02-23T14:00:50.633940",
+     "duration": 0.045486,
+     "end_time": "2022-06-23T10:17:18.257901",
      "exception": false,
-     "start_time": "2022-02-23T14:00:50.576117",
+     "start_time": "2022-06-23T10:17:18.212415",
      "status": "completed"
     },
     "tags": []
@@ -4219,14 +4372,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "b3fb4702",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:18.356145Z",
+     "iopub.status.busy": "2022-06-23T10:17:18.355865Z",
+     "iopub.status.idle": "2022-06-23T10:17:18.372899Z",
+     "shell.execute_reply": "2022-06-23T10:17:18.372274Z"
+    },
     "papermill": {
-     "duration": 0.091864,
-     "end_time": "2022-02-23T14:00:50.785659",
+     "duration": 0.069313,
+     "end_time": "2022-06-23T10:17:18.374402",
      "exception": false,
-     "start_time": "2022-02-23T14:00:50.693795",
+     "start_time": "2022-06-23T10:17:18.305089",
      "status": "completed"
     },
     "tags": []
@@ -4302,14 +4461,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "5581adc8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:18.485854Z",
+     "iopub.status.busy": "2022-06-23T10:17:18.485569Z",
+     "iopub.status.idle": "2022-06-23T10:17:18.491584Z",
+     "shell.execute_reply": "2022-06-23T10:17:18.489346Z"
+    },
     "papermill": {
-     "duration": 0.07064,
-     "end_time": "2022-02-23T14:00:50.921214",
+     "duration": 0.065592,
+     "end_time": "2022-06-23T10:17:18.495186",
      "exception": false,
-     "start_time": "2022-02-23T14:00:50.850574",
+     "start_time": "2022-06-23T10:17:18.429594",
      "status": "completed"
     },
     "tags": []
@@ -4328,14 +4493,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "03c76662",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:18.592962Z",
+     "iopub.status.busy": "2022-06-23T10:17:18.592683Z",
+     "iopub.status.idle": "2022-06-23T10:17:18.711699Z",
+     "shell.execute_reply": "2022-06-23T10:17:18.711022Z"
+    },
     "papermill": {
-     "duration": 0.228095,
-     "end_time": "2022-02-23T14:00:51.225590",
+     "duration": 0.172393,
+     "end_time": "2022-06-23T10:17:18.714821",
      "exception": false,
-     "start_time": "2022-02-23T14:00:50.997495",
+     "start_time": "2022-06-23T10:17:18.542428",
      "status": "completed"
     },
     "tags": []
@@ -4715,17 +4886,17 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:25:17.771627\n",
+       "    date_created:              2022-06-23T10:17:18.662854\n",
        "    time_coverage_start:       2018-05-01T00:00:00+00:00\n",
        "    time_coverage_end:         2018-05-11T00:00:00+00:00\n",
        "    time_coverage_duration:    P10DT0H0M0S\n",
        "    time_coverage_resolution:  P1DT0H0M0S\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c2c1bc09-42f3-4f0e-a585-e757358a58c0' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c2c1bc09-42f3-4f0e-a585-e757358a58c0' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 10</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0a6b4a6c-c770-4ebe-91e8-b56277091a8f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0a6b4a6c-c770-4ebe-91e8-b56277091a8f' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-01T12:00:00 ... 2018-05-...</div><input id='attrs-eb22fe18-d219-4682-b93f-2286c115986a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eb22fe18-d219-4682-b93f-2286c115986a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6586022-22bc-4c68-9e7b-cce215151291' class='xr-var-data-in' type='checkbox'><label for='data-e6586022-22bc-4c68-9e7b-cce215151291' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-01T12:00:00.000000000&#x27;, &#x27;2018-05-02T12:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-ca265fca-6593-459c-9759-175aacc168c7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-ca265fca-6593-459c-9759-175aacc168c7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 10</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-09839e53-72ff-4553-a6ed-10fbcc6d5f5d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-09839e53-72ff-4553-a6ed-10fbcc6d5f5d' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-01T12:00:00 ... 2018-05-...</div><input id='attrs-8ac68e0a-3418-42c9-a5c4-40078ec58076' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8ac68e0a-3418-42c9-a5c4-40078ec58076' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-66598c63-2a1c-4cd7-8a94-3b17510098d3' class='xr-var-data-in' type='checkbox'><label for='data-66598c63-2a1c-4cd7-8a94-3b17510098d3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-01T12:00:00.000000000&#x27;, &#x27;2018-05-02T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-03T12:00:00.000000000&#x27;, &#x27;2018-05-04T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-05T12:00:00.000000000&#x27;, &#x27;2018-05-06T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-07T12:00:00.000000000&#x27;, &#x27;2018-05-08T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-09T12:00:00.000000000&#x27;, &#x27;2018-05-10T12:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(10, 2), meta=np.ndarray&gt;</div><input id='attrs-ccf58985-0f94-4f02-a619-29eb33b344eb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ccf58985-0f94-4f02-a619-29eb33b344eb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-386bfeb8-d0ae-48c8-b564-4058c501f2f4' class='xr-var-data-in' type='checkbox'><label for='data-386bfeb8-d0ae-48c8-b564-4058c501f2f4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(10, 2), meta=np.ndarray&gt;</div><input id='attrs-980b6a62-9bf8-49a3-825a-0fb4eb326d92' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-980b6a62-9bf8-49a3-825a-0fb4eb326d92' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-714344e8-8868-46f6-bdfe-a5cf8664849a' class='xr-var-data-in' type='checkbox'><label for='data-714344e8-8868-46f6-bdfe-a5cf8664849a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4782,9 +4953,9 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-4bf96e94-f58f-4d17-b9b1-ffcb7eebe7a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4bf96e94-f58f-4d17-b9b1-ffcb7eebe7a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-30bb04c5-124d-4038-97d3-4e32d05e9b11' class='xr-var-data-in' type='checkbox'><label for='data-30bb04c5-124d-4038-97d3-4e32d05e9b11' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
-       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-876b38a1-5fc5-48c5-9364-e444a59cf82c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-876b38a1-5fc5-48c5-9364-e444a59cf82c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-11a31300-3804-42f6-8119-5f1d047449a6' class='xr-var-data-in' type='checkbox'><label for='data-11a31300-3804-42f6-8119-5f1d047449a6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
-       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d7178610-19b5-4fc4-9be6-ba1a50d259bb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d7178610-19b5-4fc4-9be6-ba1a50d259bb' class='xr-section-summary' >Data variables: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-2a1cd4cb-0d30-49fa-85f3-fe6806ea7089' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2a1cd4cb-0d30-49fa-85f3-fe6806ea7089' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-972a1128-511b-455f-9163-b559b5547a5c' class='xr-var-data-in' type='checkbox'><label for='data-972a1128-511b-455f-9163-b559b5547a5c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-fb9ad5d6-69c2-42f4-9308-b75a8e88e191' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fb9ad5d6-69c2-42f4-9308-b75a8e88e191' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-41878881-0459-4a42-8c68-d9bc1b904a05' class='xr-var-data-in' type='checkbox'><label for='data-41878881-0459-4a42-8c68-d9bc1b904a05' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
+       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-e7862392-1ecf-4606-9832-2e63471b07dd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e7862392-1ecf-4606-9832-2e63471b07dd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-044ced9b-7843-4b9d-80d9-2ab33416a8fe' class='xr-var-data-in' type='checkbox'><label for='data-044ced9b-7843-4b9d-80d9-2ab33416a8fe' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
+       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cdc8d0fc-ab88-4ba2-a86d-12c16267008e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cdc8d0fc-ab88-4ba2-a86d-12c16267008e' class='xr-section-summary' >Data variables: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-3a4290c7-13c5-464b-b678-f65c79777e5d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3a4290c7-13c5-464b-b678-f65c79777e5d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-18bf7639-b14c-4eb3-95e7-4d8d8c9e8557' class='xr-var-data-in' type='checkbox'><label for='data-18bf7639-b14c-4eb3-95e7-4d8d8c9e8557' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4882,7 +5053,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-75670c87-5583-416d-9f35-1806c5f5154b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-75670c87-5583-416d-9f35-1806c5f5154b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ce4ee1a8-d7a2-4950-b77a-fad1c9323ef9' class='xr-var-data-in' type='checkbox'><label for='data-ce4ee1a8-d7a2-4950-b77a-fad1c9323ef9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-d2660435-a75a-4821-8157-4c5e395b0dc4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d2660435-a75a-4821-8157-4c5e395b0dc4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-091f5587-0fed-4792-bc2e-9702d2074f15' class='xr-var-data-in' type='checkbox'><label for='data-091f5587-0fed-4792-bc2e-9702d2074f15' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4980,7 +5151,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-f6baed9c-73f8-48ce-9d2e-c0684f98545d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f6baed9c-73f8-48ce-9d2e-c0684f98545d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9ca8eb31-a8a8-4894-8dd3-11fe0160cd6e' class='xr-var-data-in' type='checkbox'><label for='data-9ca8eb31-a8a8-4894-8dd3-11fe0160cd6e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-d1aae19c-9a4b-4007-b3d4-762919dee76f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d1aae19c-9a4b-4007-b3d4-762919dee76f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-99025023-096f-481c-ace3-f17e2003b57d' class='xr-var-data-in' type='checkbox'><label for='data-99025023-096f-481c-ace3-f17e2003b57d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5078,7 +5249,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-6a4d29e8-8b44-42f0-8eaf-6c15c6a4979b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6a4d29e8-8b44-42f0-8eaf-6c15c6a4979b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eaa970a4-d1e0-47cf-80a4-4a6ebe7bdd7b' class='xr-var-data-in' type='checkbox'><label for='data-eaa970a4-d1e0-47cf-80a4-4a6ebe7bdd7b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-3a4e39c2-2d9b-49d1-9570-ea2d2da4a525' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3a4e39c2-2d9b-49d1-9570-ea2d2da4a525' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ae960646-d27e-4204-bbe1-ac98f77b549e' class='xr-var-data-in' type='checkbox'><label for='data-ae960646-d27e-4204-bbe1-ac98f77b549e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5176,7 +5347,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-f6a20dd6-57d1-444e-b569-972859bd2bc9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f6a20dd6-57d1-444e-b569-972859bd2bc9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6aee57be-543e-45fd-b6e0-b6ce11ee7b21' class='xr-var-data-in' type='checkbox'><label for='data-6aee57be-543e-45fd-b6e0-b6ce11ee7b21' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-0c2b9e73-ee0f-4e2d-86f8-99eff2b0d5fc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0c2b9e73-ee0f-4e2d-86f8-99eff2b0d5fc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a1e66e60-5ada-4d20-b69a-2db182775825' class='xr-var-data-in' type='checkbox'><label for='data-a1e66e60-5ada-4d20-b69a-2db182775825' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5274,7 +5445,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-6c465964-5c16-4932-a89f-4f3d73be2c84' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6c465964-5c16-4932-a89f-4f3d73be2c84' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8ccc65fb-feed-4a8c-918c-c160c8aeadf2' class='xr-var-data-in' type='checkbox'><label for='data-8ccc65fb-feed-4a8c-918c-c160c8aeadf2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-b39db303-2110-487e-8ba8-798615c90e0b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b39db303-2110-487e-8ba8-798615c90e0b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f5f1aa24-9088-4071-bbb6-3f09a1db71b1' class='xr-var-data-in' type='checkbox'><label for='data-f5f1aa24-9088-4071-bbb6-3f09a1db71b1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5372,7 +5543,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-2d7f1cc4-bc8f-48ad-8e8b-6c4b0499227a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2d7f1cc4-bc8f-48ad-8e8b-6c4b0499227a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0fdf908e-0650-4e8b-8db4-b57c10462716' class='xr-var-data-in' type='checkbox'><label for='data-0fdf908e-0650-4e8b-8db4-b57c10462716' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cc2b0ebe-6e8e-447f-95dc-b1fc5e099596' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cc2b0ebe-6e8e-447f-95dc-b1fc5e099596' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-01T00:00:00+00:00&#x27;, &#x27;2018-05-10T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;1 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:25:17.771627</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-05-11T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P10DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1DT0H0M0S</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-1a2791a5-6bca-454d-8465-7b9786537a54' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1a2791a5-6bca-454d-8465-7b9786537a54' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f95fdfa8-9adc-4e18-b3d5-b8e4a768d0ae' class='xr-var-data-in' type='checkbox'><label for='data-f95fdfa8-9adc-4e18-b3d5-b8e4a768d0ae' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e4a99133-fb3f-4b5c-a4eb-921735d4f325' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e4a99133-fb3f-4b5c-a4eb-921735d4f325' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-01T00:00:00+00:00&#x27;, &#x27;2018-05-10T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;1 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:17:18.662854</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-05-11T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P10DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1DT0H0M0S</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -5395,7 +5566,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:25:17.771627\n",
+       "    date_created:              2022-06-23T10:17:18.662854\n",
        "    time_coverage_start:       2018-05-01T00:00:00+00:00\n",
        "    time_coverage_end:         2018-05-11T00:00:00+00:00\n",
        "    time_coverage_duration:    P10DT0H0M0S\n",
@@ -5403,7 +5574,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5415,14 +5586,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "b82aaef7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:18.821631Z",
+     "iopub.status.busy": "2022-06-23T10:17:18.821353Z",
+     "iopub.status.idle": "2022-06-23T10:17:19.697180Z",
+     "shell.execute_reply": "2022-06-23T10:17:19.696588Z"
+    },
     "papermill": {
-     "duration": 1.400576,
-     "end_time": "2022-02-23T14:00:52.690101",
+     "duration": 0.938885,
+     "end_time": "2022-06-23T10:17:19.705080",
      "exception": false,
-     "start_time": "2022-02-23T14:00:51.289525",
+     "start_time": "2022-06-23T10:17:18.766195",
      "status": "completed"
     },
     "tags": []
@@ -5431,10 +5608,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f9c74d08040>"
+       "<matplotlib.image.AxesImage at 0x7f0e9cf25c70>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -5459,7 +5636,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0e859299-3503-4b9c-90fc-707e46f39861",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.064122,
+     "end_time": "2022-06-23T10:17:19.830457",
+     "exception": false,
+     "start_time": "2022-06-23T10:17:19.766335",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
@@ -5483,14 +5669,14 @@
    "version": "3.8.12"
   },
   "papermill": {
-   "duration": 34.983004,
-   "end_time": "2022-02-23T14:00:53.290917",
+   "duration": 84.087443,
+   "end_time": "2022-06-23T10:17:20.507026",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/tmp/tmpdwv_zxbq",
-   "output_path": "/tmp/cur_notebook.ipynb",
+   "input_path": "/tmp/tmpi4ustmtn",
+   "output_path": "/tmp/notebook_output.ipynb",
    "parameters": {},
-   "start_time": "2022-02-23T14:00:18.307913",
+   "start_time": "2022-06-23T10:15:56.419583",
    "version": "2.1.0"
   },
   "properties": {

--- a/notebooks/curated/EDC_Sentinel_Hub-Data-access.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-Data-access.ipynb
@@ -5496,6 +5496,7 @@
   "properties": {
    "description": "Euro Data Cube Sentinel Hub - data access",
    "id": "sh-data-access",
+   "license": null,
    "name": "Sentinel Hub data access using xcube",
    "requirements": [
     "eurodatacube"

--- a/notebooks/curated/EDC_Sentinel_Hub-Datasets.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-Datasets.ipynb
@@ -5028,6 +5028,7 @@
   "properties": {
    "description": "Euro Data Cube Sentinel Hub - datasets",
    "id": "sh-xcube-datasets",
+   "license": null,
    "name": "Sentinel Hub datasets using XCUBE",
    "requirements": [
     "eurodatacube"

--- a/notebooks/curated/EDC_Sentinel_Hub-Datasets.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-Datasets.ipynb
@@ -6,16 +6,16 @@
    "id": "2ca71008",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:58.535286Z",
-     "iopub.status.busy": "2022-02-23T14:00:58.534618Z",
-     "iopub.status.idle": "2022-02-23T14:00:58.670581Z",
-     "shell.execute_reply": "2022-02-23T14:00:58.669398Z"
+     "iopub.execute_input": "2022-06-23T10:15:59.449316Z",
+     "iopub.status.busy": "2022-06-23T10:15:59.448992Z",
+     "iopub.status.idle": "2022-06-23T10:16:44.247212Z",
+     "shell.execute_reply": "2022-06-23T10:16:44.246704Z"
     },
     "papermill": {
-     "duration": 0.177753,
-     "end_time": "2022-02-23T14:00:58.673095",
+     "duration": 44.857501,
+     "end_time": "2022-06-23T10:16:44.269211",
      "exception": false,
-     "start_time": "2022-02-23T14:00:58.495342",
+     "start_time": "2022-06-23T10:15:59.411710",
      "status": "completed"
     },
     "tags": []
@@ -55,16 +55,16 @@
    "id": "90608d0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:58.757371Z",
-     "iopub.status.busy": "2022-02-23T14:00:58.757085Z",
-     "iopub.status.idle": "2022-02-23T14:00:58.768391Z",
-     "shell.execute_reply": "2022-02-23T14:00:58.767242Z"
+     "iopub.execute_input": "2022-06-23T10:16:44.310758Z",
+     "iopub.status.busy": "2022-06-23T10:16:44.310462Z",
+     "iopub.status.idle": "2022-06-23T10:16:44.316497Z",
+     "shell.execute_reply": "2022-06-23T10:16:44.316040Z"
     },
     "papermill": {
-     "duration": 0.05797,
-     "end_time": "2022-02-23T14:00:58.770610",
+     "duration": 0.029554,
+     "end_time": "2022-06-23T10:16:44.317962",
      "exception": false,
-     "start_time": "2022-02-23T14:00:58.712640",
+     "start_time": "2022-06-23T10:16:44.288408",
      "status": "completed"
     },
     "tags": []
@@ -128,10 +128,10 @@
    "id": "baf75446",
    "metadata": {
     "papermill": {
-     "duration": 0.059282,
-     "end_time": "2022-02-23T14:00:58.869202",
+     "duration": 0.021911,
+     "end_time": "2022-06-23T10:16:44.360568",
      "exception": false,
-     "start_time": "2022-02-23T14:00:58.809920",
+     "start_time": "2022-06-23T10:16:44.338657",
      "status": "completed"
     },
     "tags": []
@@ -150,14 +150,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "6100aab6",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:44.407683Z",
+     "iopub.status.busy": "2022-06-23T10:16:44.407411Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.594487Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.593404Z"
+    },
     "papermill": {
-     "duration": 1.498832,
-     "end_time": "2022-02-23T14:01:00.408003",
+     "duration": 1.21507,
+     "end_time": "2022-06-23T10:16:45.596430",
      "exception": false,
-     "start_time": "2022-02-23T14:00:58.909171",
+     "start_time": "2022-06-23T10:16:44.381360",
      "status": "completed"
     },
     "tags": []
@@ -173,14 +179,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "a49637c3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:45.640414Z",
+     "iopub.status.busy": "2022-06-23T10:16:45.640116Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.644123Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.643494Z"
+    },
     "papermill": {
-     "duration": 0.047317,
-     "end_time": "2022-02-23T14:01:00.494935",
+     "duration": 0.028235,
+     "end_time": "2022-06-23T10:16:45.645594",
      "exception": false,
-     "start_time": "2022-02-23T14:01:00.447618",
+     "start_time": "2022-06-23T10:16:45.617359",
      "status": "completed"
     },
     "tags": []
@@ -197,14 +209,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "1f290784",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:45.692550Z",
+     "iopub.status.busy": "2022-06-23T10:16:45.691642Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.697391Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.695912Z"
+    },
     "papermill": {
-     "duration": 0.068061,
-     "end_time": "2022-02-23T14:01:00.602501",
+     "duration": 0.03095,
+     "end_time": "2022-06-23T10:16:45.700463",
      "exception": false,
-     "start_time": "2022-02-23T14:01:00.534440",
+     "start_time": "2022-06-23T10:16:45.669513",
      "status": "completed"
     },
     "tags": []
@@ -216,14 +234,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "1cfcc49d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:45.749000Z",
+     "iopub.status.busy": "2022-06-23T10:16:45.748722Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.842023Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.841414Z"
+    },
     "papermill": {
-     "duration": 0.176808,
-     "end_time": "2022-02-23T14:01:00.819119",
+     "duration": 0.116807,
+     "end_time": "2022-06-23T10:16:45.843545",
      "exception": false,
-     "start_time": "2022-02-23T14:01:00.642311",
+     "start_time": "2022-06-23T10:16:45.726738",
      "status": "completed"
     },
     "tags": []
@@ -232,25 +256,25 @@
     {
      "data": {
       "text/plain": [
-       "['LOTL2',\n",
-       " 'LETML1',\n",
-       " 'LTML2',\n",
-       " 'S5PL2',\n",
+       "['S1GRD',\n",
+       " 'CUSTOM',\n",
        " 'DEM',\n",
        " 'S2L1C',\n",
-       " 'LTML1',\n",
-       " 'MODIS',\n",
-       " 'S2L2A',\n",
+       " 'LETML1',\n",
        " 'LETML2',\n",
-       " 'CUSTOM',\n",
-       " 'S1GRD',\n",
+       " 'LTML2',\n",
        " 'LOTL1',\n",
+       " 'LTML1',\n",
        " 'S3OLCI',\n",
-       " 'LMSSL1',\n",
-       " 'S3SLSTR']"
+       " 'S3SLSTR',\n",
+       " 'S5PL2',\n",
+       " 'S2L2A',\n",
+       " 'MODIS',\n",
+       " 'LOTL2',\n",
+       " 'LMSSL1']"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -265,10 +289,10 @@
    "id": "3c056774",
    "metadata": {
     "papermill": {
-     "duration": 0.039804,
-     "end_time": "2022-02-23T14:01:00.902472",
+     "duration": 0.020893,
+     "end_time": "2022-06-23T10:16:45.886076",
      "exception": false,
-     "start_time": "2022-02-23T14:01:00.862668",
+     "start_time": "2022-06-23T10:16:45.865183",
      "status": "completed"
     },
     "tags": []
@@ -279,14 +303,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "f15b14c4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:45.933143Z",
+     "iopub.status.busy": "2022-06-23T10:16:45.932871Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.946096Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.945530Z"
+    },
     "papermill": {
-     "duration": 0.059812,
-     "end_time": "2022-02-23T14:01:01.001569",
+     "duration": 0.037444,
+     "end_time": "2022-06-23T10:16:45.947760",
      "exception": false,
-     "start_time": "2022-02-23T14:01:00.941757",
+     "start_time": "2022-06-23T10:16:45.910316",
      "status": "completed"
     },
     "tags": []
@@ -319,7 +349,7 @@
        " 'CLP']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -330,14 +360,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "12dde912",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:45.993257Z",
+     "iopub.status.busy": "2022-06-23T10:16:45.992297Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.998818Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.998297Z"
+    },
     "papermill": {
-     "duration": 0.052244,
-     "end_time": "2022-02-23T14:01:01.098250",
+     "duration": 0.030997,
+     "end_time": "2022-06-23T10:16:46.000131",
      "exception": false,
-     "start_time": "2022-02-23T14:01:01.046006",
+     "start_time": "2022-06-23T10:16:45.969134",
      "status": "completed"
     },
     "tags": []
@@ -364,14 +400,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "f60da31f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:46.050910Z",
+     "iopub.status.busy": "2022-06-23T10:16:46.050622Z",
+     "iopub.status.idle": "2022-06-23T10:16:46.382800Z",
+     "shell.execute_reply": "2022-06-23T10:16:46.382361Z"
+    },
     "papermill": {
-     "duration": 0.91268,
-     "end_time": "2022-02-23T14:01:02.052980",
+     "duration": 0.357475,
+     "end_time": "2022-06-23T10:16:46.384981",
      "exception": false,
-     "start_time": "2022-02-23T14:01:01.140300",
+     "start_time": "2022-06-23T10:16:46.027506",
      "status": "completed"
     },
     "tags": []
@@ -745,7 +787,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-06-23T08:23:34.209728\n",
+       "    date_created:            2022-06-23T10:16:46.186870\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -753,7 +795,7 @@
        "    geospatial_lat_min:      54.27\n",
        "    geospatial_lon_max:      11.01376\n",
        "    geospatial_lat_max:      54.63864\n",
-       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-6a842176-465b-42ca-88f1-02492beefaa6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-6a842176-465b-42ca-88f1-02492beefaa6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-1197f9be-1d2f-4c78-b854-4c7e569c316c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1197f9be-1d2f-4c78-b854-4c7e569c316c' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-dccf7e1e-e2db-4af6-a10b-a88c98b5a0c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dccf7e1e-e2db-4af6-a10b-a88c98b5a0c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6d8f2349-3c30-472a-896e-536d13ba0d95' class='xr-var-data-in' type='checkbox'><label for='data-6d8f2349-3c30-472a-896e-536d13ba0d95' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-756af571-4d32-4cea-91ce-fcf2ffceba3c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-756af571-4d32-4cea-91ce-fcf2ffceba3c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4668ab00-b55b-4074-9d88-af6b82cf5657' class='xr-var-data-in' type='checkbox'><label for='data-4668ab00-b55b-4074-9d88-af6b82cf5657' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-96f82163-ee65-4907-8392-56029611027b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-96f82163-ee65-4907-8392-56029611027b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cdf8f768-4fc5-4d31-9ae0-0b302ac4877b' class='xr-var-data-in' type='checkbox'><label for='data-cdf8f768-4fc5-4d31-9ae0-0b302ac4877b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
+       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-76e74db9-afa0-4729-b96c-8fdc11687a52' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-76e74db9-afa0-4729-b96c-8fdc11687a52' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4c18a86a-5874-4758-bb69-f932c4f2bdfe' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4c18a86a-5874-4758-bb69-f932c4f2bdfe' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-fb7094a8-e264-41af-a154-c28422163f70' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fb7094a8-e264-41af-a154-c28422163f70' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-44484a6d-25be-4b33-be82-5664139d2aff' class='xr-var-data-in' type='checkbox'><label for='data-44484a6d-25be-4b33-be82-5664139d2aff' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-3e392f18-1db7-4c42-9e88-1afab73ed355' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3e392f18-1db7-4c42-9e88-1afab73ed355' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e490a722-275f-4aed-9a25-abe5c6dcfe6a' class='xr-var-data-in' type='checkbox'><label for='data-e490a722-275f-4aed-9a25-abe5c6dcfe6a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-b55ac846-a344-454f-800e-27075dd428e0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b55ac846-a344-454f-800e-27075dd428e0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-352ab2ea-0160-4a22-a7ac-30777515c3f9' class='xr-var-data-in' type='checkbox'><label for='data-352ab2ea-0160-4a22-a7ac-30777515c3f9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
        "       &#x27;2018-05-18T10:40:24.000000000&#x27;, &#x27;2018-05-20T10:34:58.000000000&#x27;,\n",
        "       &#x27;2018-05-22T10:20:25.000000000&#x27;, &#x27;2018-05-23T10:41:24.000000000&#x27;,\n",
        "       &#x27;2018-05-25T10:30:24.000000000&#x27;, &#x27;2018-05-28T10:40:23.000000000&#x27;,\n",
@@ -775,7 +817,7 @@
        "       &#x27;2018-07-19T10:30:20.000000000&#x27;, &#x27;2018-07-21T10:20:24.000000000&#x27;,\n",
        "       &#x27;2018-07-22T10:40:20.000000000&#x27;, &#x27;2018-07-24T10:30:23.000000000&#x27;,\n",
        "       &#x27;2018-07-26T10:21:50.000000000&#x27;, &#x27;2018-07-27T10:40:23.000000000&#x27;,\n",
-       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-1036c49e-5d00-4ef7-a446-f5ac9b91a65c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1036c49e-5d00-4ef7-a446-f5ac9b91a65c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5521331b-9275-4577-afe1-658083902cd5' class='xr-var-data-in' type='checkbox'><label for='data-5521331b-9275-4577-afe1-658083902cd5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-f747530d-5e14-4d48-bd21-bafb8b3d8d29' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f747530d-5e14-4d48-bd21-bafb8b3d8d29' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-28f0db3e-9d65-41a7-9d45-9aa2ea8e08c9' class='xr-var-data-in' type='checkbox'><label for='data-28f0db3e-9d65-41a7-9d45-9aa2ea8e08c9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -832,7 +874,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-c1806e86-a53a-4490-be0f-2d4a86dfcaa6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c1806e86-a53a-4490-be0f-2d4a86dfcaa6' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3e33b8b6-f18c-4e27-9f78-56e1579b3800' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3e33b8b6-f18c-4e27-9f78-56e1579b3800' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ab1bff0e-4690-41ab-9667-55a2b6b4b9d8' class='xr-var-data-in' type='checkbox'><label for='data-ab1bff0e-4690-41ab-9667-55a2b6b4b9d8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-db3c7968-a2db-4a75-b01b-c7f255282ec3' class='xr-section-summary-in' type='checkbox'  checked><label for='section-db3c7968-a2db-4a75-b01b-c7f255282ec3' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ed0b9d9e-e297-4de6-8ca5-46357716cf0d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ed0b9d9e-e297-4de6-8ca5-46357716cf0d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d7599a2f-b3b5-469c-aef2-00b82d3eacec' class='xr-var-data-in' type='checkbox'><label for='data-d7599a2f-b3b5-469c-aef2-00b82d3eacec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -974,7 +1016,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8267c41f-4918-4e79-b8ff-27e60a3cdbc5' class='xr-section-summary-in' type='checkbox'  ><label for='section-8267c41f-4918-4e79-b8ff-27e60a3cdbc5' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;SCL&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:23:34.209728</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-d5c82c80-f203-406b-8f99-54030362cfd8' class='xr-section-summary-in' type='checkbox'  ><label for='section-d5c82c80-f203-406b-8f99-54030362cfd8' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;SCL&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:16:46.186870</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -991,7 +1033,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{'program': 'xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-06-23T08:23:34.209728\n",
+       "    date_created:            2022-06-23T10:16:46.186870\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -1002,7 +1044,7 @@
        "    processing_level:        L2A"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1014,14 +1056,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "633e0fa1",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:46.441067Z",
+     "iopub.status.busy": "2022-06-23T10:16:46.440801Z",
+     "iopub.status.idle": "2022-06-23T10:16:55.484475Z",
+     "shell.execute_reply": "2022-06-23T10:16:55.483842Z"
+    },
     "papermill": {
-     "duration": 5.657093,
-     "end_time": "2022-02-23T14:01:07.755274",
+     "duration": 9.072087,
+     "end_time": "2022-06-23T10:16:55.485913",
      "exception": false,
-     "start_time": "2022-02-23T14:01:02.098181",
+     "start_time": "2022-06-23T10:16:46.413826",
      "status": "completed"
     },
     "tags": []
@@ -1030,10 +1078,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7ff6ff4f4af0>"
+       "<matplotlib.image.AxesImage at 0x7f8df0d6baf0>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1059,10 +1107,10 @@
    "id": "45f6b61b",
    "metadata": {
     "papermill": {
-     "duration": 0.047203,
-     "end_time": "2022-02-23T14:01:07.848071",
+     "duration": 0.025466,
+     "end_time": "2022-06-23T10:16:55.540989",
      "exception": false,
-     "start_time": "2022-02-23T14:01:07.800868",
+     "start_time": "2022-06-23T10:16:55.515523",
      "status": "completed"
     },
     "tags": []
@@ -1073,14 +1121,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "04023765",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:55.593532Z",
+     "iopub.status.busy": "2022-06-23T10:16:55.592764Z",
+     "iopub.status.idle": "2022-06-23T10:16:55.607962Z",
+     "shell.execute_reply": "2022-06-23T10:16:55.607425Z"
+    },
     "papermill": {
-     "duration": 0.069921,
-     "end_time": "2022-02-23T14:01:07.962432",
+     "duration": 0.043817,
+     "end_time": "2022-06-23T10:16:55.609587",
      "exception": false,
-     "start_time": "2022-02-23T14:01:07.892511",
+     "start_time": "2022-06-23T10:16:55.565770",
      "status": "completed"
     },
     "tags": []
@@ -1110,7 +1164,7 @@
        " 'CLP']"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1121,14 +1175,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "fb3b5281",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:55.662262Z",
+     "iopub.status.busy": "2022-06-23T10:16:55.661984Z",
+     "iopub.status.idle": "2022-06-23T10:16:55.667248Z",
+     "shell.execute_reply": "2022-06-23T10:16:55.666698Z"
+    },
     "papermill": {
-     "duration": 0.059691,
-     "end_time": "2022-02-23T14:01:08.070918",
+     "duration": 0.033156,
+     "end_time": "2022-06-23T10:16:55.668685",
      "exception": false,
-     "start_time": "2022-02-23T14:01:08.011227",
+     "start_time": "2022-06-23T10:16:55.635529",
      "status": "completed"
     },
     "tags": []
@@ -1155,14 +1215,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "89c7399b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:55.724639Z",
+     "iopub.status.busy": "2022-06-23T10:16:55.724306Z",
+     "iopub.status.idle": "2022-06-23T10:16:55.888171Z",
+     "shell.execute_reply": "2022-06-23T10:16:55.887684Z"
+    },
     "papermill": {
-     "duration": 0.316721,
-     "end_time": "2022-02-23T14:01:08.433279",
+     "duration": 0.192625,
+     "end_time": "2022-06-23T10:16:55.890179",
      "exception": false,
-     "start_time": "2022-02-23T14:01:08.116558",
+     "start_time": "2022-06-23T10:16:55.697554",
      "status": "completed"
     },
     "tags": []
@@ -1536,7 +1602,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L1C Data Cube Subset\n",
        "    history:                 [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-06-23T08:23:42.998877\n",
+       "    date_created:            2022-06-23T10:16:55.856762\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -1544,7 +1610,7 @@
        "    geospatial_lat_min:      54.27\n",
        "    geospatial_lon_max:      11.01376\n",
        "    geospatial_lat_max:      54.63864\n",
-       "    processing_level:        L1C</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2e6972b7-2215-44ac-8995-0606be9b6335' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2e6972b7-2215-44ac-8995-0606be9b6335' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-04c3f2b5-3f54-4d23-834f-fcba37fb2590' class='xr-section-summary-in' type='checkbox'  checked><label for='section-04c3f2b5-3f54-4d23-834f-fcba37fb2590' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-040b773f-7d8c-43b2-8ad9-a650eb684331' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-040b773f-7d8c-43b2-8ad9-a650eb684331' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f9ec68d2-a35d-4929-b5be-678541ab2534' class='xr-var-data-in' type='checkbox'><label for='data-f9ec68d2-a35d-4929-b5be-678541ab2534' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-4cbe4f22-5db4-4874-8174-d31f8143e6a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4cbe4f22-5db4-4874-8174-d31f8143e6a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-49bc1f6c-daec-4ef9-9eb9-763c7ce1dcc9' class='xr-var-data-in' type='checkbox'><label for='data-49bc1f6c-daec-4ef9-9eb9-763c7ce1dcc9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-0edbb941-9cbf-4554-8c96-60c7edbf3af9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0edbb941-9cbf-4554-8c96-60c7edbf3af9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4235c0a0-63ce-48ba-96a1-de5bc3a86a69' class='xr-var-data-in' type='checkbox'><label for='data-4235c0a0-63ce-48ba-96a1-de5bc3a86a69' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
+       "    processing_level:        L1C</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-6999b4e2-9dc6-4806-847e-4272c75af6a1' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-6999b4e2-9dc6-4806-847e-4272c75af6a1' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-5273ae42-5490-4b98-a547-f29951968bdd' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5273ae42-5490-4b98-a547-f29951968bdd' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-e022690c-36b4-4038-afc6-7284a34c04e2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e022690c-36b4-4038-afc6-7284a34c04e2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3363298b-ec32-48f1-94b5-51f5e5d10711' class='xr-var-data-in' type='checkbox'><label for='data-3363298b-ec32-48f1-94b5-51f5e5d10711' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-86b34b0f-10d5-4b8a-8dca-fd89511c359c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-86b34b0f-10d5-4b8a-8dca-fd89511c359c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-84cc023b-5fd8-4ac0-b4c5-178cfda68a39' class='xr-var-data-in' type='checkbox'><label for='data-84cc023b-5fd8-4ac0-b4c5-178cfda68a39' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-cf1a5041-2e6a-4933-b053-7c576fb0eaed' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cf1a5041-2e6a-4933-b053-7c576fb0eaed' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-66ae26fc-9f88-427a-b997-662041f96529' class='xr-var-data-in' type='checkbox'><label for='data-66ae26fc-9f88-427a-b997-662041f96529' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
        "       &#x27;2018-05-18T10:40:24.000000000&#x27;, &#x27;2018-05-20T10:34:58.000000000&#x27;,\n",
        "       &#x27;2018-05-22T10:20:25.000000000&#x27;, &#x27;2018-05-23T10:41:24.000000000&#x27;,\n",
        "       &#x27;2018-05-25T10:30:24.000000000&#x27;, &#x27;2018-05-28T10:40:23.000000000&#x27;,\n",
@@ -1566,7 +1632,7 @@
        "       &#x27;2018-07-19T10:30:20.000000000&#x27;, &#x27;2018-07-21T10:20:24.000000000&#x27;,\n",
        "       &#x27;2018-07-22T10:40:20.000000000&#x27;, &#x27;2018-07-24T10:30:23.000000000&#x27;,\n",
        "       &#x27;2018-07-26T10:21:50.000000000&#x27;, &#x27;2018-07-27T10:40:23.000000000&#x27;,\n",
-       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-c29a2656-4b01-4667-ac97-4230c1b0d159' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c29a2656-4b01-4667-ac97-4230c1b0d159' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0e75fe1-59ac-4bf9-a908-6bf3937be914' class='xr-var-data-in' type='checkbox'><label for='data-e0e75fe1-59ac-4bf9-a908-6bf3937be914' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-4aa449cc-8e6a-42ef-86e1-4510ead12199' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4aa449cc-8e6a-42ef-86e1-4510ead12199' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5f9b84ad-ff5d-462f-adb5-46f5bee33d75' class='xr-var-data-in' type='checkbox'><label for='data-5f9b84ad-ff5d-462f-adb5-46f5bee33d75' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1623,7 +1689,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-44f5bf48-2b65-4f6e-9f56-4ccd8c10822f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-44f5bf48-2b65-4f6e-9f56-4ccd8c10822f' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ca671989-8726-4878-8405-ba6de945d1db' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ca671989-8726-4878-8405-ba6de945d1db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8a4fc501-8145-4cab-9423-95abdf601c24' class='xr-var-data-in' type='checkbox'><label for='data-8a4fc501-8145-4cab-9423-95abdf601c24' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-68978c70-79be-4e4a-a9ab-1c7848174983' class='xr-section-summary-in' type='checkbox'  checked><label for='section-68978c70-79be-4e4a-a9ab-1c7848174983' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-46db0779-c0a4-497c-96e9-b4c9f5ac27a4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-46db0779-c0a4-497c-96e9-b4c9f5ac27a4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ec86be28-a66c-4f54-a0af-e2ea7164b942' class='xr-var-data-in' type='checkbox'><label for='data-ec86be28-a66c-4f54-a0af-e2ea7164b942' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1765,7 +1831,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8fb0fe99-b7ae-44a1-8d5c-06f912147328' class='xr-section-summary-in' type='checkbox'  ><label for='section-8fb0fe99-b7ae-44a1-8d5c-06f912147328' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L1C Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L1C&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:23:42.998877</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1C</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-bf6929fd-61b4-4639-b06b-8af4d1735a54' class='xr-section-summary-in' type='checkbox'  ><label for='section-bf6929fd-61b4-4639-b06b-8af4d1735a54' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L1C Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L1C&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:16:55.856762</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1C</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1782,7 +1848,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L1C Data Cube Subset\n",
        "    history:                 [{'program': 'xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-06-23T08:23:42.998877\n",
+       "    date_created:            2022-06-23T10:16:55.856762\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -1793,7 +1859,7 @@
        "    processing_level:        L1C"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1805,14 +1871,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "0f08e7db",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:55.949217Z",
+     "iopub.status.busy": "2022-06-23T10:16:55.948901Z",
+     "iopub.status.idle": "2022-06-23T10:17:05.276823Z",
+     "shell.execute_reply": "2022-06-23T10:17:05.276241Z"
+    },
     "papermill": {
-     "duration": 10.607464,
-     "end_time": "2022-02-23T14:01:19.087817",
+     "duration": 9.361154,
+     "end_time": "2022-06-23T10:17:05.280474",
      "exception": false,
-     "start_time": "2022-02-23T14:01:08.480353",
+     "start_time": "2022-06-23T10:16:55.919320",
      "status": "completed"
     },
     "tags": []
@@ -1821,10 +1893,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7ff6ffb31fd0>"
+       "<matplotlib.image.AxesImage at 0x7f8df132b0a0>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1850,10 +1922,10 @@
    "id": "913126da",
    "metadata": {
     "papermill": {
-     "duration": 0.053501,
-     "end_time": "2022-02-23T14:01:19.199938",
+     "duration": 0.031419,
+     "end_time": "2022-06-23T10:17:05.346842",
      "exception": false,
-     "start_time": "2022-02-23T14:01:19.146437",
+     "start_time": "2022-06-23T10:17:05.315423",
      "status": "completed"
     },
     "tags": []
@@ -1864,14 +1936,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "c1c7d231",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:05.411090Z",
+     "iopub.status.busy": "2022-06-23T10:17:05.410806Z",
+     "iopub.status.idle": "2022-06-23T10:17:05.423307Z",
+     "shell.execute_reply": "2022-06-23T10:17:05.422794Z"
+    },
     "papermill": {
-     "duration": 0.066448,
-     "end_time": "2022-02-23T14:01:19.319529",
+     "duration": 0.047622,
+     "end_time": "2022-06-23T10:17:05.424792",
      "exception": false,
-     "start_time": "2022-02-23T14:01:19.253081",
+     "start_time": "2022-06-23T10:17:05.377170",
      "status": "completed"
     },
     "tags": []
@@ -1883,7 +1961,7 @@
        "['VV', 'HH', 'VH', 'localIncidenceAngle', 'scatteringArea', 'shadowMask', 'HV']"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1894,14 +1972,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "522cf686",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:05.494020Z",
+     "iopub.status.busy": "2022-06-23T10:17:05.493743Z",
+     "iopub.status.idle": "2022-06-23T10:17:05.497507Z",
+     "shell.execute_reply": "2022-06-23T10:17:05.496931Z"
+    },
     "papermill": {
-     "duration": 0.05805,
-     "end_time": "2022-02-23T14:01:19.427502",
+     "duration": 0.042968,
+     "end_time": "2022-06-23T10:17:05.499072",
      "exception": false,
-     "start_time": "2022-02-23T14:01:19.369452",
+     "start_time": "2022-06-23T10:17:05.456104",
      "status": "completed"
     },
     "tags": []
@@ -1918,14 +2002,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "c693c028",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:05.566854Z",
+     "iopub.status.busy": "2022-06-23T10:17:05.566570Z",
+     "iopub.status.idle": "2022-06-23T10:17:05.569679Z",
+     "shell.execute_reply": "2022-06-23T10:17:05.569170Z"
+    },
     "papermill": {
-     "duration": 0.063338,
-     "end_time": "2022-02-23T14:01:19.546029",
+     "duration": 0.035911,
+     "end_time": "2022-06-23T10:17:05.571010",
      "exception": false,
-     "start_time": "2022-02-23T14:01:19.482691",
+     "start_time": "2022-06-23T10:17:05.535099",
      "status": "completed"
     },
     "tags": []
@@ -1937,14 +2027,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "c771a192",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:05.646030Z",
+     "iopub.status.busy": "2022-06-23T10:17:05.645747Z",
+     "iopub.status.idle": "2022-06-23T10:17:05.650009Z",
+     "shell.execute_reply": "2022-06-23T10:17:05.649362Z"
+    },
     "papermill": {
-     "duration": 0.059624,
-     "end_time": "2022-02-23T14:01:19.656571",
+     "duration": 0.039132,
+     "end_time": "2022-06-23T10:17:05.651385",
      "exception": false,
-     "start_time": "2022-02-23T14:01:19.596947",
+     "start_time": "2022-06-23T10:17:05.612253",
      "status": "completed"
     },
     "tags": []
@@ -1963,14 +2059,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "e74bfbf4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:05.719066Z",
+     "iopub.status.busy": "2022-06-23T10:17:05.718790Z",
+     "iopub.status.idle": "2022-06-23T10:17:05.913056Z",
+     "shell.execute_reply": "2022-06-23T10:17:05.912394Z"
+    },
     "papermill": {
-     "duration": 0.227763,
-     "end_time": "2022-02-23T14:01:19.935772",
+     "duration": 0.233423,
+     "end_time": "2022-06-23T10:17:05.915120",
      "exception": false,
-     "start_time": "2022-02-23T14:01:19.708009",
+     "start_time": "2022-06-23T10:17:05.681697",
      "status": "completed"
     },
     "tags": []
@@ -2344,7 +2446,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S1GRD Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:23:54.435450\n",
+       "    date_created:              2022-06-23T10:17:05.796036\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -2353,7 +2455,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        10.55296\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L1B</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-78a52ec2-d635-4d5e-86bd-e59d4afcc18f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-78a52ec2-d635-4d5e-86bd-e59d4afcc18f' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 3072</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-96999df3-f99e-4eee-a05e-546454bf704f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-96999df3-f99e-4eee-a05e-546454bf704f' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-750f9da8-832f-47d0-ba30-df57997eced5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-750f9da8-832f-47d0-ba30-df57997eced5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-50ca82b0-0121-410d-bcd2-5af9888c9097' class='xr-var-data-in' type='checkbox'><label for='data-50ca82b0-0121-410d-bcd2-5af9888c9097' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.55 10.55</div><input id='attrs-3eed77d4-004e-43f4-a217-2afbf4f46da1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3eed77d4-004e-43f4-a217-2afbf4f46da1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6e6c0d64-b083-42a6-8fe5-0884c8df95bf' class='xr-var-data-in' type='checkbox'><label for='data-6e6c0d64-b083-42a6-8fe5-0884c8df95bf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 10.55251, 10.55269, 10.55287])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-05-15 ... 2019-08-01</div><input id='attrs-36d435ef-c76b-482e-9e5a-0c6e4eb811c9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-36d435ef-c76b-482e-9e5a-0c6e4eb811c9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-45aad9b1-6ddd-45c5-ad5e-3fd12800c0cd' class='xr-var-data-in' type='checkbox'><label for='data-45aad9b1-6ddd-45c5-ad5e-3fd12800c0cd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-05-15T00:00:00.000000000&#x27;, &#x27;2019-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L1B</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-60c1499e-a9cf-4b47-b34c-5f0af6a27e38' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-60c1499e-a9cf-4b47-b34c-5f0af6a27e38' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 3072</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-c61138b6-be7a-4812-aa40-56b7a90d55ed' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c61138b6-be7a-4812-aa40-56b7a90d55ed' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-99c01ac2-7420-43d8-a272-f19634e80776' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-99c01ac2-7420-43d8-a272-f19634e80776' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-427fc224-dc04-495e-ad42-a2cae0eb440a' class='xr-var-data-in' type='checkbox'><label for='data-427fc224-dc04-495e-ad42-a2cae0eb440a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.55 10.55</div><input id='attrs-6b0a3769-46fc-4da4-abba-bddd97404640' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6b0a3769-46fc-4da4-abba-bddd97404640' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e34b125d-70f3-4940-91c1-eeb03dad141a' class='xr-var-data-in' type='checkbox'><label for='data-e34b125d-70f3-4940-91c1-eeb03dad141a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 10.55251, 10.55269, 10.55287])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-05-15 ... 2019-08-01</div><input id='attrs-ba00152a-9736-4a3a-9106-291067f3ac80' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ba00152a-9736-4a3a-9106-291067f3ac80' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7b2a6279-39bf-48fc-81f7-58324aae9679' class='xr-var-data-in' type='checkbox'><label for='data-7b2a6279-39bf-48fc-81f7-58324aae9679' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-05-15T00:00:00.000000000&#x27;, &#x27;2019-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-05-19T00:00:00.000000000&#x27;, &#x27;2019-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-05-23T00:00:00.000000000&#x27;, &#x27;2019-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-05-27T00:00:00.000000000&#x27;, &#x27;2019-05-29T00:00:00.000000000&#x27;,\n",
@@ -2373,7 +2475,7 @@
        "       &#x27;2019-07-22T00:00:00.000000000&#x27;, &#x27;2019-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-07-26T00:00:00.000000000&#x27;, &#x27;2019-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-07-30T00:00:00.000000000&#x27;, &#x27;2019-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-9b4d7579-b58c-412a-a6f6-e10b09104051' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9b4d7579-b58c-412a-a6f6-e10b09104051' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ac4a305c-b1dc-46ef-827f-27d3ffaf5f98' class='xr-var-data-in' type='checkbox'><label for='data-ac4a305c-b1dc-46ef-827f-27d3ffaf5f98' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-0ba07b48-fa2f-4f21-9e83-4843a8922737' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0ba07b48-fa2f-4f21-9e83-4843a8922737' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9e53ab3d-ba56-4324-b2f8-fcae3486a193' class='xr-var-data-in' type='checkbox'><label for='data-9e53ab3d-ba56-4324-b2f8-fcae3486a193' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2430,7 +2532,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-987f324b-7685-4a54-9546-969bcb57e979' class='xr-section-summary-in' type='checkbox'  checked><label for='section-987f324b-7685-4a54-9546-969bcb57e979' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>VH</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e53d2e13-09d9-456b-91a8-5fee87cbf752' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e53d2e13-09d9-456b-91a8-5fee87cbf752' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-225837ac-4295-4832-8226-bfdce500ca34' class='xr-var-data-in' type='checkbox'><label for='data-225837ac-4295-4832-8226-bfdce500ca34' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Linear power in the chosen backscattering coefficient</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-3eb20de9-6f4b-4a0a-b748-d8367b4beb67' class='xr-section-summary-in' type='checkbox'  checked><label for='section-3eb20de9-6f4b-4a0a-b748-d8367b4beb67' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>VH</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-be0ca23f-20ab-4860-872a-355a449fd337' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-be0ca23f-20ab-4860-872a-355a449fd337' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cbc88c34-8476-42e4-bb80-037eeb47f5bb' class='xr-var-data-in' type='checkbox'><label for='data-cbc88c34-8476-42e4-bb80-037eeb47f5bb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Linear power in the chosen backscattering coefficient</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2562,7 +2664,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-50afe2c7-672f-4f10-8a66-a887d7de39a5' class='xr-section-summary-in' type='checkbox'  ><label for='section-50afe2c7-672f-4f10-8a66-a887d7de39a5' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S1GRD Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S1GRD&#x27;, &#x27;band_names&#x27;: [&#x27;VH&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 10.55296, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:23:54.435450</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.55296</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1B</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-3e673004-6b24-4659-bdce-ae2e994b447d' class='xr-section-summary-in' type='checkbox'  ><label for='section-3e673004-6b24-4659-bdce-ae2e994b447d' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S1GRD Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S1GRD&#x27;, &#x27;band_names&#x27;: [&#x27;VH&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 10.55296, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:17:05.796036</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.55296</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1B</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2579,7 +2681,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S1GRD Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:23:54.435450\n",
+       "    date_created:              2022-06-23T10:17:05.796036\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -2591,7 +2693,7 @@
        "    processing_level:          L1B"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2603,14 +2705,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "e95bb550",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:05.979573Z",
+     "iopub.status.busy": "2022-06-23T10:17:05.979300Z",
+     "iopub.status.idle": "2022-06-23T10:17:20.897885Z",
+     "shell.execute_reply": "2022-06-23T10:17:20.897337Z"
+    },
     "papermill": {
-     "duration": 14.599199,
-     "end_time": "2022-02-23T14:01:34.590036",
+     "duration": 14.968785,
+     "end_time": "2022-06-23T10:17:20.915177",
      "exception": false,
-     "start_time": "2022-02-23T14:01:19.990837",
+     "start_time": "2022-06-23T10:17:05.946392",
      "status": "completed"
     },
     "tags": []
@@ -2619,10 +2727,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7ff6ffa5cb50>"
+       "<matplotlib.image.AxesImage at 0x7f8df12405e0>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2645,14 +2753,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "c7eb5013",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:21.026745Z",
+     "iopub.status.busy": "2022-06-23T10:17:21.026469Z",
+     "iopub.status.idle": "2022-06-23T10:17:21.034849Z",
+     "shell.execute_reply": "2022-06-23T10:17:21.034372Z"
+    },
     "papermill": {
-     "duration": 0.093956,
-     "end_time": "2022-02-23T14:01:34.770635",
+     "duration": 0.064391,
+     "end_time": "2022-06-23T10:17:21.036597",
      "exception": false,
-     "start_time": "2022-02-23T14:01:34.676679",
+     "start_time": "2022-06-23T10:17:20.972206",
      "status": "completed"
     },
     "tags": []
@@ -2661,25 +2775,25 @@
     {
      "data": {
       "text/plain": [
-       "['LOTL2',\n",
-       " 'LETML1',\n",
-       " 'LTML2',\n",
-       " 'S5PL2',\n",
-       " 'DEM',\n",
-       " 'S2L1C',\n",
-       " 'LTML1',\n",
-       " 'MODIS',\n",
-       " 'S2L2A',\n",
+       "['S1GRD',\n",
+       " 'LOTL2',\n",
        " 'LETML2',\n",
-       " 'CUSTOM',\n",
-       " 'S1GRD',\n",
-       " 'LOTL1',\n",
-       " 'S3OLCI',\n",
        " 'LMSSL1',\n",
-       " 'S3SLSTR']"
+       " 'S3OLCI',\n",
+       " 'S2L2A',\n",
+       " 'LTML1',\n",
+       " 'DEM',\n",
+       " 'LETML1',\n",
+       " 'LOTL1',\n",
+       " 'S5PL2',\n",
+       " 'CUSTOM',\n",
+       " 'LTML2',\n",
+       " 'S2L1C',\n",
+       " 'S3SLSTR',\n",
+       " 'MODIS']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2693,10 +2807,10 @@
    "id": "21ac9f02",
    "metadata": {
     "papermill": {
-     "duration": 0.081827,
-     "end_time": "2022-02-23T14:01:34.936839",
+     "duration": 0.053423,
+     "end_time": "2022-06-23T10:17:21.145239",
      "exception": false,
-     "start_time": "2022-02-23T14:01:34.855012",
+     "start_time": "2022-06-23T10:17:21.091816",
      "status": "completed"
     },
     "tags": []
@@ -2707,14 +2821,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "c83b0ac3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:21.254011Z",
+     "iopub.status.busy": "2022-06-23T10:17:21.253731Z",
+     "iopub.status.idle": "2022-06-23T10:17:21.265405Z",
+     "shell.execute_reply": "2022-06-23T10:17:21.264865Z"
+    },
     "papermill": {
-     "duration": 0.099612,
-     "end_time": "2022-02-23T14:01:35.121455",
+     "duration": 0.069105,
+     "end_time": "2022-06-23T10:17:21.266944",
      "exception": false,
-     "start_time": "2022-02-23T14:01:35.021843",
+     "start_time": "2022-06-23T10:17:21.197839",
      "status": "completed"
     },
     "tags": []
@@ -2726,7 +2846,7 @@
        "['DEM']"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2737,14 +2857,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "1131e9f0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:21.382230Z",
+     "iopub.status.busy": "2022-06-23T10:17:21.381954Z",
+     "iopub.status.idle": "2022-06-23T10:17:21.385200Z",
+     "shell.execute_reply": "2022-06-23T10:17:21.384753Z"
+    },
     "papermill": {
-     "duration": 0.134404,
-     "end_time": "2022-02-23T14:01:35.348323",
+     "duration": 0.058553,
+     "end_time": "2022-06-23T10:17:21.386608",
      "exception": false,
-     "start_time": "2022-02-23T14:01:35.213919",
+     "start_time": "2022-06-23T10:17:21.328055",
      "status": "completed"
     },
     "tags": []
@@ -2761,14 +2887,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "7fc5ef4e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:21.510138Z",
+     "iopub.status.busy": "2022-06-23T10:17:21.509791Z",
+     "iopub.status.idle": "2022-06-23T10:17:21.513368Z",
+     "shell.execute_reply": "2022-06-23T10:17:21.512772Z"
+    },
     "papermill": {
-     "duration": 0.085126,
-     "end_time": "2022-02-23T14:01:35.509000",
+     "duration": 0.070579,
+     "end_time": "2022-06-23T10:17:21.514803",
      "exception": false,
-     "start_time": "2022-02-23T14:01:35.423874",
+     "start_time": "2022-06-23T10:17:21.444224",
      "status": "completed"
     },
     "tags": []
@@ -2780,14 +2912,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "5f8d299d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:21.624286Z",
+     "iopub.status.busy": "2022-06-23T10:17:21.624009Z",
+     "iopub.status.idle": "2022-06-23T10:17:21.628413Z",
+     "shell.execute_reply": "2022-06-23T10:17:21.627630Z"
+    },
     "papermill": {
-     "duration": 0.100532,
-     "end_time": "2022-02-23T14:01:35.693592",
+     "duration": 0.061796,
+     "end_time": "2022-06-23T10:17:21.629965",
      "exception": false,
-     "start_time": "2022-02-23T14:01:35.593060",
+     "start_time": "2022-06-23T10:17:21.568169",
      "status": "completed"
     },
     "tags": []
@@ -2806,14 +2944,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "1376aa19",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:21.745731Z",
+     "iopub.status.busy": "2022-06-23T10:17:21.745459Z",
+     "iopub.status.idle": "2022-06-23T10:17:21.845210Z",
+     "shell.execute_reply": "2022-06-23T10:17:21.844598Z"
+    },
     "papermill": {
-     "duration": 0.286377,
-     "end_time": "2022-02-23T14:01:36.075589",
+     "duration": 0.163288,
+     "end_time": "2022-06-23T10:17:21.847230",
      "exception": false,
-     "start_time": "2022-02-23T14:01:35.789212",
+     "start_time": "2022-06-23T10:17:21.683942",
      "status": "completed"
     },
     "tags": []
@@ -3187,7 +3331,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     DEM Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:24:09.822914\n",
+       "    date_created:              2022-06-23T10:17:21.821630\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-22T00:00:00+00:00\n",
        "    time_coverage_duration:    P100DT0H0M0S\n",
@@ -3195,7 +3339,7 @@
        "    geospatial_lon_min:        10.0\n",
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        10.512\n",
-       "    geospatial_lat_max:        54.400000000000006</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-4fbd1af5-5e05-49ce-9bf6-2fe9445a3956' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-4fbd1af5-5e05-49ce-9bf6-2fe9445a3956' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>lat</span>: 650</li><li><span class='xr-has-index'>lon</span>: 2560</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-62e25275-9b0b-4a82-8f43-f4162512751d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-62e25275-9b0b-4a82-8f43-f4162512751d' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.4 54.4 54.4 ... 54.27 54.27</div><input id='attrs-62ff5ee6-ac05-4f21-a5ca-1d7f15d3d75d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-62ff5ee6-ac05-4f21-a5ca-1d7f15d3d75d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13bb83e7-0b49-4d10-8b82-7ad12364d079' class='xr-var-data-in' type='checkbox'><label for='data-13bb83e7-0b49-4d10-8b82-7ad12364d079' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.3999, 54.3997, 54.3995, ..., 54.2705, 54.2703, 54.2701])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.51 10.51</div><input id='attrs-51714985-52ef-49f4-b43a-485dbb292086' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-51714985-52ef-49f4-b43a-485dbb292086' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d72841cd-a917-4795-a8f4-48adfa60dfeb' class='xr-var-data-in' type='checkbox'><label for='data-d72841cd-a917-4795-a8f4-48adfa60dfeb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.0001, 10.0003, 10.0005, ..., 10.5115, 10.5117, 10.5119])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-07-03</div><input id='attrs-15a2497a-4afb-487e-ac82-2a39a5f479c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-15a2497a-4afb-487e-ac82-2a39a5f479c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ffe6bc2b-9eae-41e8-9554-f0b1882cbd2b' class='xr-var-data-in' type='checkbox'><label for='data-ffe6bc2b-9eae-41e8-9554-f0b1882cbd2b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-07-03T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2), meta=np.ndarray&gt;</div><input id='attrs-0aaf0650-dc15-4799-b5a3-b9c898bff701' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0aaf0650-dc15-4799-b5a3-b9c898bff701' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-977bb208-32cb-49af-9441-0613e19161e9' class='xr-var-data-in' type='checkbox'><label for='data-977bb208-32cb-49af-9441-0613e19161e9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    geospatial_lat_max:        54.400000000000006</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-13ff0a31-eb39-4162-93f5-21da40177ab7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-13ff0a31-eb39-4162-93f5-21da40177ab7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>lat</span>: 650</li><li><span class='xr-has-index'>lon</span>: 2560</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-fa1cffb8-1bb4-4c8d-a8f9-72ba0ebf8425' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fa1cffb8-1bb4-4c8d-a8f9-72ba0ebf8425' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.4 54.4 54.4 ... 54.27 54.27</div><input id='attrs-4bb29e90-1512-4205-86ff-267700d6e2d3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4bb29e90-1512-4205-86ff-267700d6e2d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a80b3489-519d-4614-bf7e-642ada14afb9' class='xr-var-data-in' type='checkbox'><label for='data-a80b3489-519d-4614-bf7e-642ada14afb9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.3999, 54.3997, 54.3995, ..., 54.2705, 54.2703, 54.2701])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.51 10.51</div><input id='attrs-e4b3406c-640f-4cf2-820f-a7ee451a4ce9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e4b3406c-640f-4cf2-820f-a7ee451a4ce9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-35d64272-f514-4344-b7f8-7ad63a8de16b' class='xr-var-data-in' type='checkbox'><label for='data-35d64272-f514-4344-b7f8-7ad63a8de16b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.0001, 10.0003, 10.0005, ..., 10.5115, 10.5117, 10.5119])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-07-03</div><input id='attrs-f941cb5f-7dae-44eb-b030-b2bf5e2ffb76' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f941cb5f-7dae-44eb-b030-b2bf5e2ffb76' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d97f9473-e5fb-4466-b40e-75b23049da4d' class='xr-var-data-in' type='checkbox'><label for='data-d97f9473-e5fb-4466-b40e-75b23049da4d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-07-03T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2), meta=np.ndarray&gt;</div><input id='attrs-e60912bf-c639-4acf-863c-8f6aac5f7254' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e60912bf-c639-4acf-863c-8f6aac5f7254' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2fc58470-cc63-4041-a1bc-d613bb19ae5e' class='xr-var-data-in' type='checkbox'><label for='data-2fc58470-cc63-4041-a1bc-d613bb19ae5e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3252,7 +3396,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9c38953a-d81e-402c-aafa-82f8b9abf996' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9c38953a-d81e-402c-aafa-82f8b9abf996' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>DEM</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 650, 512), meta=np.ndarray&gt;</div><input id='attrs-bb9ac1d7-079d-4eea-af44-393183cf2db7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bb9ac1d7-079d-4eea-af44-393183cf2db7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-905d1bb8-2b3f-466f-a370-fcb3c6474ea9' class='xr-var-data-in' type='checkbox'><label for='data-905d1bb8-2b3f-466f-a370-fcb3c6474ea9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Meters</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8d861e68-72e4-4436-8886-5cf2ac1474d0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8d861e68-72e4-4436-8886-5cf2ac1474d0' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>DEM</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 650, 512), meta=np.ndarray&gt;</div><input id='attrs-392518be-0903-4ee8-9634-e019c7029c32' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-392518be-0903-4ee8-9634-e019c7029c32' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a5494f65-b76b-4da0-bb22-c4e6e265e7a1' class='xr-var-data-in' type='checkbox'><label for='data-a5494f65-b76b-4da0-bb22-c4e6e265e7a1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Meters</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3340,7 +3484,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-66254276-c5af-48bb-b2bd-033072a40797' class='xr-section-summary-in' type='checkbox'  ><label for='section-66254276-c5af-48bb-b2bd-033072a40797' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>DEM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;DEM&#x27;, &#x27;band_names&#x27;: [&#x27;DEM&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 650], &#x27;bbox&#x27;: [10.0, 54.27, 10.512, 54.400000000000006], &#x27;spatial_res&#x27;: 0.0002, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;100 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:24:09.822914</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-22T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P100DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P100DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.512</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.400000000000006</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-3e7fbeb0-a00f-4237-abc8-5c60f00d3bf1' class='xr-section-summary-in' type='checkbox'  ><label for='section-3e7fbeb0-a00f-4237-abc8-5c60f00d3bf1' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>DEM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;DEM&#x27;, &#x27;band_names&#x27;: [&#x27;DEM&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 650], &#x27;bbox&#x27;: [10.0, 54.27, 10.512, 54.400000000000006], &#x27;spatial_res&#x27;: 0.0002, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;100 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:17:21.821630</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-22T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P100DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P100DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.512</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.400000000000006</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -3357,7 +3501,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     DEM Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:24:09.822914\n",
+       "    date_created:              2022-06-23T10:17:21.821630\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-22T00:00:00+00:00\n",
        "    time_coverage_duration:    P100DT0H0M0S\n",
@@ -3368,7 +3512,7 @@
        "    geospatial_lat_max:        54.400000000000006"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3380,14 +3524,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "ad6e059a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:21.957397Z",
+     "iopub.status.busy": "2022-06-23T10:17:21.956882Z",
+     "iopub.status.idle": "2022-06-23T10:17:24.513502Z",
+     "shell.execute_reply": "2022-06-23T10:17:24.512932Z"
+    },
     "papermill": {
-     "duration": 3.052612,
-     "end_time": "2022-02-23T14:01:39.219746",
+     "duration": 2.618093,
+     "end_time": "2022-06-23T10:17:24.518862",
      "exception": false,
-     "start_time": "2022-02-23T14:01:36.167134",
+     "start_time": "2022-06-23T10:17:21.900769",
      "status": "completed"
     },
     "tags": []
@@ -3396,10 +3546,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7ff6ff925160>"
+       "<matplotlib.image.AxesImage at 0x7f8df1187a60>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -3425,10 +3575,10 @@
    "id": "132e7855",
    "metadata": {
     "papermill": {
-     "duration": 0.080997,
-     "end_time": "2022-02-23T14:01:39.383663",
+     "duration": 0.061571,
+     "end_time": "2022-06-23T10:17:24.641574",
      "exception": false,
-     "start_time": "2022-02-23T14:01:39.302666",
+     "start_time": "2022-06-23T10:17:24.580003",
      "status": "completed"
     },
     "tags": []
@@ -3442,10 +3592,10 @@
    "id": "d7b797d7",
    "metadata": {
     "papermill": {
-     "duration": 0.081584,
-     "end_time": "2022-02-23T14:01:39.547818",
+     "duration": 0.061989,
+     "end_time": "2022-06-23T10:17:24.765045",
      "exception": false,
-     "start_time": "2022-02-23T14:01:39.466234",
+     "start_time": "2022-06-23T10:17:24.703056",
      "status": "completed"
     },
     "tags": []
@@ -3456,14 +3606,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "1c7ed20c",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:24.891676Z",
+     "iopub.status.busy": "2022-06-23T10:17:24.890357Z",
+     "iopub.status.idle": "2022-06-23T10:17:24.894579Z",
+     "shell.execute_reply": "2022-06-23T10:17:24.894098Z"
+    },
     "papermill": {
-     "duration": 0.090099,
-     "end_time": "2022-02-23T14:01:39.720917",
+     "duration": 0.069505,
+     "end_time": "2022-06-23T10:17:24.895967",
      "exception": false,
-     "start_time": "2022-02-23T14:01:39.630818",
+     "start_time": "2022-06-23T10:17:24.826462",
      "status": "completed"
     },
     "tags": []
@@ -3480,14 +3636,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "f2c4f7e9",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:25.023217Z",
+     "iopub.status.busy": "2022-06-23T10:17:25.022942Z",
+     "iopub.status.idle": "2022-06-23T10:17:25.026320Z",
+     "shell.execute_reply": "2022-06-23T10:17:25.025811Z"
+    },
     "papermill": {
-     "duration": 0.088879,
-     "end_time": "2022-02-23T14:01:39.894361",
+     "duration": 0.070573,
+     "end_time": "2022-06-23T10:17:25.027736",
      "exception": false,
-     "start_time": "2022-02-23T14:01:39.805482",
+     "start_time": "2022-06-23T10:17:24.957163",
      "status": "completed"
     },
     "tags": []
@@ -3504,10 +3666,10 @@
    "id": "21e16924",
    "metadata": {
     "papermill": {
-     "duration": 0.180795,
-     "end_time": "2022-02-23T14:01:40.160662",
+     "duration": 0.063639,
+     "end_time": "2022-06-23T10:17:25.155467",
      "exception": false,
-     "start_time": "2022-02-23T14:01:39.979867",
+     "start_time": "2022-06-23T10:17:25.091828",
      "status": "completed"
     },
     "tags": []
@@ -3518,14 +3680,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "c99e1a81",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:25.280448Z",
+     "iopub.status.busy": "2022-06-23T10:17:25.280021Z",
+     "iopub.status.idle": "2022-06-23T10:17:25.284538Z",
+     "shell.execute_reply": "2022-06-23T10:17:25.283752Z"
+    },
     "papermill": {
-     "duration": 0.191851,
-     "end_time": "2022-02-23T14:01:40.432924",
+     "duration": 0.068708,
+     "end_time": "2022-06-23T10:17:25.286003",
      "exception": false,
-     "start_time": "2022-02-23T14:01:40.241073",
+     "start_time": "2022-06-23T10:17:25.217295",
      "status": "completed"
     },
     "tags": []
@@ -3546,14 +3714,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "id": "195ed394",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:25.411769Z",
+     "iopub.status.busy": "2022-06-23T10:17:25.411330Z",
+     "iopub.status.idle": "2022-06-23T10:17:25.525662Z",
+     "shell.execute_reply": "2022-06-23T10:17:25.525146Z"
+    },
     "papermill": {
-     "duration": 0.236427,
-     "end_time": "2022-02-23T14:01:40.773882",
+     "duration": 0.180773,
+     "end_time": "2022-06-23T10:17:25.527955",
      "exception": false,
-     "start_time": "2022-02-23T14:01:40.537455",
+     "start_time": "2022-06-23T10:17:25.347182",
      "status": "completed"
     },
     "tags": []
@@ -3930,11 +4104,11 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     CUSTOM Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:24:15.141282\n",
+       "    date_created:              2022-06-23T10:17:25.487713\n",
        "    time_coverage_start:       2018-01-01T00:00:00+00:00\n",
        "    time_coverage_end:         2019-01-07T00:00:00+00:00\n",
        "    time_coverage_duration:    P371DT0H0M0S\n",
-       "    time_coverage_resolution:  P7DT0H0M0S</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-62f64f68-c6f4-4cae-9a54-2a3f502a84c6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-62f64f68-c6f4-4cae-9a54-2a3f502a84c6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 53</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-1dcc0557-9636-49f5-9baf-3c612041afd6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1dcc0557-9636-49f5-9baf-3c612041afd6' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-01-04T12:00:00 ... 2019-01-...</div><input id='attrs-b26ceea8-0214-466d-9b70-6363d56321a6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b26ceea8-0214-466d-9b70-6363d56321a6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c12898fe-7962-490c-b0fa-3d1cb9fa9d43' class='xr-var-data-in' type='checkbox'><label for='data-c12898fe-7962-490c-b0fa-3d1cb9fa9d43' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-01-04T12:00:00.000000000&#x27;, &#x27;2018-01-11T12:00:00.000000000&#x27;,\n",
+       "    time_coverage_resolution:  P7DT0H0M0S</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-cb49a7b2-6c17-4b3e-b68d-136622fbd7dc' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-cb49a7b2-6c17-4b3e-b68d-136622fbd7dc' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 53</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-9b9b90c7-82ee-4e6c-b5fa-8b21770a2071' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9b9b90c7-82ee-4e6c-b5fa-8b21770a2071' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-01-04T12:00:00 ... 2019-01-...</div><input id='attrs-e7429975-730e-4063-9f6f-71b9f144396f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e7429975-730e-4063-9f6f-71b9f144396f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5585ee62-76d4-4b00-bfd4-86a4c70ad569' class='xr-var-data-in' type='checkbox'><label for='data-5585ee62-76d4-4b00-bfd4-86a4c70ad569' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-01-04T12:00:00.000000000&#x27;, &#x27;2018-01-11T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-01-18T12:00:00.000000000&#x27;, &#x27;2018-01-25T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-02-01T12:00:00.000000000&#x27;, &#x27;2018-02-08T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-02-15T12:00:00.000000000&#x27;, &#x27;2018-02-22T12:00:00.000000000&#x27;,\n",
@@ -3960,7 +4134,7 @@
        "       &#x27;2018-11-22T12:00:00.000000000&#x27;, &#x27;2018-11-29T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-12-06T12:00:00.000000000&#x27;, &#x27;2018-12-13T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-12-20T12:00:00.000000000&#x27;, &#x27;2018-12-27T12:00:00.000000000&#x27;,\n",
-       "       &#x27;2019-01-03T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(53, 2), meta=np.ndarray&gt;</div><input id='attrs-aab7c411-5011-4151-be0b-db110b74d269' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aab7c411-5011-4151-be0b-db110b74d269' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bd300467-671c-43fe-9bde-bfcb6766797f' class='xr-var-data-in' type='checkbox'><label for='data-bd300467-671c-43fe-9bde-bfcb6766797f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2019-01-03T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(53, 2), meta=np.ndarray&gt;</div><input id='attrs-c5420a20-9136-4c95-b6a7-e724f7993689' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c5420a20-9136-4c95-b6a7-e724f7993689' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1512dfe3-95c2-4f8c-b9e1-e1da5815df2d' class='xr-var-data-in' type='checkbox'><label for='data-1512dfe3-95c2-4f8c-b9e1-e1da5815df2d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4017,9 +4191,9 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-ef0567e2-5e51-449b-90a4-61800e5ea3ed' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ef0567e2-5e51-449b-90a4-61800e5ea3ed' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-011da1a6-3da0-4d3e-bf48-91069d05d3ad' class='xr-var-data-in' type='checkbox'><label for='data-011da1a6-3da0-4d3e-bf48-91069d05d3ad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
-       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-86e8d215-8c47-4f06-b01f-abea217db853' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-86e8d215-8c47-4f06-b01f-abea217db853' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9470c7b5-1f63-474f-b7fa-e0d1bad36ba1' class='xr-var-data-in' type='checkbox'><label for='data-9470c7b5-1f63-474f-b7fa-e0d1bad36ba1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
-       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f67b6e9e-255e-49ad-8770-0a18f5d46497' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f67b6e9e-255e-49ad-8770-0a18f5d46497' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>BLUE</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-e81d1051-93d0-430b-8582-29ee0f03f5cf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e81d1051-93d0-430b-8582-29ee0f03f5cf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8b699f6-3b03-4900-9ec5-cb3aad6b1c98' class='xr-var-data-in' type='checkbox'><label for='data-f8b699f6-3b03-4900-9ec5-cb3aad6b1c98' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-905be1c2-6173-4057-831b-bd1288a8409b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-905be1c2-6173-4057-831b-bd1288a8409b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6e30b52-ea07-4a60-85e0-aa4a85ac33ca' class='xr-var-data-in' type='checkbox'><label for='data-e6e30b52-ea07-4a60-85e0-aa4a85ac33ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
+       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-7992834f-ff2f-4488-8107-87ea4495d800' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7992834f-ff2f-4488-8107-87ea4495d800' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9e81fe2f-93a8-4ce8-8c32-2f5f7ba4a454' class='xr-var-data-in' type='checkbox'><label for='data-9e81fe2f-93a8-4ce8-8c32-2f5f7ba4a454' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
+       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-eb90b59e-f580-4029-869d-9eebaa6a4054' class='xr-section-summary-in' type='checkbox'  checked><label for='section-eb90b59e-f580-4029-869d-9eebaa6a4054' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>BLUE</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-eb0e8c2b-c6a3-41fb-b1c8-3410b2b69c25' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-eb0e8c2b-c6a3-41fb-b1c8-3410b2b69c25' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-427c8c33-9618-458e-ac80-09c429dfc585' class='xr-var-data-in' type='checkbox'><label for='data-427c8c33-9618-458e-ac80-09c429dfc585' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4135,7 +4309,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>GREEN</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-cd56991f-1fa1-4b80-ae91-fdc040b8b241' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cd56991f-1fa1-4b80-ae91-fdc040b8b241' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4197b316-03a9-4e6c-a5ff-ec59b1b92bda' class='xr-var-data-in' type='checkbox'><label for='data-4197b316-03a9-4e6c-a5ff-ec59b1b92bda' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>GREEN</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-4bce8449-061c-41b5-93d5-5a2b5501bb82' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4bce8449-061c-41b5-93d5-5a2b5501bb82' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1f70992a-e25f-4349-84a2-7464cf934f15' class='xr-var-data-in' type='checkbox'><label for='data-1f70992a-e25f-4349-84a2-7464cf934f15' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4251,7 +4425,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>RED</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-14d7b550-8587-4b89-be56-35db0fe1e240' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-14d7b550-8587-4b89-be56-35db0fe1e240' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a4e480da-c224-4b72-823e-0add9e70a7d2' class='xr-var-data-in' type='checkbox'><label for='data-a4e480da-c224-4b72-823e-0add9e70a7d2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>RED</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-87b98252-f68c-453a-925b-3e9c8b9333d7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-87b98252-f68c-453a-925b-3e9c8b9333d7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ca231a77-28e6-46e1-8cba-07b29c509314' class='xr-var-data-in' type='checkbox'><label for='data-ca231a77-28e6-46e1-8cba-07b29c509314' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4367,7 +4541,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-94ddb4aa-0cb4-4fce-95db-5691c8732e9c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-94ddb4aa-0cb4-4fce-95db-5691c8732e9c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-155e5f0b-ace6-4f81-952e-7ecd36ac76c8' class='xr-var-data-in' type='checkbox'><label for='data-155e5f0b-ace6-4f81-952e-7ecd36ac76c8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d6d2a2f4-fc19-4168-aff4-05484f0032f5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d6d2a2f4-fc19-4168-aff4-05484f0032f5' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>CUSTOM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;CUSTOM&#x27;, &#x27;band_names&#x27;: [&#x27;RED&#x27;, &#x27;GREEN&#x27;, &#x27;BLUE&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: &#x27;UINT8&#x27;, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-01-01T00:00:00+00:00&#x27;, &#x27;2019-01-01T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;7 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: &#x27;1a3ab057-3c51-447c-9f85-27d4b633b3f5&#x27;, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:24:15.141282</dd><dt><span>time_coverage_start :</span></dt><dd>2018-01-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-01-07T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P371DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P7DT0H0M0S</dd></dl></div></li></ul></div></div>"
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d7155dda-a12c-417c-9f24-58aaec571952' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d7155dda-a12c-417c-9f24-58aaec571952' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7dde18a3-9cb6-4c4a-92be-b5656555ce21' class='xr-var-data-in' type='checkbox'><label for='data-7dde18a3-9cb6-4c4a-92be-b5656555ce21' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-18f09a1e-48d0-40bc-a195-8e004afe15d7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-18f09a1e-48d0-40bc-a195-8e004afe15d7' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>CUSTOM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;CUSTOM&#x27;, &#x27;band_names&#x27;: [&#x27;RED&#x27;, &#x27;GREEN&#x27;, &#x27;BLUE&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: &#x27;UINT8&#x27;, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-01-01T00:00:00+00:00&#x27;, &#x27;2019-01-01T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;7 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: &#x27;1a3ab057-3c51-447c-9f85-27d4b633b3f5&#x27;, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:17:25.487713</dd><dt><span>time_coverage_start :</span></dt><dd>2018-01-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-01-07T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P371DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P7DT0H0M0S</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -4387,14 +4561,14 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     CUSTOM Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:24:15.141282\n",
+       "    date_created:              2022-06-23T10:17:25.487713\n",
        "    time_coverage_start:       2018-01-01T00:00:00+00:00\n",
        "    time_coverage_end:         2019-01-07T00:00:00+00:00\n",
        "    time_coverage_duration:    P371DT0H0M0S\n",
        "    time_coverage_resolution:  P7DT0H0M0S"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4406,14 +4580,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "id": "713ecf6b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:25.658738Z",
+     "iopub.status.busy": "2022-06-23T10:17:25.658428Z",
+     "iopub.status.idle": "2022-06-23T10:17:25.664120Z",
+     "shell.execute_reply": "2022-06-23T10:17:25.663530Z"
+    },
     "papermill": {
-     "duration": 0.094485,
-     "end_time": "2022-02-23T14:01:40.954846",
+     "duration": 0.071582,
+     "end_time": "2022-06-23T10:17:25.665477",
      "exception": false,
-     "start_time": "2022-02-23T14:01:40.860361",
+     "start_time": "2022-06-23T10:17:25.593895",
      "status": "completed"
     },
     "tags": []
@@ -4425,14 +4605,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "id": "e68435db",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:25.796991Z",
+     "iopub.status.busy": "2022-06-23T10:17:25.796707Z",
+     "iopub.status.idle": "2022-06-23T10:17:28.162072Z",
+     "shell.execute_reply": "2022-06-23T10:17:28.161551Z"
+    },
     "papermill": {
-     "duration": 2.771522,
-     "end_time": "2022-02-23T14:01:43.815814",
+     "duration": 2.439627,
+     "end_time": "2022-06-23T10:17:28.171345",
      "exception": false,
-     "start_time": "2022-02-23T14:01:41.044292",
+     "start_time": "2022-06-23T10:17:25.731718",
      "status": "completed"
     },
     "tags": []
@@ -4441,10 +4627,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7ff6ff814970>"
+       "<matplotlib.image.AxesImage at 0x7f8df107ea60>"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -4473,14 +4659,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "id": "e58aa631",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:28.328566Z",
+     "iopub.status.busy": "2022-06-23T10:17:28.328248Z",
+     "iopub.status.idle": "2022-06-23T10:17:28.340913Z",
+     "shell.execute_reply": "2022-06-23T10:17:28.340326Z"
+    },
     "papermill": {
-     "duration": 0.119679,
-     "end_time": "2022-02-23T14:01:44.034816",
+     "duration": 0.093355,
+     "end_time": "2022-06-23T10:17:28.342321",
      "exception": false,
-     "start_time": "2022-02-23T14:01:43.915137",
+     "start_time": "2022-06-23T10:17:28.248966",
      "status": "completed"
     },
     "tags": []
@@ -4885,7 +5077,7 @@
        "Coordinates:\n",
        "  * x        (x) float64 1.546e+06 1.546e+06 1.546e+06 ... 1.705e+06 1.705e+06\n",
        "  * y        (y) float64 5.857e+06 5.857e+06 5.856e+06 ... 5.762e+06 5.762e+06\n",
-       "Dimensions without coordinates: b</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>b</span>: 3</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-46d95fe9-8f55-4f01-a1c8-0e6bbc61b7d2' class='xr-array-in' type='checkbox' checked><label for='section-46d95fe9-8f55-4f01-a1c8-0e6bbc61b7d2' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>61 99 8 52 118 118 223 158 15 200 ... 3 242 164 3 227 195 17 254 166 1</span></div><div class='xr-array-data'><pre>array([[[ 61,  99,   8],\n",
+       "Dimensions without coordinates: b</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>b</span>: 3</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-090931b6-a010-439d-8f50-6400b4a900e0' class='xr-array-in' type='checkbox' checked><label for='section-090931b6-a010-439d-8f50-6400b4a900e0' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>61 99 8 52 118 118 223 158 15 200 ... 3 242 164 3 227 195 17 254 166 1</span></div><div class='xr-array-data'><pre>array([[[ 61,  99,   8],\n",
        "        [ 52, 118, 118],\n",
        "        [223, 158,  15],\n",
        "        ...,\n",
@@ -4925,9 +5117,9 @@
        "        ...,\n",
        "        [242, 164,   3],\n",
        "        [227, 195,  17],\n",
-       "        [254, 166,   1]]], dtype=uint8)</pre></div></div></li><li class='xr-section-item'><input id='section-13ca3453-88d1-4bc8-9292-a042b56bee36' class='xr-section-summary-in' type='checkbox'  checked><label for='section-13ca3453-88d1-4bc8-9292-a042b56bee36' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-7dfc21b8-4b88-4820-bc6a-f61e196bc6c3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7dfc21b8-4b88-4820-bc6a-f61e196bc6c3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-72fc3942-1e7f-43d8-8553-5de623dfe804' class='xr-var-data-in' type='checkbox'><label for='data-72fc3942-1e7f-43d8-8553-5de623dfe804' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
-       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-e196cf7d-ac7d-4be1-8f2f-d556414d000f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e196cf7d-ac7d-4be1-8f2f-d556414d000f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3c3ac47e-9a0c-44a3-b000-e50ac55e341c' class='xr-var-data-in' type='checkbox'><label for='data-3c3ac47e-9a0c-44a3-b000-e50ac55e341c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
-       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-977d3f79-a2a3-45bc-899a-70a84803ce1e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-977d3f79-a2a3-45bc-899a-70a84803ce1e' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "        [254, 166,   1]]], dtype=uint8)</pre></div></div></li><li class='xr-section-item'><input id='section-fa485bb2-602d-4d99-a311-e4376a74961a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fa485bb2-602d-4d99-a311-e4376a74961a' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-edd8d9dd-6927-4b6d-85db-7e4450208652' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-edd8d9dd-6927-4b6d-85db-7e4450208652' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0d4940e3-61b3-47e9-96ee-bb84882cecff' class='xr-var-data-in' type='checkbox'><label for='data-0d4940e3-61b3-47e9-96ee-bb84882cecff' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
+       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-db43da37-f93a-4236-a9a0-21028e3c6f20' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-db43da37-f93a-4236-a9a0-21028e3c6f20' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-835eb659-c4eb-4a61-ab0b-f55ecfa535de' class='xr-var-data-in' type='checkbox'><label for='data-835eb659-c4eb-4a61-ab0b-f55ecfa535de' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
+       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8b454b9e-b5f3-475a-a8e2-eae882ca220e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-8b454b9e-b5f3-475a-a8e2-eae882ca220e' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray (y: 305, x: 512, b: 3)>\n",
@@ -4978,7 +5170,7 @@
        "Dimensions without coordinates: b"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4991,7 +5183,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c7973ee3-42c1-4314-8bde-104b4a3ea311",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.080717,
+     "end_time": "2022-06-23T10:17:28.502876",
+     "exception": false,
+     "start_time": "2022-06-23T10:17:28.422159",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
@@ -5015,14 +5216,14 @@
    "version": "3.8.12"
   },
   "papermill": {
-   "duration": 47.25754,
-   "end_time": "2022-02-23T14:01:44.675867",
+   "duration": 91.130194,
+   "end_time": "2022-06-23T10:17:29.197869",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/tmp/tmpen94v4to",
-   "output_path": "/tmp/cur_notebook.ipynb",
+   "input_path": "/tmp/tmp6qvjihld",
+   "output_path": "/tmp/notebook_output.ipynb",
    "parameters": {},
-   "start_time": "2022-02-23T14:00:57.418327",
+   "start_time": "2022-06-23T10:15:58.067675",
    "version": "2.1.0"
   },
   "properties": {

--- a/notebooks/curated/EDC_Sentinel_Hub-Datasets.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-Datasets.ipynb
@@ -150,15 +150,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "6100aab6",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:00:58.950818Z",
-     "iopub.status.busy": "2022-02-23T14:00:58.949916Z",
-     "iopub.status.idle": "2022-02-23T14:01:00.405890Z",
-     "shell.execute_reply": "2022-02-23T14:01:00.405199Z"
-    },
     "papermill": {
      "duration": 1.498832,
      "end_time": "2022-02-23T14:01:00.408003",
@@ -179,15 +173,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "a49637c3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:00.488489Z",
-     "iopub.status.busy": "2022-02-23T14:01:00.487551Z",
-     "iopub.status.idle": "2022-02-23T14:01:00.492889Z",
-     "shell.execute_reply": "2022-02-23T14:01:00.491958Z"
-    },
     "papermill": {
      "duration": 0.047317,
      "end_time": "2022-02-23T14:01:00.494935",
@@ -209,15 +197,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "1f290784",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:00.596651Z",
-     "iopub.status.busy": "2022-02-23T14:01:00.595869Z",
-     "iopub.status.idle": "2022-02-23T14:01:00.600574Z",
-     "shell.execute_reply": "2022-02-23T14:01:00.599390Z"
-    },
     "papermill": {
      "duration": 0.068061,
      "end_time": "2022-02-23T14:01:00.602501",
@@ -234,15 +216,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "1cfcc49d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:00.683199Z",
-     "iopub.status.busy": "2022-02-23T14:01:00.682739Z",
-     "iopub.status.idle": "2022-02-23T14:01:00.816919Z",
-     "shell.execute_reply": "2022-02-23T14:01:00.815838Z"
-    },
     "papermill": {
      "duration": 0.176808,
      "end_time": "2022-02-23T14:01:00.819119",
@@ -256,25 +232,25 @@
     {
      "data": {
       "text/plain": [
-       "['S3SLSTR',\n",
-       " 'LTML1',\n",
-       " 'S3OLCI',\n",
-       " 'LOTL2',\n",
-       " 'MODIS',\n",
-       " 'S2L1C',\n",
-       " 'S1GRD',\n",
+       "['LOTL2',\n",
+       " 'LETML1',\n",
+       " 'LTML2',\n",
        " 'S5PL2',\n",
-       " 'LOTL1',\n",
+       " 'DEM',\n",
+       " 'S2L1C',\n",
+       " 'LTML1',\n",
+       " 'MODIS',\n",
+       " 'S2L2A',\n",
        " 'LETML2',\n",
        " 'CUSTOM',\n",
-       " 'S2L2A',\n",
-       " 'LTML2',\n",
+       " 'S1GRD',\n",
+       " 'LOTL1',\n",
+       " 'S3OLCI',\n",
        " 'LMSSL1',\n",
-       " 'LETML1',\n",
-       " 'DEM']"
+       " 'S3SLSTR']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,15 +279,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "f15b14c4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:00.983599Z",
-     "iopub.status.busy": "2022-02-23T14:01:00.983186Z",
-     "iopub.status.idle": "2022-02-23T14:01:00.999307Z",
-     "shell.execute_reply": "2022-02-23T14:01:00.998521Z"
-    },
     "papermill": {
      "duration": 0.059812,
      "end_time": "2022-02-23T14:01:01.001569",
@@ -349,7 +319,7 @@
        " 'CLP']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -360,15 +330,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "12dde912",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:01.089917Z",
-     "iopub.status.busy": "2022-02-23T14:01:01.089197Z",
-     "iopub.status.idle": "2022-02-23T14:01:01.096308Z",
-     "shell.execute_reply": "2022-02-23T14:01:01.095279Z"
-    },
     "papermill": {
      "duration": 0.052244,
      "end_time": "2022-02-23T14:01:01.098250",
@@ -383,8 +347,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n",
       "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/pandas/core/tools/timedeltas.py:148: FutureWarning: Units 'M', 'Y' and 'y' do not represent unambiguous timedelta values and will be removed in a future version.\n",
       "  return _coerce_scalar_to_timedelta_type(arg, unit=unit, errors=errors)\n"
      ]
@@ -394,7 +356,7 @@
     "cube_config = CubeConfig(dataset_name='S2L2A',\n",
     "                         band_names=['SCL'],\n",
     "                         tile_size=[512, 512],\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         spatial_res=spatial_res,\n",
     "                         time_range=['2018-05-14', '2018-07-31'],\n",
     "                         time_tolerance='30M')  "
@@ -402,15 +364,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "f60da31f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:01.183604Z",
-     "iopub.status.busy": "2022-02-23T14:01:01.183060Z",
-     "iopub.status.idle": "2022-02-23T14:01:02.050490Z",
-     "shell.execute_reply": "2022-02-23T14:01:02.049008Z"
-    },
     "papermill": {
      "duration": 0.91268,
      "end_time": "2022-02-23T14:01:02.052980",
@@ -789,7 +745,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-02-23T14:01:01.771915\n",
+       "    date_created:            2022-06-23T08:23:34.209728\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -797,7 +753,7 @@
        "    geospatial_lat_min:      54.27\n",
        "    geospatial_lon_max:      11.01376\n",
        "    geospatial_lat_max:      54.63864\n",
-       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-831f2536-1640-4c7c-9af4-f48846358aa2' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-831f2536-1640-4c7c-9af4-f48846358aa2' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-723d1334-34cb-4b92-b0c5-5798aed3dd6f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-723d1334-34cb-4b92-b0c5-5798aed3dd6f' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-e67d64cb-a767-4202-bc9c-950279788735' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e67d64cb-a767-4202-bc9c-950279788735' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ee6ee1c6-e2b6-435e-a6be-bb38dfad2d25' class='xr-var-data-in' type='checkbox'><label for='data-ee6ee1c6-e2b6-435e-a6be-bb38dfad2d25' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-aa11030b-a7b3-4054-8f6d-6bb575becb82' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aa11030b-a7b3-4054-8f6d-6bb575becb82' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d33bc393-f83b-4d20-aedf-846659724014' class='xr-var-data-in' type='checkbox'><label for='data-d33bc393-f83b-4d20-aedf-846659724014' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-9147e082-c748-4c05-8f27-6c447cf23258' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9147e082-c748-4c05-8f27-6c447cf23258' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5e75c80d-e313-4832-b881-16d1ed9df06e' class='xr-var-data-in' type='checkbox'><label for='data-5e75c80d-e313-4832-b881-16d1ed9df06e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
+       "    processing_level:        L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-6a842176-465b-42ca-88f1-02492beefaa6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-6a842176-465b-42ca-88f1-02492beefaa6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-1197f9be-1d2f-4c78-b854-4c7e569c316c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1197f9be-1d2f-4c78-b854-4c7e569c316c' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-dccf7e1e-e2db-4af6-a10b-a88c98b5a0c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dccf7e1e-e2db-4af6-a10b-a88c98b5a0c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6d8f2349-3c30-472a-896e-536d13ba0d95' class='xr-var-data-in' type='checkbox'><label for='data-6d8f2349-3c30-472a-896e-536d13ba0d95' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-756af571-4d32-4cea-91ce-fcf2ffceba3c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-756af571-4d32-4cea-91ce-fcf2ffceba3c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4668ab00-b55b-4074-9d88-af6b82cf5657' class='xr-var-data-in' type='checkbox'><label for='data-4668ab00-b55b-4074-9d88-af6b82cf5657' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-96f82163-ee65-4907-8392-56029611027b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-96f82163-ee65-4907-8392-56029611027b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cdf8f768-4fc5-4d31-9ae0-0b302ac4877b' class='xr-var-data-in' type='checkbox'><label for='data-cdf8f768-4fc5-4d31-9ae0-0b302ac4877b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
        "       &#x27;2018-05-18T10:40:24.000000000&#x27;, &#x27;2018-05-20T10:34:58.000000000&#x27;,\n",
        "       &#x27;2018-05-22T10:20:25.000000000&#x27;, &#x27;2018-05-23T10:41:24.000000000&#x27;,\n",
        "       &#x27;2018-05-25T10:30:24.000000000&#x27;, &#x27;2018-05-28T10:40:23.000000000&#x27;,\n",
@@ -819,7 +775,7 @@
        "       &#x27;2018-07-19T10:30:20.000000000&#x27;, &#x27;2018-07-21T10:20:24.000000000&#x27;,\n",
        "       &#x27;2018-07-22T10:40:20.000000000&#x27;, &#x27;2018-07-24T10:30:23.000000000&#x27;,\n",
        "       &#x27;2018-07-26T10:21:50.000000000&#x27;, &#x27;2018-07-27T10:40:23.000000000&#x27;,\n",
-       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-4389ad54-7073-42a6-b750-3604fbbcf92a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4389ad54-7073-42a6-b750-3604fbbcf92a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-71f802e1-28f5-437b-800e-ae45359d63cc' class='xr-var-data-in' type='checkbox'><label for='data-71f802e1-28f5-437b-800e-ae45359d63cc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-1036c49e-5d00-4ef7-a446-f5ac9b91a65c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1036c49e-5d00-4ef7-a446-f5ac9b91a65c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5521331b-9275-4577-afe1-658083902cd5' class='xr-var-data-in' type='checkbox'><label for='data-5521331b-9275-4577-afe1-658083902cd5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -876,7 +832,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-058d023b-fd20-48e8-8f3f-5f5444b1a2d8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-058d023b-fd20-48e8-8f3f-5f5444b1a2d8' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-51c1d149-4556-41c9-ad18-a25249feb749' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-51c1d149-4556-41c9-ad18-a25249feb749' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dd0ac698-99ad-43ea-9bbd-b18e9f60cc18' class='xr-var-data-in' type='checkbox'><label for='data-dd0ac698-99ad-43ea-9bbd-b18e9f60cc18' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-c1806e86-a53a-4490-be0f-2d4a86dfcaa6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c1806e86-a53a-4490-be0f-2d4a86dfcaa6' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3e33b8b6-f18c-4e27-9f78-56e1579b3800' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3e33b8b6-f18c-4e27-9f78-56e1579b3800' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ab1bff0e-4690-41ab-9667-55a2b6b4b9d8' class='xr-var-data-in' type='checkbox'><label for='data-ab1bff0e-4690-41ab-9667-55a2b6b4b9d8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1018,7 +974,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-230f621c-afd8-42c9-b840-d9752771ea59' class='xr-section-summary-in' type='checkbox'  ><label for='section-230f621c-afd8-42c9-b840-d9752771ea59' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;SCL&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:01.771915</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8267c41f-4918-4e79-b8ff-27e60a3cdbc5' class='xr-section-summary-in' type='checkbox'  ><label for='section-8267c41f-4918-4e79-b8ff-27e60a3cdbc5' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;SCL&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:23:34.209728</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1035,7 +991,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L2A Data Cube Subset\n",
        "    history:                 [{'program': 'xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-02-23T14:01:01.771915\n",
+       "    date_created:            2022-06-23T08:23:34.209728\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -1046,7 +1002,7 @@
        "    processing_level:        L2A"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1058,15 +1014,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "633e0fa1",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:02.151941Z",
-     "iopub.status.busy": "2022-02-23T14:01:02.151179Z",
-     "iopub.status.idle": "2022-02-23T14:01:07.752960Z",
-     "shell.execute_reply": "2022-02-23T14:01:07.751738Z"
-    },
     "papermill": {
      "duration": 5.657093,
      "end_time": "2022-02-23T14:01:07.755274",
@@ -1080,10 +1030,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f950a83f3d0>"
+       "<matplotlib.image.AxesImage at 0x7ff6ff4f4af0>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1123,15 +1073,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "04023765",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:07.941693Z",
-     "iopub.status.busy": "2022-02-23T14:01:07.939593Z",
-     "iopub.status.idle": "2022-02-23T14:01:07.959825Z",
-     "shell.execute_reply": "2022-02-23T14:01:07.958932Z"
-    },
     "papermill": {
      "duration": 0.069921,
      "end_time": "2022-02-23T14:01:07.962432",
@@ -1166,7 +1110,7 @@
        " 'CLP']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1177,15 +1121,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "fb3b5281",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:08.062870Z",
-     "iopub.status.busy": "2022-02-23T14:01:08.062289Z",
-     "iopub.status.idle": "2022-02-23T14:01:08.068717Z",
-     "shell.execute_reply": "2022-02-23T14:01:08.067664Z"
-    },
     "papermill": {
      "duration": 0.059691,
      "end_time": "2022-02-23T14:01:08.070918",
@@ -1200,8 +1138,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n",
       "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/pandas/core/tools/timedeltas.py:148: FutureWarning: Units 'M', 'Y' and 'y' do not represent unambiguous timedelta values and will be removed in a future version.\n",
       "  return _coerce_scalar_to_timedelta_type(arg, unit=unit, errors=errors)\n"
      ]
@@ -1211,7 +1147,7 @@
     "cube_config = CubeConfig(dataset_name='S2L1C',\n",
     "                         band_names=['B04'],\n",
     "                         tile_size=[512, 512],\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         spatial_res=spatial_res,\n",
     "                         time_range=['2018-05-14', '2018-07-31'],\n",
     "                         time_tolerance='30M')  "
@@ -1219,15 +1155,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "89c7399b",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:08.182619Z",
-     "iopub.status.busy": "2022-02-23T14:01:08.181988Z",
-     "iopub.status.idle": "2022-02-23T14:01:08.430679Z",
-     "shell.execute_reply": "2022-02-23T14:01:08.429892Z"
-    },
     "papermill": {
      "duration": 0.316721,
      "end_time": "2022-02-23T14:01:08.433279",
@@ -1606,7 +1536,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L1C Data Cube Subset\n",
        "    history:                 [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-02-23T14:01:08.390899\n",
+       "    date_created:            2022-06-23T08:23:42.998877\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -1614,7 +1544,7 @@
        "    geospatial_lat_min:      54.27\n",
        "    geospatial_lon_max:      11.01376\n",
        "    geospatial_lat_max:      54.63864\n",
-       "    processing_level:        L1C</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-aa544035-456c-42e5-8304-f94b1708f97e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-aa544035-456c-42e5-8304-f94b1708f97e' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-cf52a4b6-63cc-4180-84c2-5e81329274c2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cf52a4b6-63cc-4180-84c2-5e81329274c2' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-d0c8dd99-03e7-477f-865e-358812b52a71' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d0c8dd99-03e7-477f-865e-358812b52a71' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-15c68edd-5f87-4be5-ae63-258318434100' class='xr-var-data-in' type='checkbox'><label for='data-15c68edd-5f87-4be5-ae63-258318434100' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-07d49458-3fc0-4111-9356-145aa657a4a0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-07d49458-3fc0-4111-9356-145aa657a4a0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-870403ac-8a93-4f81-8ac3-2b222ac41be4' class='xr-var-data-in' type='checkbox'><label for='data-870403ac-8a93-4f81-8ac3-2b222ac41be4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-23a737f5-1f58-4b46-bae0-5c8301d451c1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-23a737f5-1f58-4b46-bae0-5c8301d451c1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c43fc4af-b7ea-42a0-af69-41b746b6cae4' class='xr-var-data-in' type='checkbox'><label for='data-c43fc4af-b7ea-42a0-af69-41b746b6cae4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
+       "    processing_level:        L1C</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2e6972b7-2215-44ac-8995-0606be9b6335' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2e6972b7-2215-44ac-8995-0606be9b6335' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 45</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-04c3f2b5-3f54-4d23-834f-fcba37fb2590' class='xr-section-summary-in' type='checkbox'  checked><label for='section-04c3f2b5-3f54-4d23-834f-fcba37fb2590' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-040b773f-7d8c-43b2-8ad9-a650eb684331' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-040b773f-7d8c-43b2-8ad9-a650eb684331' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f9ec68d2-a35d-4929-b5be-678541ab2534' class='xr-var-data-in' type='checkbox'><label for='data-f9ec68d2-a35d-4929-b5be-678541ab2534' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-4cbe4f22-5db4-4874-8174-d31f8143e6a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4cbe4f22-5db4-4874-8174-d31f8143e6a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-49bc1f6c-daec-4ef9-9eb9-763c7ce1dcc9' class='xr-var-data-in' type='checkbox'><label for='data-49bc1f6c-daec-4ef9-9eb9-763c7ce1dcc9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15T10:30:24 ... 2018-07-...</div><input id='attrs-0edbb941-9cbf-4554-8c96-60c7edbf3af9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0edbb941-9cbf-4554-8c96-60c7edbf3af9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4235c0a0-63ce-48ba-96a1-de5bc3a86a69' class='xr-var-data-in' type='checkbox'><label for='data-4235c0a0-63ce-48ba-96a1-de5bc3a86a69' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T10:30:24.000000000&#x27;, &#x27;2018-05-17T10:22:09.000000000&#x27;,\n",
        "       &#x27;2018-05-18T10:40:24.000000000&#x27;, &#x27;2018-05-20T10:34:58.000000000&#x27;,\n",
        "       &#x27;2018-05-22T10:20:25.000000000&#x27;, &#x27;2018-05-23T10:41:24.000000000&#x27;,\n",
        "       &#x27;2018-05-25T10:30:24.000000000&#x27;, &#x27;2018-05-28T10:40:23.000000000&#x27;,\n",
@@ -1636,7 +1566,7 @@
        "       &#x27;2018-07-19T10:30:20.000000000&#x27;, &#x27;2018-07-21T10:20:24.000000000&#x27;,\n",
        "       &#x27;2018-07-22T10:40:20.000000000&#x27;, &#x27;2018-07-24T10:30:23.000000000&#x27;,\n",
        "       &#x27;2018-07-26T10:21:50.000000000&#x27;, &#x27;2018-07-27T10:40:23.000000000&#x27;,\n",
-       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-ee6b1834-9fa4-4bea-b480-8a5c428a0996' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee6b1834-9fa4-4bea-b480-8a5c428a0996' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87597373-9af2-45fd-b7e9-498d87a0b6b8' class='xr-var-data-in' type='checkbox'><label for='data-87597373-9af2-45fd-b7e9-498d87a0b6b8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2018-07-29T10:30:19.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 2), meta=np.ndarray&gt;</div><input id='attrs-c29a2656-4b01-4667-ac97-4230c1b0d159' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c29a2656-4b01-4667-ac97-4230c1b0d159' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0e75fe1-59ac-4bf9-a908-6bf3937be914' class='xr-var-data-in' type='checkbox'><label for='data-e0e75fe1-59ac-4bf9-a908-6bf3937be914' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1693,7 +1623,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-0bd3aaa1-c7d5-4a1c-a1ac-5ba6c1bdbdd7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0bd3aaa1-c7d5-4a1c-a1ac-5ba6c1bdbdd7' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-928a7897-d22d-4edf-b341-f757a4305c59' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-928a7897-d22d-4edf-b341-f757a4305c59' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-50db116f-8d0d-4c04-a0a4-e048766d0130' class='xr-var-data-in' type='checkbox'><label for='data-50db116f-8d0d-4c04-a0a4-e048766d0130' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-44f5bf48-2b65-4f6e-9f56-4ccd8c10822f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-44f5bf48-2b65-4f6e-9f56-4ccd8c10822f' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ca671989-8726-4878-8405-ba6de945d1db' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ca671989-8726-4878-8405-ba6de945d1db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8a4fc501-8145-4cab-9423-95abdf601c24' class='xr-var-data-in' type='checkbox'><label for='data-8a4fc501-8145-4cab-9423-95abdf601c24' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1835,7 +1765,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-010bc74e-5441-4936-b614-3f97249a0a1f' class='xr-section-summary-in' type='checkbox'  ><label for='section-010bc74e-5441-4936-b614-3f97249a0a1f' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L1C Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L1C&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:08.390899</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1C</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8fb0fe99-b7ae-44a1-8d5c-06f912147328' class='xr-section-summary-in' type='checkbox'  ><label for='section-8fb0fe99-b7ae-44a1-8d5c-06f912147328' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L1C Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L1C&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: None, &#x27;time_tolerance&#x27;: &#x27;0 days 00:30:00&#x27;, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:23:42.998877</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-15T10:30:24+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-07-29T10:30:19+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P74DT23H59M55S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1C</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1852,7 +1782,7 @@
        "    Conventions:             CF-1.7\n",
        "    title:                   S2L1C Data Cube Subset\n",
        "    history:                 [{'program': 'xcube_sh.chunkstore.SentinelHubChu...\n",
-       "    date_created:            2022-02-23T14:01:08.390899\n",
+       "    date_created:            2022-06-23T08:23:42.998877\n",
        "    time_coverage_start:     2018-05-15T10:30:24+00:00\n",
        "    time_coverage_end:       2018-07-29T10:30:19+00:00\n",
        "    time_coverage_duration:  P74DT23H59M55S\n",
@@ -1863,7 +1793,7 @@
        "    processing_level:        L1C"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1875,15 +1805,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "0f08e7db",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:08.527158Z",
-     "iopub.status.busy": "2022-02-23T14:01:08.526407Z",
-     "iopub.status.idle": "2022-02-23T14:01:19.084437Z",
-     "shell.execute_reply": "2022-02-23T14:01:19.083562Z"
-    },
     "papermill": {
      "duration": 10.607464,
      "end_time": "2022-02-23T14:01:19.087817",
@@ -1897,10 +1821,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f950aea6ca0>"
+       "<matplotlib.image.AxesImage at 0x7ff6ffb31fd0>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1940,15 +1864,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "c1c7d231",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:19.304180Z",
-     "iopub.status.busy": "2022-02-23T14:01:19.303356Z",
-     "iopub.status.idle": "2022-02-23T14:01:19.317847Z",
-     "shell.execute_reply": "2022-02-23T14:01:19.317225Z"
-    },
     "papermill": {
      "duration": 0.066448,
      "end_time": "2022-02-23T14:01:19.319529",
@@ -1965,7 +1883,7 @@
        "['VV', 'HH', 'VH', 'localIncidenceAngle', 'scatteringArea', 'shadowMask', 'HV']"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1976,15 +1894,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "522cf686",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:19.419907Z",
-     "iopub.status.busy": "2022-02-23T14:01:19.419576Z",
-     "iopub.status.idle": "2022-02-23T14:01:19.424966Z",
-     "shell.execute_reply": "2022-02-23T14:01:19.424007Z"
-    },
     "papermill": {
      "duration": 0.05805,
      "end_time": "2022-02-23T14:01:19.427502",
@@ -2006,15 +1918,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "c693c028",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:19.535168Z",
-     "iopub.status.busy": "2022-02-23T14:01:19.534548Z",
-     "iopub.status.idle": "2022-02-23T14:01:19.538492Z",
-     "shell.execute_reply": "2022-02-23T14:01:19.537788Z"
-    },
     "papermill": {
      "duration": 0.063338,
      "end_time": "2022-02-23T14:01:19.546029",
@@ -2031,15 +1937,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "c771a192",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:19.648008Z",
-     "iopub.status.busy": "2022-02-23T14:01:19.647716Z",
-     "iopub.status.idle": "2022-02-23T14:01:19.654115Z",
-     "shell.execute_reply": "2022-02-23T14:01:19.653289Z"
-    },
     "papermill": {
      "duration": 0.059624,
      "end_time": "2022-02-23T14:01:19.656571",
@@ -2049,38 +1949,23 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cube_config = CubeConfig(dataset_name='S1GRD',\n",
     "                         band_names=['VH'],\n",
     "                         tile_size=[512, 512],\n",
     "                         crs = \"http://www.opengis.net/def/crs/EPSG/0/4326\",\n",
     "                         spatial_res = spatial_res,\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         time_range=['2019-05-14', '2019-07-31'],\n",
     "                         time_period='2D')  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "e74bfbf4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:19.768249Z",
-     "iopub.status.busy": "2022-02-23T14:01:19.767853Z",
-     "iopub.status.idle": "2022-02-23T14:01:19.934057Z",
-     "shell.execute_reply": "2022-02-23T14:01:19.933363Z"
-    },
     "papermill": {
      "duration": 0.227763,
      "end_time": "2022-02-23T14:01:19.935772",
@@ -2459,7 +2344,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S1GRD Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:19.898418\n",
+       "    date_created:              2022-06-23T08:23:54.435450\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -2468,7 +2353,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        10.55296\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L1B</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1a795b39-7c59-4fb2-b422-41f3ffcdbdb8' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1a795b39-7c59-4fb2-b422-41f3ffcdbdb8' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 3072</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4819ea2a-3074-479c-b3cd-2cf1ad741cf8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4819ea2a-3074-479c-b3cd-2cf1ad741cf8' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-118129c4-754f-4fb2-a79d-8a9e7279a075' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-118129c4-754f-4fb2-a79d-8a9e7279a075' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-82d9e72d-c99c-4062-9dbf-f94bf6099963' class='xr-var-data-in' type='checkbox'><label for='data-82d9e72d-c99c-4062-9dbf-f94bf6099963' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.55 10.55</div><input id='attrs-517c66f8-6a36-4889-a19f-ef40b0e6f595' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-517c66f8-6a36-4889-a19f-ef40b0e6f595' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1c8a3f65-afcc-436f-b853-6aca97b01740' class='xr-var-data-in' type='checkbox'><label for='data-1c8a3f65-afcc-436f-b853-6aca97b01740' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 10.55251, 10.55269, 10.55287])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-05-15 ... 2019-08-01</div><input id='attrs-d2fca468-2c3e-47d9-9af3-a57628f831f0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d2fca468-2c3e-47d9-9af3-a57628f831f0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0dba4a14-3e3b-48ca-8e6d-b6bd29de2cfa' class='xr-var-data-in' type='checkbox'><label for='data-0dba4a14-3e3b-48ca-8e6d-b6bd29de2cfa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-05-15T00:00:00.000000000&#x27;, &#x27;2019-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L1B</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-78a52ec2-d635-4d5e-86bd-e59d4afcc18f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-78a52ec2-d635-4d5e-86bd-e59d4afcc18f' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 3072</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-96999df3-f99e-4eee-a05e-546454bf704f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-96999df3-f99e-4eee-a05e-546454bf704f' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-750f9da8-832f-47d0-ba30-df57997eced5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-750f9da8-832f-47d0-ba30-df57997eced5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-50ca82b0-0121-410d-bcd2-5af9888c9097' class='xr-var-data-in' type='checkbox'><label for='data-50ca82b0-0121-410d-bcd2-5af9888c9097' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.55 10.55</div><input id='attrs-3eed77d4-004e-43f4-a217-2afbf4f46da1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3eed77d4-004e-43f4-a217-2afbf4f46da1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6e6c0d64-b083-42a6-8fe5-0884c8df95bf' class='xr-var-data-in' type='checkbox'><label for='data-6e6c0d64-b083-42a6-8fe5-0884c8df95bf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 10.55251, 10.55269, 10.55287])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-05-15 ... 2019-08-01</div><input id='attrs-36d435ef-c76b-482e-9e5a-0c6e4eb811c9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-36d435ef-c76b-482e-9e5a-0c6e4eb811c9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-45aad9b1-6ddd-45c5-ad5e-3fd12800c0cd' class='xr-var-data-in' type='checkbox'><label for='data-45aad9b1-6ddd-45c5-ad5e-3fd12800c0cd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-05-15T00:00:00.000000000&#x27;, &#x27;2019-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-05-19T00:00:00.000000000&#x27;, &#x27;2019-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-05-23T00:00:00.000000000&#x27;, &#x27;2019-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-05-27T00:00:00.000000000&#x27;, &#x27;2019-05-29T00:00:00.000000000&#x27;,\n",
@@ -2488,7 +2373,7 @@
        "       &#x27;2019-07-22T00:00:00.000000000&#x27;, &#x27;2019-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-07-26T00:00:00.000000000&#x27;, &#x27;2019-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-07-30T00:00:00.000000000&#x27;, &#x27;2019-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-4c4c8d79-f900-4be9-9938-faf4f8f2be1e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4c4c8d79-f900-4be9-9938-faf4f8f2be1e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2c7e407b-912d-4e0c-9014-e429ab6f7907' class='xr-var-data-in' type='checkbox'><label for='data-2c7e407b-912d-4e0c-9014-e429ab6f7907' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-9b4d7579-b58c-412a-a6f6-e10b09104051' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9b4d7579-b58c-412a-a6f6-e10b09104051' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ac4a305c-b1dc-46ef-827f-27d3ffaf5f98' class='xr-var-data-in' type='checkbox'><label for='data-ac4a305c-b1dc-46ef-827f-27d3ffaf5f98' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2545,7 +2430,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-c0475995-0b2b-4438-9dbd-8e14264afb8d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c0475995-0b2b-4438-9dbd-8e14264afb8d' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>VH</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-b80af22c-e55a-4e44-af2d-950fb40b0f90' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b80af22c-e55a-4e44-af2d-950fb40b0f90' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-73bc080e-20b7-4bb7-85d8-581e125eeb4e' class='xr-var-data-in' type='checkbox'><label for='data-73bc080e-20b7-4bb7-85d8-581e125eeb4e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Linear power in the chosen backscattering coefficient</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-987f324b-7685-4a54-9546-969bcb57e979' class='xr-section-summary-in' type='checkbox'  checked><label for='section-987f324b-7685-4a54-9546-969bcb57e979' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>VH</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e53d2e13-09d9-456b-91a8-5fee87cbf752' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e53d2e13-09d9-456b-91a8-5fee87cbf752' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-225837ac-4295-4832-8226-bfdce500ca34' class='xr-var-data-in' type='checkbox'><label for='data-225837ac-4295-4832-8226-bfdce500ca34' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Linear power in the chosen backscattering coefficient</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2677,7 +2562,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-0327d6ec-c1a6-44ee-8177-640abedc020a' class='xr-section-summary-in' type='checkbox'  ><label for='section-0327d6ec-c1a6-44ee-8177-640abedc020a' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S1GRD Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S1GRD&#x27;, &#x27;band_names&#x27;: [&#x27;VH&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 10.55296, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:19.898418</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.55296</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1B</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-50afe2c7-672f-4f10-8a66-a887d7de39a5' class='xr-section-summary-in' type='checkbox'  ><label for='section-50afe2c7-672f-4f10-8a66-a887d7de39a5' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S1GRD Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S1GRD&#x27;, &#x27;band_names&#x27;: [&#x27;VH&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 10.55296, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:23:54.435450</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.55296</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L1B</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2694,7 +2579,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S1GRD Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:19.898418\n",
+       "    date_created:              2022-06-23T08:23:54.435450\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -2706,7 +2591,7 @@
        "    processing_level:          L1B"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2718,15 +2603,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "e95bb550",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:20.045060Z",
-     "iopub.status.busy": "2022-02-23T14:01:20.044378Z",
-     "iopub.status.idle": "2022-02-23T14:01:34.575281Z",
-     "shell.execute_reply": "2022-02-23T14:01:34.574539Z"
-    },
     "papermill": {
      "duration": 14.599199,
      "end_time": "2022-02-23T14:01:34.590036",
@@ -2740,10 +2619,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f950ae09820>"
+       "<matplotlib.image.AxesImage at 0x7ff6ffa5cb50>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2766,15 +2645,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "id": "c7eb5013",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:34.754464Z",
-     "iopub.status.busy": "2022-02-23T14:01:34.754170Z",
-     "iopub.status.idle": "2022-02-23T14:01:34.768270Z",
-     "shell.execute_reply": "2022-02-23T14:01:34.767275Z"
-    },
     "papermill": {
      "duration": 0.093956,
      "end_time": "2022-02-23T14:01:34.770635",
@@ -2788,25 +2661,25 @@
     {
      "data": {
       "text/plain": [
-       "['S1GRD',\n",
-       " 'S3OLCI',\n",
+       "['LOTL2',\n",
+       " 'LETML1',\n",
        " 'LTML2',\n",
-       " 'S3SLSTR',\n",
-       " 'S2L1C',\n",
-       " 'CUSTOM',\n",
-       " 'LOTL1',\n",
-       " 'LMSSL1',\n",
-       " 'LOTL2',\n",
-       " 'MODIS',\n",
        " 'S5PL2',\n",
-       " 'LETML2',\n",
        " 'DEM',\n",
+       " 'S2L1C',\n",
        " 'LTML1',\n",
+       " 'MODIS',\n",
        " 'S2L2A',\n",
-       " 'LETML1']"
+       " 'LETML2',\n",
+       " 'CUSTOM',\n",
+       " 'S1GRD',\n",
+       " 'LOTL1',\n",
+       " 'S3OLCI',\n",
+       " 'LMSSL1',\n",
+       " 'S3SLSTR']"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2834,15 +2707,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "id": "c83b0ac3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:35.103482Z",
-     "iopub.status.busy": "2022-02-23T14:01:35.102998Z",
-     "iopub.status.idle": "2022-02-23T14:01:35.119261Z",
-     "shell.execute_reply": "2022-02-23T14:01:35.118391Z"
-    },
     "papermill": {
      "duration": 0.099612,
      "end_time": "2022-02-23T14:01:35.121455",
@@ -2856,10 +2723,10 @@
     {
      "data": {
       "text/plain": [
-       "['DEM', 'DEM']"
+       "['DEM']"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2870,15 +2737,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "id": "1131e9f0",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:35.340413Z",
-     "iopub.status.busy": "2022-02-23T14:01:35.339780Z",
-     "iopub.status.idle": "2022-02-23T14:01:35.345963Z",
-     "shell.execute_reply": "2022-02-23T14:01:35.345103Z"
-    },
     "papermill": {
      "duration": 0.134404,
      "end_time": "2022-02-23T14:01:35.348323",
@@ -2900,15 +2761,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "id": "7fc5ef4e",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:35.503442Z",
-     "iopub.status.busy": "2022-02-23T14:01:35.502790Z",
-     "iopub.status.idle": "2022-02-23T14:01:35.507077Z",
-     "shell.execute_reply": "2022-02-23T14:01:35.506158Z"
-    },
     "papermill": {
      "duration": 0.085126,
      "end_time": "2022-02-23T14:01:35.509000",
@@ -2925,15 +2780,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "id": "5f8d299d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:35.686111Z",
-     "iopub.status.busy": "2022-02-23T14:01:35.685453Z",
-     "iopub.status.idle": "2022-02-23T14:01:35.691596Z",
-     "shell.execute_reply": "2022-02-23T14:01:35.690726Z"
-    },
     "papermill": {
      "duration": 0.100532,
      "end_time": "2022-02-23T14:01:35.693592",
@@ -2943,38 +2792,23 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cube_config = CubeConfig(dataset_name='DEM',\n",
     "                         band_names=['DEM'],\n",
     "                         tile_size=[512, 512],\n",
     "                         crs = \"http://www.opengis.net/def/crs/EPSG/0/4326\",\n",
     "                         spatial_res = spatial_res,\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         time_range=['2019-05-14', '2019-07-31'],\n",
     "                         time_period='100D')  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "id": "1376aa19",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:35.864290Z",
-     "iopub.status.busy": "2022-02-23T14:01:35.863591Z",
-     "iopub.status.idle": "2022-02-23T14:01:36.073413Z",
-     "shell.execute_reply": "2022-02-23T14:01:36.072734Z"
-    },
     "papermill": {
      "duration": 0.286377,
      "end_time": "2022-02-23T14:01:36.075589",
@@ -3353,7 +3187,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     DEM Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:36.039947\n",
+       "    date_created:              2022-06-23T08:24:09.822914\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-22T00:00:00+00:00\n",
        "    time_coverage_duration:    P100DT0H0M0S\n",
@@ -3361,7 +3195,7 @@
        "    geospatial_lon_min:        10.0\n",
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        10.512\n",
-       "    geospatial_lat_max:        54.400000000000006</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-9337c7b9-12e1-4577-b0fe-7fa51b0d99c4' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-9337c7b9-12e1-4577-b0fe-7fa51b0d99c4' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>lat</span>: 650</li><li><span class='xr-has-index'>lon</span>: 2560</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b4bdd05b-2050-4aa3-b104-b25d371ea8e3' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b4bdd05b-2050-4aa3-b104-b25d371ea8e3' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.4 54.4 54.4 ... 54.27 54.27</div><input id='attrs-ed8e708a-d7d4-44ad-9834-29081a357938' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ed8e708a-d7d4-44ad-9834-29081a357938' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-528c2e18-2124-42d6-9896-95420b4a1ac0' class='xr-var-data-in' type='checkbox'><label for='data-528c2e18-2124-42d6-9896-95420b4a1ac0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.3999, 54.3997, 54.3995, ..., 54.2705, 54.2703, 54.2701])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.51 10.51</div><input id='attrs-39b704d2-4548-4091-92aa-fd6a43aa6f8e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-39b704d2-4548-4091-92aa-fd6a43aa6f8e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-83ff60da-d28c-4eb3-9c95-58e6345c8e63' class='xr-var-data-in' type='checkbox'><label for='data-83ff60da-d28c-4eb3-9c95-58e6345c8e63' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.0001, 10.0003, 10.0005, ..., 10.5115, 10.5117, 10.5119])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-07-03</div><input id='attrs-594436f6-cb34-4c27-b22f-ac3f590898d9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-594436f6-cb34-4c27-b22f-ac3f590898d9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b608442e-26b0-44a2-b196-6f3e06af8d6c' class='xr-var-data-in' type='checkbox'><label for='data-b608442e-26b0-44a2-b196-6f3e06af8d6c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-07-03T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2), meta=np.ndarray&gt;</div><input id='attrs-d602418a-36f9-476f-b667-5fa122403d83' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d602418a-36f9-476f-b667-5fa122403d83' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e155cb79-5e30-4c74-90a7-ded6e84fcf8e' class='xr-var-data-in' type='checkbox'><label for='data-e155cb79-5e30-4c74-90a7-ded6e84fcf8e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    geospatial_lat_max:        54.400000000000006</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-4fbd1af5-5e05-49ce-9bf6-2fe9445a3956' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-4fbd1af5-5e05-49ce-9bf6-2fe9445a3956' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>lat</span>: 650</li><li><span class='xr-has-index'>lon</span>: 2560</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-62e25275-9b0b-4a82-8f43-f4162512751d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-62e25275-9b0b-4a82-8f43-f4162512751d' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.4 54.4 54.4 ... 54.27 54.27</div><input id='attrs-62ff5ee6-ac05-4f21-a5ca-1d7f15d3d75d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-62ff5ee6-ac05-4f21-a5ca-1d7f15d3d75d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13bb83e7-0b49-4d10-8b82-7ad12364d079' class='xr-var-data-in' type='checkbox'><label for='data-13bb83e7-0b49-4d10-8b82-7ad12364d079' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.3999, 54.3997, 54.3995, ..., 54.2705, 54.2703, 54.2701])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 10.51 10.51</div><input id='attrs-51714985-52ef-49f4-b43a-485dbb292086' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-51714985-52ef-49f4-b43a-485dbb292086' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d72841cd-a917-4795-a8f4-48adfa60dfeb' class='xr-var-data-in' type='checkbox'><label for='data-d72841cd-a917-4795-a8f4-48adfa60dfeb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.0001, 10.0003, 10.0005, ..., 10.5115, 10.5117, 10.5119])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-07-03</div><input id='attrs-15a2497a-4afb-487e-ac82-2a39a5f479c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-15a2497a-4afb-487e-ac82-2a39a5f479c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ffe6bc2b-9eae-41e8-9554-f0b1882cbd2b' class='xr-var-data-in' type='checkbox'><label for='data-ffe6bc2b-9eae-41e8-9554-f0b1882cbd2b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-07-03T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2), meta=np.ndarray&gt;</div><input id='attrs-0aaf0650-dc15-4799-b5a3-b9c898bff701' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0aaf0650-dc15-4799-b5a3-b9c898bff701' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-977bb208-32cb-49af-9441-0613e19161e9' class='xr-var-data-in' type='checkbox'><label for='data-977bb208-32cb-49af-9441-0613e19161e9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3418,7 +3252,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8de591d4-b91a-4b3b-9717-a646f67072cc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8de591d4-b91a-4b3b-9717-a646f67072cc' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>DEM</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 650, 512), meta=np.ndarray&gt;</div><input id='attrs-e427bbb6-9ccb-407f-8144-f12cf3a86bd0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e427bbb6-9ccb-407f-8144-f12cf3a86bd0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e098d271-d3ac-49e0-9c4b-8030381fd307' class='xr-var-data-in' type='checkbox'><label for='data-e098d271-d3ac-49e0-9c4b-8030381fd307' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Meters</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9c38953a-d81e-402c-aafa-82f8b9abf996' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9c38953a-d81e-402c-aafa-82f8b9abf996' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>DEM</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 650, 512), meta=np.ndarray&gt;</div><input id='attrs-bb9ac1d7-079d-4eea-af44-393183cf2db7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bb9ac1d7-079d-4eea-af44-393183cf2db7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-905d1bb8-2b3f-466f-a370-fcb3c6474ea9' class='xr-var-data-in' type='checkbox'><label for='data-905d1bb8-2b3f-466f-a370-fcb3c6474ea9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>Meters</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3506,7 +3340,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-78fde9e0-aafa-47b2-ad48-9b9ea1306bd1' class='xr-section-summary-in' type='checkbox'  ><label for='section-78fde9e0-aafa-47b2-ad48-9b9ea1306bd1' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>DEM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;DEM&#x27;, &#x27;band_names&#x27;: [&#x27;DEM&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 650], &#x27;bbox&#x27;: [10.0, 54.27, 10.512, 54.400000000000006], &#x27;spatial_res&#x27;: 0.0002, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;100 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:36.039947</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-22T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P100DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P100DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.512</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.400000000000006</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-66254276-c5af-48bb-b2bd-033072a40797' class='xr-section-summary-in' type='checkbox'  ><label for='section-66254276-c5af-48bb-b2bd-033072a40797' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>DEM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;DEM&#x27;, &#x27;band_names&#x27;: [&#x27;DEM&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 650], &#x27;bbox&#x27;: [10.0, 54.27, 10.512, 54.400000000000006], &#x27;spatial_res&#x27;: 0.0002, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2019-05-14T00:00:00+00:00&#x27;, &#x27;2019-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;100 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:24:09.822914</dd><dt><span>time_coverage_start :</span></dt><dd>2019-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-08-22T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P100DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P100DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.512</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.400000000000006</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -3523,7 +3357,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     DEM Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:36.039947\n",
+       "    date_created:              2022-06-23T08:24:09.822914\n",
        "    time_coverage_start:       2019-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2019-08-22T00:00:00+00:00\n",
        "    time_coverage_duration:    P100DT0H0M0S\n",
@@ -3534,7 +3368,7 @@
        "    geospatial_lat_max:        54.400000000000006"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3546,15 +3380,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "ad6e059a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:36.258405Z",
-     "iopub.status.busy": "2022-02-23T14:01:36.257777Z",
-     "iopub.status.idle": "2022-02-23T14:01:39.214579Z",
-     "shell.execute_reply": "2022-02-23T14:01:39.213750Z"
-    },
     "papermill": {
      "duration": 3.052612,
      "end_time": "2022-02-23T14:01:39.219746",
@@ -3568,10 +3396,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f950ad496a0>"
+       "<matplotlib.image.AxesImage at 0x7ff6ff925160>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -3628,15 +3456,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "id": "1c7ed20c",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:39.714138Z",
-     "iopub.status.busy": "2022-02-23T14:01:39.713429Z",
-     "iopub.status.idle": "2022-02-23T14:01:39.718647Z",
-     "shell.execute_reply": "2022-02-23T14:01:39.717524Z"
-    },
     "papermill": {
      "duration": 0.090099,
      "end_time": "2022-02-23T14:01:39.720917",
@@ -3658,15 +3480,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "id": "f2c4f7e9",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:39.888453Z",
-     "iopub.status.busy": "2022-02-23T14:01:39.887664Z",
-     "iopub.status.idle": "2022-02-23T14:01:39.892526Z",
-     "shell.execute_reply": "2022-02-23T14:01:39.891555Z"
-    },
     "papermill": {
      "duration": 0.088879,
      "end_time": "2022-02-23T14:01:39.894361",
@@ -3702,15 +3518,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "id": "c99e1a81",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:40.424686Z",
-     "iopub.status.busy": "2022-02-23T14:01:40.423866Z",
-     "iopub.status.idle": "2022-02-23T14:01:40.430895Z",
-     "shell.execute_reply": "2022-02-23T14:01:40.429786Z"
-    },
     "papermill": {
      "duration": 0.191851,
      "end_time": "2022-02-23T14:01:40.432924",
@@ -3720,22 +3530,13 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/eurodatacube-2022.02/lib/python3.8/site-packages/xcube_sh/config.py:145: UserWarning: the geometry parameter is no longer supported, use bbox instead\n",
-      "  warnings.warn('the geometry parameter is no longer '\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cube_config = CubeConfig(dataset_name='CUSTOM',\n",
     "                         band_names=['RED', 'GREEN', 'BLUE'],                        \n",
     "                         tile_size=[width, height],\n",
     "                         crs='http://www.opengis.net/def/crs/EPSG/0/3857',\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         time_range=['2018-01-01', '2019-01-01'],\n",
     "                         time_period='7d',\n",
     "                         spatial_res=spatial_res,\n",
@@ -3745,15 +3546,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "id": "195ed394",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:40.625373Z",
-     "iopub.status.busy": "2022-02-23T14:01:40.625106Z",
-     "iopub.status.idle": "2022-02-23T14:01:40.770366Z",
-     "shell.execute_reply": "2022-02-23T14:01:40.769553Z"
-    },
     "papermill": {
      "duration": 0.236427,
      "end_time": "2022-02-23T14:01:40.773882",
@@ -4135,11 +3930,11 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     CUSTOM Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:40.720193\n",
+       "    date_created:              2022-06-23T08:24:15.141282\n",
        "    time_coverage_start:       2018-01-01T00:00:00+00:00\n",
        "    time_coverage_end:         2019-01-07T00:00:00+00:00\n",
        "    time_coverage_duration:    P371DT0H0M0S\n",
-       "    time_coverage_resolution:  P7DT0H0M0S</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-96239ba0-b70b-4867-9cc9-22d438f0c4f6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-96239ba0-b70b-4867-9cc9-22d438f0c4f6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 53</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-f57325b0-d1f3-42c9-affd-bc239c36d592' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f57325b0-d1f3-42c9-affd-bc239c36d592' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-01-04T12:00:00 ... 2019-01-...</div><input id='attrs-f82796d0-7387-4b99-a015-354fd27b29d5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f82796d0-7387-4b99-a015-354fd27b29d5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-71d8e696-2882-4c3f-9067-91743b1582e2' class='xr-var-data-in' type='checkbox'><label for='data-71d8e696-2882-4c3f-9067-91743b1582e2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-01-04T12:00:00.000000000&#x27;, &#x27;2018-01-11T12:00:00.000000000&#x27;,\n",
+       "    time_coverage_resolution:  P7DT0H0M0S</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-62f64f68-c6f4-4cae-9a54-2a3f502a84c6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-62f64f68-c6f4-4cae-9a54-2a3f502a84c6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 53</li><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-1dcc0557-9636-49f5-9baf-3c612041afd6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1dcc0557-9636-49f5-9baf-3c612041afd6' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-01-04T12:00:00 ... 2019-01-...</div><input id='attrs-b26ceea8-0214-466d-9b70-6363d56321a6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b26ceea8-0214-466d-9b70-6363d56321a6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c12898fe-7962-490c-b0fa-3d1cb9fa9d43' class='xr-var-data-in' type='checkbox'><label for='data-c12898fe-7962-490c-b0fa-3d1cb9fa9d43' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-01-04T12:00:00.000000000&#x27;, &#x27;2018-01-11T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-01-18T12:00:00.000000000&#x27;, &#x27;2018-01-25T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-02-01T12:00:00.000000000&#x27;, &#x27;2018-02-08T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-02-15T12:00:00.000000000&#x27;, &#x27;2018-02-22T12:00:00.000000000&#x27;,\n",
@@ -4165,7 +3960,7 @@
        "       &#x27;2018-11-22T12:00:00.000000000&#x27;, &#x27;2018-11-29T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-12-06T12:00:00.000000000&#x27;, &#x27;2018-12-13T12:00:00.000000000&#x27;,\n",
        "       &#x27;2018-12-20T12:00:00.000000000&#x27;, &#x27;2018-12-27T12:00:00.000000000&#x27;,\n",
-       "       &#x27;2019-01-03T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(53, 2), meta=np.ndarray&gt;</div><input id='attrs-479e872c-54fc-4cb4-986f-ff88c27b871f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-479e872c-54fc-4cb4-986f-ff88c27b871f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7ee5e1ea-3cf2-44a7-9c16-9794bba13ec9' class='xr-var-data-in' type='checkbox'><label for='data-7ee5e1ea-3cf2-44a7-9c16-9794bba13ec9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2019-01-03T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(53, 2), meta=np.ndarray&gt;</div><input id='attrs-aab7c411-5011-4151-be0b-db110b74d269' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aab7c411-5011-4151-be0b-db110b74d269' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bd300467-671c-43fe-9bde-bfcb6766797f' class='xr-var-data-in' type='checkbox'><label for='data-bd300467-671c-43fe-9bde-bfcb6766797f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4222,9 +4017,9 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-ed3e9598-0312-41d6-8aa2-2375fb302862' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ed3e9598-0312-41d6-8aa2-2375fb302862' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1a3f4d91-db84-4564-9dc2-5be991e05598' class='xr-var-data-in' type='checkbox'><label for='data-1a3f4d91-db84-4564-9dc2-5be991e05598' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
-       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-67699ebf-618b-4a97-b6b2-db23d70744db' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-67699ebf-618b-4a97-b6b2-db23d70744db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5596b927-bf93-46a1-8ba1-5a28f6ebf999' class='xr-var-data-in' type='checkbox'><label for='data-5596b927-bf93-46a1-8ba1-5a28f6ebf999' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
-       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0ba0545d-ffec-47f5-9610-a6a714531b87' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0ba0545d-ffec-47f5-9610-a6a714531b87' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>BLUE</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-cdb3e3e8-3a03-4427-a2a2-e891aaadf21b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cdb3e3e8-3a03-4427-a2a2-e891aaadf21b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5b86114f-7d9a-4ec8-860e-0a560724704b' class='xr-var-data-in' type='checkbox'><label for='data-5b86114f-7d9a-4ec8-860e-0a560724704b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-ef0567e2-5e51-449b-90a4-61800e5ea3ed' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ef0567e2-5e51-449b-90a4-61800e5ea3ed' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-011da1a6-3da0-4d3e-bf48-91069d05d3ad' class='xr-var-data-in' type='checkbox'><label for='data-011da1a6-3da0-4d3e-bf48-91069d05d3ad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
+       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-86e8d215-8c47-4f06-b01f-abea217db853' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-86e8d215-8c47-4f06-b01f-abea217db853' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9470c7b5-1f63-474f-b7fa-e0d1bad36ba1' class='xr-var-data-in' type='checkbox'><label for='data-9470c7b5-1f63-474f-b7fa-e0d1bad36ba1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
+       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f67b6e9e-255e-49ad-8770-0a18f5d46497' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f67b6e9e-255e-49ad-8770-0a18f5d46497' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>BLUE</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-e81d1051-93d0-430b-8582-29ee0f03f5cf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e81d1051-93d0-430b-8582-29ee0f03f5cf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8b699f6-3b03-4900-9ec5-cb3aad6b1c98' class='xr-var-data-in' type='checkbox'><label for='data-f8b699f6-3b03-4900-9ec5-cb3aad6b1c98' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4340,7 +4135,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>GREEN</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-602eaf1b-7891-41b0-962e-e26b92ce3d05' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-602eaf1b-7891-41b0-962e-e26b92ce3d05' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5b6fcb03-3573-4c1c-97ad-b82947cb4dce' class='xr-var-data-in' type='checkbox'><label for='data-5b6fcb03-3573-4c1c-97ad-b82947cb4dce' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>GREEN</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-cd56991f-1fa1-4b80-ae91-fdc040b8b241' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cd56991f-1fa1-4b80-ae91-fdc040b8b241' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4197b316-03a9-4e6c-a5ff-ec59b1b92bda' class='xr-var-data-in' type='checkbox'><label for='data-4197b316-03a9-4e6c-a5ff-ec59b1b92bda' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4456,7 +4251,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>RED</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-ed70fafd-e93a-4ebc-9a14-0d38b9d7c964' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ed70fafd-e93a-4ebc-9a14-0d38b9d7c964' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c2315189-a801-40d6-8a35-331fcc3e1aa7' class='xr-var-data-in' type='checkbox'><label for='data-c2315189-a801-40d6-8a35-331fcc3e1aa7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>RED</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 305, 512), meta=np.ndarray&gt;</div><input id='attrs-14d7b550-8587-4b89-be56-35db0fe1e240' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-14d7b550-8587-4b89-be56-35db0fe1e240' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a4e480da-c224-4b72-823e-0add9e70a7d2' class='xr-var-data-in' type='checkbox'><label for='data-a4e480da-c224-4b72-823e-0add9e70a7d2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>crs</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4572,7 +4367,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-5e1b2737-83d3-4c1f-aee8-8a95fe6ea34b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5e1b2737-83d3-4c1f-aee8-8a95fe6ea34b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-90033e9a-4d33-4ae2-a650-092a5e4449a8' class='xr-var-data-in' type='checkbox'><label for='data-90033e9a-4d33-4ae2-a650-092a5e4449a8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1ed4bc3e-823d-4111-8b7a-7af097a461d1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1ed4bc3e-823d-4111-8b7a-7af097a461d1' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>CUSTOM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;CUSTOM&#x27;, &#x27;band_names&#x27;: [&#x27;RED&#x27;, &#x27;GREEN&#x27;, &#x27;BLUE&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: &#x27;UINT8&#x27;, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-01-01T00:00:00+00:00&#x27;, &#x27;2019-01-01T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;7 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: &#x27;1a3ab057-3c51-447c-9f85-27d4b633b3f5&#x27;, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:40.720193</dd><dt><span>time_coverage_start :</span></dt><dd>2018-01-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-01-07T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P371DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P7DT0H0M0S</dd></dl></div></li></ul></div></div>"
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>crs</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-94ddb4aa-0cb4-4fce-95db-5691c8732e9c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-94ddb4aa-0cb4-4fce-95db-5691c8732e9c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-155e5f0b-ace6-4f81-952e-7ecd36ac76c8' class='xr-var-data-in' type='checkbox'><label for='data-155e5f0b-ace6-4f81-952e-7ecd36ac76c8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / Pseudo-Mercator&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;Popular Visualisation Pseudo-Mercator&quot;,METHOD[&quot;Popular Visualisation Pseudo Mercator&quot;,ID[&quot;EPSG&quot;,1024]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;False easting&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting (X)&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing (Y)&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],USAGE[SCOPE[&quot;Web mapping and visualisation.&quot;],AREA[&quot;World between 85.06°S and 85.06°N.&quot;],BBOX[-85.06,-180,85.06,180]],ID[&quot;EPSG&quot;,3857]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d6d2a2f4-fc19-4168-aff4-05484f0032f5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d6d2a2f4-fc19-4168-aff4-05484f0032f5' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>CUSTOM Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;CUSTOM&#x27;, &#x27;band_names&#x27;: [&#x27;RED&#x27;, &#x27;GREEN&#x27;, &#x27;BLUE&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: &#x27;UINT8&#x27;, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 305], &#x27;bbox&#x27;: [1545577, 5761986, 1705367.0, 5857173.40234375], &#x27;spatial_res&#x27;: 312.08984375, &#x27;crs&#x27;: &#x27;EPSG:3857&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-01-01T00:00:00+00:00&#x27;, &#x27;2019-01-01T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;7 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: &#x27;1a3ab057-3c51-447c-9f85-27d4b633b3f5&#x27;, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:24:15.141282</dd><dt><span>time_coverage_start :</span></dt><dd>2018-01-01T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2019-01-07T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P371DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P7DT0H0M0S</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -4592,14 +4387,14 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     CUSTOM Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:40.720193\n",
+       "    date_created:              2022-06-23T08:24:15.141282\n",
        "    time_coverage_start:       2018-01-01T00:00:00+00:00\n",
        "    time_coverage_end:         2019-01-07T00:00:00+00:00\n",
        "    time_coverage_duration:    P371DT0H0M0S\n",
        "    time_coverage_resolution:  P7DT0H0M0S"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4611,15 +4406,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "id": "713ecf6b",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:40.946681Z",
-     "iopub.status.busy": "2022-02-23T14:01:40.946076Z",
-     "iopub.status.idle": "2022-02-23T14:01:40.952905Z",
-     "shell.execute_reply": "2022-02-23T14:01:40.952070Z"
-    },
     "papermill": {
      "duration": 0.094485,
      "end_time": "2022-02-23T14:01:40.954846",
@@ -4636,15 +4425,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "id": "e68435db",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:41.131085Z",
-     "iopub.status.busy": "2022-02-23T14:01:41.130483Z",
-     "iopub.status.idle": "2022-02-23T14:01:43.807627Z",
-     "shell.execute_reply": "2022-02-23T14:01:43.806916Z"
-    },
     "papermill": {
      "duration": 2.771522,
      "end_time": "2022-02-23T14:01:43.815814",
@@ -4658,10 +4441,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f950ac32970>"
+       "<matplotlib.image.AxesImage at 0x7ff6ff814970>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -4690,15 +4473,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "id": "e58aa631",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:44.014624Z",
-     "iopub.status.busy": "2022-02-23T14:01:44.014038Z",
-     "iopub.status.idle": "2022-02-23T14:01:44.033207Z",
-     "shell.execute_reply": "2022-02-23T14:01:44.032564Z"
-    },
     "papermill": {
      "duration": 0.119679,
      "end_time": "2022-02-23T14:01:44.034816",
@@ -5108,7 +4885,7 @@
        "Coordinates:\n",
        "  * x        (x) float64 1.546e+06 1.546e+06 1.546e+06 ... 1.705e+06 1.705e+06\n",
        "  * y        (y) float64 5.857e+06 5.857e+06 5.856e+06 ... 5.762e+06 5.762e+06\n",
-       "Dimensions without coordinates: b</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>b</span>: 3</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-dfe50926-d5e0-46c2-9b13-9828810ab352' class='xr-array-in' type='checkbox' checked><label for='section-dfe50926-d5e0-46c2-9b13-9828810ab352' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>61 99 8 52 118 118 223 158 15 200 ... 3 242 164 3 227 195 17 254 166 1</span></div><div class='xr-array-data'><pre>array([[[ 61,  99,   8],\n",
+       "Dimensions without coordinates: b</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 305</li><li><span class='xr-has-index'>x</span>: 512</li><li><span>b</span>: 3</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-46d95fe9-8f55-4f01-a1c8-0e6bbc61b7d2' class='xr-array-in' type='checkbox' checked><label for='section-46d95fe9-8f55-4f01-a1c8-0e6bbc61b7d2' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>61 99 8 52 118 118 223 158 15 200 ... 3 242 164 3 227 195 17 254 166 1</span></div><div class='xr-array-data'><pre>array([[[ 61,  99,   8],\n",
        "        [ 52, 118, 118],\n",
        "        [223, 158,  15],\n",
        "        ...,\n",
@@ -5148,9 +4925,9 @@
        "        ...,\n",
        "        [242, 164,   3],\n",
        "        [227, 195,  17],\n",
-       "        [254, 166,   1]]], dtype=uint8)</pre></div></div></li><li class='xr-section-item'><input id='section-5cd7fb16-a94e-4f65-9fc9-68ea00c518ac' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5cd7fb16-a94e-4f65-9fc9-68ea00c518ac' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-21933c51-8d66-4541-9f95-c5bf0b308631' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-21933c51-8d66-4541-9f95-c5bf0b308631' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-acde697b-2647-4cfe-a102-714a7f07bc50' class='xr-var-data-in' type='checkbox'><label for='data-acde697b-2647-4cfe-a102-714a7f07bc50' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
-       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-a0242488-af1c-490d-9bfb-c1fbf06e8830' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a0242488-af1c-490d-9bfb-c1fbf06e8830' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d816e135-1304-4984-905f-4a25e82a5c40' class='xr-var-data-in' type='checkbox'><label for='data-d816e135-1304-4984-905f-4a25e82a5c40' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
-       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7092768c-62ec-466f-b6d4-cc2240a3247c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7092768c-62ec-466f-b6d4-cc2240a3247c' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "        [254, 166,   1]]], dtype=uint8)</pre></div></div></li><li class='xr-section-item'><input id='section-13ca3453-88d1-4bc8-9292-a042b56bee36' class='xr-section-summary-in' type='checkbox'  checked><label for='section-13ca3453-88d1-4bc8-9292-a042b56bee36' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.546e+06 1.546e+06 ... 1.705e+06</div><input id='attrs-7dfc21b8-4b88-4820-bc6a-f61e196bc6c3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7dfc21b8-4b88-4820-bc6a-f61e196bc6c3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-72fc3942-1e7f-43d8-8553-5de623dfe804' class='xr-var-data-in' type='checkbox'><label for='data-72fc3942-1e7f-43d8-8553-5de623dfe804' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([1545733.044922, 1546045.134766, 1546357.224609, ..., 1704586.775391,\n",
+       "       1704898.865234, 1705210.955078])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.857e+06 5.857e+06 ... 5.762e+06</div><input id='attrs-e196cf7d-ac7d-4be1-8f2f-d556414d000f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e196cf7d-ac7d-4be1-8f2f-d556414d000f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3c3ac47e-9a0c-44a3-b000-e50ac55e341c' class='xr-var-data-in' type='checkbox'><label for='data-3c3ac47e-9a0c-44a3-b000-e50ac55e341c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5857017.357422, 5856705.267578, 5856393.177734, ..., 5762766.224609,\n",
+       "       5762454.134766, 5762142.044922])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-977d3f79-a2a3-45bc-899a-70a84803ce1e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-977d3f79-a2a3-45bc-899a-70a84803ce1e' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray (y: 305, x: 512, b: 3)>\n",
@@ -5201,7 +4978,7 @@
        "Dimensions without coordinates: b"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5209,13 +4986,21 @@
    "source": [
     "rgb_array"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7973ee3-42c1-4314-8bde-104b4a3ea311",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "EDC 2022.02 (Python3)",
    "language": "python",
-   "name": "python3"
+   "name": "edc"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/curated/EDC_Sentinel_Hub-XCUBE_integration.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-XCUBE_integration.ipynb
@@ -150,15 +150,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "63549688",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:54.390636Z",
-     "iopub.status.busy": "2022-02-23T14:01:54.390394Z",
-     "iopub.status.idle": "2022-02-23T14:01:56.320994Z",
-     "shell.execute_reply": "2022-02-23T14:01:56.320216Z"
-    },
     "papermill": {
      "duration": 1.973116,
      "end_time": "2022-02-23T14:01:56.323017",
@@ -192,15 +186,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "b7fbc709",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:56.415039Z",
-     "iopub.status.busy": "2022-02-23T14:01:56.414495Z",
-     "iopub.status.idle": "2022-02-23T14:01:57.137325Z",
-     "shell.execute_reply": "2022-02-23T14:01:57.136636Z"
-    },
     "papermill": {
      "duration": 0.766252,
      "end_time": "2022-02-23T14:01:57.139333",
@@ -237,15 +225,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "2308aa69",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:57.309761Z",
-     "iopub.status.busy": "2022-02-23T14:01:57.309514Z",
-     "iopub.status.idle": "2022-02-23T14:01:57.314348Z",
-     "shell.execute_reply": "2022-02-23T14:01:57.313428Z"
-    },
     "papermill": {
      "duration": 0.048102,
      "end_time": "2022-02-23T14:01:57.316558",
@@ -267,15 +249,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "5f3c1c3d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:57.401301Z",
-     "iopub.status.busy": "2022-02-23T14:01:57.400638Z",
-     "iopub.status.idle": "2022-02-23T14:01:57.405098Z",
-     "shell.execute_reply": "2022-02-23T14:01:57.404173Z"
-    },
     "papermill": {
      "duration": 0.045895,
      "end_time": "2022-02-23T14:01:57.406797",
@@ -312,15 +288,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "d47ddd14",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:57.569698Z",
-     "iopub.status.busy": "2022-02-23T14:01:57.569280Z",
-     "iopub.status.idle": "2022-02-23T14:01:57.573406Z",
-     "shell.execute_reply": "2022-02-23T14:01:57.572566Z"
-    },
     "papermill": {
      "duration": 0.047398,
      "end_time": "2022-02-23T14:01:57.575696",
@@ -355,15 +325,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "60ba77bb",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:57.740636Z",
-     "iopub.status.busy": "2022-02-23T14:01:57.740259Z",
-     "iopub.status.idle": "2022-02-23T14:01:57.746089Z",
-     "shell.execute_reply": "2022-02-23T14:01:57.745231Z"
-    },
     "papermill": {
      "duration": 0.048718,
      "end_time": "2022-02-23T14:01:57.748463",
@@ -378,7 +342,7 @@
     "cube_config = CubeConfig(dataset_name='S2L2A',\n",
     "                         band_names=['B04', 'B05', 'B06', 'B11', 'SCL', 'CLD'],\n",
     "                         tile_size=[512, 512],\n",
-    "                         geometry=bbox,\n",
+    "                         bbox=bbox,\n",
     "                         spatial_res=spatial_res,\n",
     "                         time_range=['2018-05-14', '2018-07-31'],\n",
     "                         time_period='2D')"
@@ -403,15 +367,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "9f12d8ee",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:57.913544Z",
-     "iopub.status.busy": "2022-02-23T14:01:57.912953Z",
-     "iopub.status.idle": "2022-02-23T14:01:57.917283Z",
-     "shell.execute_reply": "2022-02-23T14:01:57.916487Z"
-    },
     "papermill": {
      "duration": 0.047201,
      "end_time": "2022-02-23T14:01:57.919100",
@@ -445,15 +403,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "d8f1e05b",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:58.090952Z",
-     "iopub.status.busy": "2022-02-23T14:01:58.090374Z",
-     "iopub.status.idle": "2022-02-23T14:01:58.289349Z",
-     "shell.execute_reply": "2022-02-23T14:01:58.288558Z"
-    },
     "papermill": {
      "duration": 0.241207,
      "end_time": "2022-02-23T14:01:58.291413",
@@ -470,15 +422,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "7c294ff7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:58.372585Z",
-     "iopub.status.busy": "2022-02-23T14:01:58.372303Z",
-     "iopub.status.idle": "2022-02-23T14:01:58.466694Z",
-     "shell.execute_reply": "2022-02-23T14:01:58.465873Z"
-    },
     "papermill": {
      "duration": 0.13804,
      "end_time": "2022-02-23T14:01:58.469743",
@@ -862,7 +808,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:58.202580\n",
+       "    date_created:              2022-06-23T08:26:12.089929\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -871,7 +817,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-74243248-2ea6-4411-8534-1abb77eb6f57' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-74243248-2ea6-4411-8534-1abb77eb6f57' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-40ae55e1-f70b-40b2-a587-579ea36f2041' class='xr-section-summary-in' type='checkbox'  checked><label for='section-40ae55e1-f70b-40b2-a587-579ea36f2041' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-73688c69-4510-4cf2-8335-a79df5f01ce7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-73688c69-4510-4cf2-8335-a79df5f01ce7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d2ce5464-b247-45fd-a7a8-8ad9a4daf833' class='xr-var-data-in' type='checkbox'><label for='data-d2ce5464-b247-45fd-a7a8-8ad9a4daf833' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-0b19bb05-55e8-43b4-9e9c-ebe7b40fb90d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0b19bb05-55e8-43b4-9e9c-ebe7b40fb90d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-102ffc61-cdf5-45b7-a5bc-4f4432425581' class='xr-var-data-in' type='checkbox'><label for='data-102ffc61-cdf5-45b7-a5bc-4f4432425581' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-dbdf0471-a1df-4a6c-83e7-709c9af53871' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dbdf0471-a1df-4a6c-83e7-709c9af53871' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-26035f7f-7225-4e37-aad6-66192275fe87' class='xr-var-data-in' type='checkbox'><label for='data-26035f7f-7225-4e37-aad6-66192275fe87' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-58c61ac7-4a65-4557-a491-5b0d3a670578' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-58c61ac7-4a65-4557-a491-5b0d3a670578' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-ae4cff08-c3da-4627-97f2-4042064a4369' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ae4cff08-c3da-4627-97f2-4042064a4369' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-dc3535a8-104a-4a7f-b367-edd75b7690b2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dc3535a8-104a-4a7f-b367-edd75b7690b2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c329fa88-bc89-4b1c-a359-207e1f8e4bf2' class='xr-var-data-in' type='checkbox'><label for='data-c329fa88-bc89-4b1c-a359-207e1f8e4bf2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-63dab4cd-c709-47df-960e-dc7fffa4c310' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-63dab4cd-c709-47df-960e-dc7fffa4c310' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-516290ef-a9bf-413b-8d9e-5f5b05762a1d' class='xr-var-data-in' type='checkbox'><label for='data-516290ef-a9bf-413b-8d9e-5f5b05762a1d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-19ae7c77-7c72-4d8d-a54b-991b54504510' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-19ae7c77-7c72-4d8d-a54b-991b54504510' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8ef644ab-a708-4684-bcfb-84123b9821d4' class='xr-var-data-in' type='checkbox'><label for='data-8ef644ab-a708-4684-bcfb-84123b9821d4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -891,7 +837,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-6d4d66ef-88d1-4d1d-a0a2-76b142602455' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6d4d66ef-88d1-4d1d-a0a2-76b142602455' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cbe39890-b9dd-4c20-b2c6-bc8c143c8626' class='xr-var-data-in' type='checkbox'><label for='data-cbe39890-b9dd-4c20-b2c6-bc8c143c8626' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-7bfe3d6b-e953-49a2-b339-b1aec7ed14b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7bfe3d6b-e953-49a2-b339-b1aec7ed14b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ed081627-d2bf-4796-a390-011dcd9f60f1' class='xr-var-data-in' type='checkbox'><label for='data-ed081627-d2bf-4796-a390-011dcd9f60f1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -948,7 +894,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-eb05ec03-ba56-44aa-ba7e-b75597e62bdb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-eb05ec03-ba56-44aa-ba7e-b75597e62bdb' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-6e662f84-71d1-4791-a053-7db435b77b6b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6e662f84-71d1-4791-a053-7db435b77b6b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-72303716-135c-4e91-91c8-dcae8b537980' class='xr-var-data-in' type='checkbox'><label for='data-72303716-135c-4e91-91c8-dcae8b537980' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-331baff0-b883-4905-a890-895e6c3c65dd' class='xr-section-summary-in' type='checkbox'  checked><label for='section-331baff0-b883-4905-a890-895e6c3c65dd' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-1cf38291-cc64-4d08-ad01-a21879022279' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1cf38291-cc64-4d08-ad01-a21879022279' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-34aaa782-463d-47d8-879f-ba83b6f86ece' class='xr-var-data-in' type='checkbox'><label for='data-34aaa782-463d-47d8-879f-ba83b6f86ece' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1090,7 +1036,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-4ac1e9a9-a877-4abf-a3c0-e94fda481768' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4ac1e9a9-a877-4abf-a3c0-e94fda481768' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bd26c9b2-9814-482d-94c9-609d5c1a0e8a' class='xr-var-data-in' type='checkbox'><label for='data-bd26c9b2-9814-482d-94c9-609d5c1a0e8a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3e104e03-e5b4-4e4e-953b-5843beab077f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3e104e03-e5b4-4e4e-953b-5843beab077f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e78c3406-8466-4443-834e-3bbded5bbf5c' class='xr-var-data-in' type='checkbox'><label for='data-e78c3406-8466-4443-834e-3bbded5bbf5c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1232,7 +1178,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-1055cf2f-c4ca-4aa5-8de8-95a661081377' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1055cf2f-c4ca-4aa5-8de8-95a661081377' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2bf23c36-bb46-4302-98e9-322c02c726d4' class='xr-var-data-in' type='checkbox'><label for='data-2bf23c36-bb46-4302-98e9-322c02c726d4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c90d90fc-0a69-4147-af48-16ac824b2ef6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c90d90fc-0a69-4147-af48-16ac824b2ef6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7067130e-cf2e-49e5-a711-e101c3a1e099' class='xr-var-data-in' type='checkbox'><label for='data-7067130e-cf2e-49e5-a711-e101c3a1e099' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1374,7 +1320,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-28d71452-f3b2-4ac2-9434-0592ed5c1881' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-28d71452-f3b2-4ac2-9434-0592ed5c1881' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-451410f0-e250-4bcb-a7ab-0efdae8f9a9d' class='xr-var-data-in' type='checkbox'><label for='data-451410f0-e250-4bcb-a7ab-0efdae8f9a9d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ac4899cb-23e3-4a3a-87f6-5f22d45cea29' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ac4899cb-23e3-4a3a-87f6-5f22d45cea29' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9aaaf4c5-b868-4682-8669-879dbf3723b9' class='xr-var-data-in' type='checkbox'><label for='data-9aaaf4c5-b868-4682-8669-879dbf3723b9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1516,7 +1462,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-cf027299-3463-4a9e-8e58-0e0e5c14040f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cf027299-3463-4a9e-8e58-0e0e5c14040f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-239169d7-b2b9-459c-91e0-78a0e642b0b4' class='xr-var-data-in' type='checkbox'><label for='data-239169d7-b2b9-459c-91e0-78a0e642b0b4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-123d1c6b-0877-47f1-85ef-997984d99363' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-123d1c6b-0877-47f1-85ef-997984d99363' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-db480ab6-7da8-408a-a76f-30e7018e879a' class='xr-var-data-in' type='checkbox'><label for='data-db480ab6-7da8-408a-a76f-30e7018e879a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1658,7 +1604,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-d467442f-c229-4f6c-8bc8-399052ce2f2b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d467442f-c229-4f6c-8bc8-399052ce2f2b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a428ff98-037a-4d48-819e-2fee876ede2e' class='xr-var-data-in' type='checkbox'><label for='data-a428ff98-037a-4d48-819e-2fee876ede2e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-439a6dee-efbc-4375-81bb-4087553d38ec' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-439a6dee-efbc-4375-81bb-4087553d38ec' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-adff8e7a-d0c2-4fbf-9674-676561a0f90d' class='xr-var-data-in' type='checkbox'><label for='data-adff8e7a-d0c2-4fbf-9674-676561a0f90d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1800,7 +1746,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9d18aeb7-0932-458a-967e-c361c6d900ca' class='xr-section-summary-in' type='checkbox'  ><label for='section-9d18aeb7-0932-458a-967e-c361c6d900ca' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:58.202580</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-b67c4ffd-cfb3-49d3-ad4d-31821c6eb5dc' class='xr-section-summary-in' type='checkbox'  ><label for='section-b67c4ffd-cfb3-49d3-ad4d-31821c6eb5dc' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:26:12.089929</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1822,7 +1768,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:58.202580\n",
+       "    date_created:              2022-06-23T08:26:12.089929\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -1834,7 +1780,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1870,15 +1816,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "fc776f7f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:58.642544Z",
-     "iopub.status.busy": "2022-02-23T14:01:58.642043Z",
-     "iopub.status.idle": "2022-02-23T14:01:58.662415Z",
-     "shell.execute_reply": "2022-02-23T14:01:58.661670Z"
-    },
     "papermill": {
      "duration": 0.067604,
      "end_time": "2022-02-23T14:01:58.664824",
@@ -2269,7 +2209,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Attributes:\n",
        "    standard_name:  time\n",
-       "    bounds:         time_bnds</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'time'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-58fea2fa-cacf-4913-85a8-d1a6fd24c6df' class='xr-array-in' type='checkbox' checked><label for='section-58fea2fa-cacf-4913-85a8-d1a6fd24c6df' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>2018-05-15 2018-05-17 2018-05-19 ... 2018-07-28 2018-07-30 2018-08-01</span></div><div class='xr-array-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    bounds:         time_bnds</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'time'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-614061d8-8651-4ebd-8f2d-1ecd791665ad' class='xr-array-in' type='checkbox' checked><label for='section-614061d8-8651-4ebd-8f2d-1ecd791665ad' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>2018-05-15 2018-05-17 2018-05-19 ... 2018-07-28 2018-07-30 2018-08-01</span></div><div class='xr-array-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2289,7 +2229,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></div></li><li class='xr-section-item'><input id='section-b4108a11-545b-438e-9dfd-8a7d1a500b4b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b4108a11-545b-438e-9dfd-8a7d1a500b4b' class='xr-section-summary' >Coordinates: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-7ae4eec9-7194-4cc9-9802-a9fbdbaa673e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7ae4eec9-7194-4cc9-9802-a9fbdbaa673e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-79d2ec81-6fc6-47df-846d-de765568294f' class='xr-var-data-in' type='checkbox'><label for='data-79d2ec81-6fc6-47df-846d-de765568294f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></div></li><li class='xr-section-item'><input id='section-b4fcc68f-c047-477c-8825-b05b8bf5a1ab' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b4fcc68f-c047-477c-8825-b05b8bf5a1ab' class='xr-section-summary' >Coordinates: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-c0855a61-8852-4d5e-a327-852868227cb8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c0855a61-8852-4d5e-a327-852868227cb8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e21a5e7e-01c4-45a7-af53-90391e9e64cc' class='xr-var-data-in' type='checkbox'><label for='data-e21a5e7e-01c4-45a7-af53-90391e9e64cc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2309,7 +2249,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d7e6a149-83e9-4a7b-96d5-a869a1b8fc4d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d7e6a149-83e9-4a7b-96d5-a869a1b8fc4d' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5bdf9300-158c-4ee0-a2e4-3dc02518a84f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5bdf9300-158c-4ee0-a2e4-3dc02518a84f' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'time' (time: 40)>\n",
@@ -2341,7 +2281,7 @@
        "    bounds:         time_bnds"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2369,15 +2309,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "568a31d3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:58.848718Z",
-     "iopub.status.busy": "2022-02-23T14:01:58.847890Z",
-     "iopub.status.idle": "2022-02-23T14:01:58.854141Z",
-     "shell.execute_reply": "2022-02-23T14:01:58.853221Z"
-    },
     "papermill": {
      "duration": 0.052866,
      "end_time": "2022-02-23T14:01:58.855958",
@@ -2394,10 +2328,10 @@
        "<html><p>No requests made yet.</p></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7fd4610883a0>"
+       "<xcube_sh.observers._RequestStats at 0x7f2c74277970>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2425,15 +2359,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "f60c0ed1",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:59.041503Z",
-     "iopub.status.busy": "2022-02-23T14:01:59.040818Z",
-     "iopub.status.idle": "2022-02-23T14:01:59.067096Z",
-     "shell.execute_reply": "2022-02-23T14:01:59.066319Z"
-    },
     "papermill": {
      "duration": 0.072284,
      "end_time": "2022-02-23T14:01:59.069134",
@@ -2799,7 +2727,7 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray &#x27;B04&#x27; (time: 40, lat: 2048, lon: 5632)&gt;\n",
-       "dask.array&lt;open_dataset-fba156355677b33de08dcb3d77f083c4B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
+       "dask.array&lt;open_dataset-966100863c4431c3f6505c3ef6d688b6B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2813,7 +2741,7 @@
        "    bandwidth:     31.0\n",
        "    bandwidth_a:   31\n",
        "    bandwidth_b:   31\n",
-       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-099588cc-55dc-4229-8404-9143c845c8e4' class='xr-array-in' type='checkbox' checked><label for='section-099588cc-55dc-4229-8404-9143c845c8e4' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-c54bde74-9211-4d07-a04c-f802970ae6ce' class='xr-array-in' type='checkbox' checked><label for='section-c54bde74-9211-4d07-a04c-f802970ae6ce' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2955,7 +2883,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-a6b68b2d-db06-491c-8065-c0b1950f51c4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a6b68b2d-db06-491c-8065-c0b1950f51c4' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-b382a1d8-1fa1-4463-9be2-217c828a94ee' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b382a1d8-1fa1-4463-9be2-217c828a94ee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d541f0eb-6525-475c-b1ec-02d2f853ee46' class='xr-var-data-in' type='checkbox'><label for='data-d541f0eb-6525-475c-b1ec-02d2f853ee46' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-2d417d78-fd63-4997-b0b4-22b355531f4d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2d417d78-fd63-4997-b0b4-22b355531f4d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ec00d187-7c99-4dce-a801-5aaae59b8edc' class='xr-var-data-in' type='checkbox'><label for='data-ec00d187-7c99-4dce-a801-5aaae59b8edc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-9fa6e74f-8af3-478a-a37a-8f94c5ec6565' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9fa6e74f-8af3-478a-a37a-8f94c5ec6565' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-47c63f22-c60e-4937-a6fa-aea92b04c082' class='xr-var-data-in' type='checkbox'><label for='data-47c63f22-c60e-4937-a6fa-aea92b04c082' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-b154c56c-40c6-4f53-8f15-0cfd8d3a4fff' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b154c56c-40c6-4f53-8f15-0cfd8d3a4fff' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-38285b61-e3c6-448c-bfc5-4a9e874a4d3e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-38285b61-e3c6-448c-bfc5-4a9e874a4d3e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-81dfe74b-fa34-4971-82b1-92f1efe5c91e' class='xr-var-data-in' type='checkbox'><label for='data-81dfe74b-fa34-4971-82b1-92f1efe5c91e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-f1c54a68-2d16-4e38-bb5e-934c6708d789' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f1c54a68-2d16-4e38-bb5e-934c6708d789' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-00460e14-ca44-480b-b383-b5201b9447d3' class='xr-var-data-in' type='checkbox'><label for='data-00460e14-ca44-480b-b383-b5201b9447d3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-462667f4-a8b4-42b9-9260-86dbd286f830' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-462667f4-a8b4-42b9-9260-86dbd286f830' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-583e1430-f838-4ca4-a32d-ed15a5ccecdf' class='xr-var-data-in' type='checkbox'><label for='data-583e1430-f838-4ca4-a32d-ed15a5ccecdf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2975,11 +2903,11 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2781742d-2bda-422b-806b-ecb659dcec55' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2781742d-2bda-422b-806b-ecb659dcec55' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bd79c36d-9de0-4276-9b3d-2b6c4a371d82' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bd79c36d-9de0-4276-9b3d-2b6c4a371d82' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'B04' (time: 40, lat: 2048, lon: 5632)>\n",
-       "dask.array<open_dataset-fba156355677b33de08dcb3d77f083c4B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
+       "dask.array<open_dataset-966100863c4431c3f6505c3ef6d688b6B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2996,7 +2924,7 @@
        "    resolution:    10"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3007,15 +2935,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "007d305d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:59.173565Z",
-     "iopub.status.busy": "2022-02-23T14:01:59.173031Z",
-     "iopub.status.idle": "2022-02-23T14:02:18.073192Z",
-     "shell.execute_reply": "2022-02-23T14:02:18.072355Z"
-    },
     "papermill": {
      "duration": 18.96803,
      "end_time": "2022-02-23T14:02:18.082778",
@@ -3029,10 +2951,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fd4605e8df0>"
+       "<matplotlib.image.AxesImage at 0x7f2c7427dbe0>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -3073,15 +2995,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "7cadaf83",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:18.330044Z",
-     "iopub.status.busy": "2022-02-23T14:02:18.329454Z",
-     "iopub.status.idle": "2022-02-23T14:02:18.336247Z",
-     "shell.execute_reply": "2022-02-23T14:02:18.335267Z"
-    },
     "papermill": {
      "duration": 0.069173,
      "end_time": "2022-02-23T14:02:18.338170",
@@ -3095,13 +3011,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>271.75 ms</td></tr><tr><td>Request duration max:</td><td>578.74 ms</td></tr><tr><td>Request duration median:</td><td>404.02 ms</td></tr><tr><td>Request duration mean:</td><td>400.09 ms</td></tr><tr><td>Request duration std:</td><td>75.87 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>330.88 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>465.60 ms</td></tr><tr><td>Request duration mean:</td><td>512.72 ms</td></tr><tr><td>Request duration std:</td><td>212.22 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7fd46054da60>"
+       "<xcube_sh.observers._RequestStats at 0x7f2c74277c10>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3129,15 +3045,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "52d2a9a1",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:18.582321Z",
-     "iopub.status.busy": "2022-02-23T14:02:18.581901Z",
-     "iopub.status.idle": "2022-02-23T14:02:18.607988Z",
-     "shell.execute_reply": "2022-02-23T14:02:18.607242Z"
-    },
     "papermill": {
      "duration": 0.088546,
      "end_time": "2022-02-23T14:02:18.609981",
@@ -3503,7 +3413,7 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray &#x27;SCL&#x27; (time: 40, lat: 2048, lon: 5632)&gt;\n",
-       "dask.array&lt;open_dataset-fba156355677b33de08dcb3d77f083c4SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
+       "dask.array&lt;open_dataset-966100863c4431c3f6505c3ef6d688b6SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -3511,7 +3421,7 @@
        "Attributes:\n",
        "    sample_type:    UINT8\n",
        "    flag_values:    0,1,2,3,4,5,6,7,8,9,10,11\n",
-       "    flag_meanings:  no_data saturated_or_defective dark_area_pixels cloud_sha...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'SCL'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-c6d13d6d-d56b-4fe8-9717-c092b085cfd9' class='xr-array-in' type='checkbox' checked><label for='section-c6d13d6d-d56b-4fe8-9717-c092b085cfd9' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    flag_meanings:  no_data saturated_or_defective dark_area_pixels cloud_sha...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'SCL'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-0a9bd1c1-9260-46f2-a25e-3154fc58c6a6' class='xr-array-in' type='checkbox' checked><label for='section-0a9bd1c1-9260-46f2-a25e-3154fc58c6a6' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3653,7 +3563,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-7e4cb218-84d9-477f-bfbb-a2e4eb0240c7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7e4cb218-84d9-477f-bfbb-a2e4eb0240c7' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-4b3cddb9-c79a-46d4-917b-2f92cc2a0cd7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4b3cddb9-c79a-46d4-917b-2f92cc2a0cd7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ea1213c7-45cd-4ba5-974f-f3084391acc8' class='xr-var-data-in' type='checkbox'><label for='data-ea1213c7-45cd-4ba5-974f-f3084391acc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-31a74b74-c6c7-4960-b82c-5d3ceb634ba2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-31a74b74-c6c7-4960-b82c-5d3ceb634ba2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6df4b28f-6866-49e3-ba4f-8b0b0b11f8a6' class='xr-var-data-in' type='checkbox'><label for='data-6df4b28f-6866-49e3-ba4f-8b0b0b11f8a6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-909de608-1877-411e-b5b2-ce1e4004eb4a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-909de608-1877-411e-b5b2-ce1e4004eb4a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-74d6624d-b92c-4eef-afa3-11111ef958a0' class='xr-var-data-in' type='checkbox'><label for='data-74d6624d-b92c-4eef-afa3-11111ef958a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-dd71f7ac-9655-4bec-9068-65c6b905edb2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-dd71f7ac-9655-4bec-9068-65c6b905edb2' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-f8b02ae0-597c-4029-a612-665496bfb680' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f8b02ae0-597c-4029-a612-665496bfb680' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5a809a4d-5113-47fe-8410-f812024a4cde' class='xr-var-data-in' type='checkbox'><label for='data-5a809a4d-5113-47fe-8410-f812024a4cde' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-34094e42-c744-4148-b398-05833dfe8ece' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-34094e42-c744-4148-b398-05833dfe8ece' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a27a4c95-71cf-4eb7-8794-9e070d313b92' class='xr-var-data-in' type='checkbox'><label for='data-a27a4c95-71cf-4eb7-8794-9e070d313b92' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-d26c7c9d-f618-4068-a80b-a564893c7bd1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d26c7c9d-f618-4068-a80b-a564893c7bd1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bacba569-1f8e-4390-ab39-5fa50cf149ca' class='xr-var-data-in' type='checkbox'><label for='data-bacba569-1f8e-4390-ab39-5fa50cf149ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -3673,11 +3583,11 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2346336e-cd2a-4d21-ae1c-aab3c97669cd' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2346336e-cd2a-4d21-ae1c-aab3c97669cd' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b311f2b0-fed2-4058-a9f5-8b45f0e56ee7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b311f2b0-fed2-4058-a9f5-8b45f0e56ee7' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'SCL' (time: 40, lat: 2048, lon: 5632)>\n",
-       "dask.array<open_dataset-fba156355677b33de08dcb3d77f083c4SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
+       "dask.array<open_dataset-966100863c4431c3f6505c3ef6d688b6SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -3688,7 +3598,7 @@
        "    flag_meanings:  no_data saturated_or_defective dark_area_pixels cloud_sha..."
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3699,15 +3609,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "78d7ed3a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:18.750828Z",
-     "iopub.status.busy": "2022-02-23T14:02:18.750402Z",
-     "iopub.status.idle": "2022-02-23T14:02:18.755704Z",
-     "shell.execute_reply": "2022-02-23T14:02:18.754950Z"
-    },
     "papermill": {
      "duration": 0.070175,
      "end_time": "2022-02-23T14:02:18.758032",
@@ -3752,15 +3656,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "c50481ca",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:19.015968Z",
-     "iopub.status.busy": "2022-02-23T14:02:19.015459Z",
-     "iopub.status.idle": "2022-02-23T14:02:19.047018Z",
-     "shell.execute_reply": "2022-02-23T14:02:19.046265Z"
-    },
     "papermill": {
      "duration": 0.095624,
      "end_time": "2022-02-23T14:02:19.049206",
@@ -4130,7 +4028,7 @@
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
-       "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'water'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-9fd4d153-3a5a-42b3-95b9-131f2613b7ea' class='xr-array-in' type='checkbox' checked><label for='section-9fd4d153-3a5a-42b3-95b9-131f2613b7ea' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'water'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-d0e35cf2-1e27-481d-82d6-8686fe377992' class='xr-array-in' type='checkbox' checked><label for='section-d0e35cf2-1e27-481d-82d6-8686fe377992' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4272,7 +4170,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-4e9dd19c-105d-4af8-8165-76bc9a95c3bf' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4e9dd19c-105d-4af8-8165-76bc9a95c3bf' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-04ae2022-a1bf-462c-9c4b-a16330907136' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-04ae2022-a1bf-462c-9c4b-a16330907136' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6ceafb96-aaf9-4a12-98cf-b831463b38cf' class='xr-var-data-in' type='checkbox'><label for='data-6ceafb96-aaf9-4a12-98cf-b831463b38cf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-3400637c-0db5-4fce-aa1f-dd742732595b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3400637c-0db5-4fce-aa1f-dd742732595b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8c949ed8-ed34-4fa6-a333-ffc0f69f7875' class='xr-var-data-in' type='checkbox'><label for='data-8c949ed8-ed34-4fa6-a333-ffc0f69f7875' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-f25b98e0-3bd1-4487-9920-ee7858be5172' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f25b98e0-3bd1-4487-9920-ee7858be5172' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9296f907-59f8-4b44-9b49-21631bcbde29' class='xr-var-data-in' type='checkbox'><label for='data-9296f907-59f8-4b44-9b49-21631bcbde29' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-78512d1b-6bf6-4e83-afb4-1dc18b51d704' class='xr-section-summary-in' type='checkbox'  checked><label for='section-78512d1b-6bf6-4e83-afb4-1dc18b51d704' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-f7efbaa8-b80a-4ca8-a659-12abad5482b5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f7efbaa8-b80a-4ca8-a659-12abad5482b5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8562f02d-9ef7-4e7e-9ded-dd5996ef39de' class='xr-var-data-in' type='checkbox'><label for='data-8562f02d-9ef7-4e7e-9ded-dd5996ef39de' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-9a4e6f47-35e1-4ece-aa1f-7a1266ac8b80' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9a4e6f47-35e1-4ece-aa1f-7a1266ac8b80' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bee1f092-4072-4ff0-805e-29f63ac03df5' class='xr-var-data-in' type='checkbox'><label for='data-bee1f092-4072-4ff0-805e-29f63ac03df5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-ca4e7390-ce73-45a5-b9fe-1d340bdefb6f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ca4e7390-ce73-45a5-b9fe-1d340bdefb6f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b3c0e982-8523-4aa5-a72d-1687185ff893' class='xr-var-data-in' type='checkbox'><label for='data-b3c0e982-8523-4aa5-a72d-1687185ff893' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -4292,7 +4190,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-57c17e45-565c-4dbc-a791-5ce85bced371' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-57c17e45-565c-4dbc-a791-5ce85bced371' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-08b0c2ba-fd7a-43f5-b5ee-a5330218ef03' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-08b0c2ba-fd7a-43f5-b5ee-a5330218ef03' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'water' (time: 40, lat: 2048, lon: 5632)>\n",
@@ -4303,7 +4201,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4314,15 +4212,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "513b98db",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:19.183016Z",
-     "iopub.status.busy": "2022-02-23T14:02:19.182707Z",
-     "iopub.status.idle": "2022-02-23T14:02:32.114294Z",
-     "shell.execute_reply": "2022-02-23T14:02:32.113525Z"
-    },
     "papermill": {
      "duration": 13.005206,
      "end_time": "2022-02-23T14:02:32.116575",
@@ -4336,10 +4228,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fd46040ef70>"
+       "<matplotlib.image.AxesImage at 0x7f2c718c5a00>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -4363,15 +4255,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "id": "ce99df81",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:32.255842Z",
-     "iopub.status.busy": "2022-02-23T14:02:32.255317Z",
-     "iopub.status.idle": "2022-02-23T14:02:32.261437Z",
-     "shell.execute_reply": "2022-02-23T14:02:32.260751Z"
-    },
     "papermill": {
      "duration": 0.074995,
      "end_time": "2022-02-23T14:02:32.263246",
@@ -4385,13 +4271,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>214.10 ms</td></tr><tr><td>Request duration max:</td><td>578.74 ms</td></tr><tr><td>Request duration median:</td><td>320.63 ms</td></tr><tr><td>Request duration mean:</td><td>337.49 ms</td></tr><tr><td>Request duration std:</td><td>91.78 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>228.43 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>375.19 ms</td></tr><tr><td>Request duration mean:</td><td>445.81 ms</td></tr><tr><td>Request duration std:</td><td>220.63 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7fd460518fa0>"
+       "<xcube_sh.observers._RequestStats at 0x7f2c7183ebb0>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4419,15 +4305,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "id": "29c335d7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:32.535305Z",
-     "iopub.status.busy": "2022-02-23T14:02:32.534572Z",
-     "iopub.status.idle": "2022-02-23T14:02:32.607680Z",
-     "shell.execute_reply": "2022-02-23T14:02:32.607011Z"
-    },
     "papermill": {
      "duration": 0.142857,
      "end_time": "2022-02-23T14:02:32.611247",
@@ -4811,7 +4691,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:58.202580\n",
+       "    date_created:              2022-06-23T08:26:12.089929\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -4820,7 +4700,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-9ccd46db-7a90-4fde-be85-3a81f2154743' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-9ccd46db-7a90-4fde-be85-3a81f2154743' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-74bf2564-d80d-4fd4-941b-b575fece32c5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-74bf2564-d80d-4fd4-941b-b575fece32c5' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-32bdf6be-b7ad-467c-a3e8-40ef66188052' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-32bdf6be-b7ad-467c-a3e8-40ef66188052' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-db97e614-c186-4eda-ab04-c8ffdc906872' class='xr-var-data-in' type='checkbox'><label for='data-db97e614-c186-4eda-ab04-c8ffdc906872' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-234de8f7-7af6-4e54-9153-1b69a206489b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-234de8f7-7af6-4e54-9153-1b69a206489b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8d2e50c0-b33a-47c6-a697-a65343074ba7' class='xr-var-data-in' type='checkbox'><label for='data-8d2e50c0-b33a-47c6-a697-a65343074ba7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-91f83937-0740-4a5c-8e89-796865008590' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-91f83937-0740-4a5c-8e89-796865008590' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-96671d77-32ca-4e50-a5a3-98f5fb2095f9' class='xr-var-data-in' type='checkbox'><label for='data-96671d77-32ca-4e50-a5a3-98f5fb2095f9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-013ca78e-4db5-4512-b4b7-206a58c60422' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-013ca78e-4db5-4512-b4b7-206a58c60422' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-9a44e135-88cb-48af-b0cf-5c44ff52ec38' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9a44e135-88cb-48af-b0cf-5c44ff52ec38' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-95794825-bb1e-4ce6-803a-9ea1e7ae6624' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-95794825-bb1e-4ce6-803a-9ea1e7ae6624' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-98869e5a-8986-4397-818b-4484188ea7da' class='xr-var-data-in' type='checkbox'><label for='data-98869e5a-8986-4397-818b-4484188ea7da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-966bae3d-6d2c-4241-b6e0-70c792fc51ba' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-966bae3d-6d2c-4241-b6e0-70c792fc51ba' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cce9d8f5-201a-4aea-bc5f-0dcb963fb783' class='xr-var-data-in' type='checkbox'><label for='data-cce9d8f5-201a-4aea-bc5f-0dcb963fb783' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-af36d8b4-f209-45ca-9c20-5dc7cb6a1688' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-af36d8b4-f209-45ca-9c20-5dc7cb6a1688' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-76e13112-842d-4220-8566-df97640f599b' class='xr-var-data-in' type='checkbox'><label for='data-76e13112-842d-4220-8566-df97640f599b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -4840,7 +4720,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-06d73034-3608-4a2d-a5fa-75fa086f4912' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06d73034-3608-4a2d-a5fa-75fa086f4912' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4f27598f-3c28-4b53-8d9c-c2f3185b7068' class='xr-var-data-in' type='checkbox'><label for='data-4f27598f-3c28-4b53-8d9c-c2f3185b7068' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-2b248dff-80a8-4bbf-8db7-593c42f4852f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2b248dff-80a8-4bbf-8db7-593c42f4852f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b8410b84-2699-4667-b0d1-0d91fc04cd4e' class='xr-var-data-in' type='checkbox'><label for='data-b8410b84-2699-4667-b0d1-0d91fc04cd4e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4897,7 +4777,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-a0301851-ebac-4de7-ab0f-19fcf22c6d2b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a0301851-ebac-4de7-ab0f-19fcf22c6d2b' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-5e99eff0-66ef-4190-9465-a08f3b7f6bfe' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5e99eff0-66ef-4190-9465-a08f3b7f6bfe' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8c8085bb-4418-42ec-927f-444dd45a62f7' class='xr-var-data-in' type='checkbox'><label for='data-8c8085bb-4418-42ec-927f-444dd45a62f7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-e0317022-c60d-42c8-aefd-fb1a05c44899' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e0317022-c60d-42c8-aefd-fb1a05c44899' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-d3bdb77b-915c-4814-993e-06c3388a2df6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d3bdb77b-915c-4814-993e-06c3388a2df6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2a09c3b3-be8b-4c9f-814d-9972535207d4' class='xr-var-data-in' type='checkbox'><label for='data-2a09c3b3-be8b-4c9f-814d-9972535207d4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5039,7 +4919,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-27be5988-d15c-40b6-ba0e-76dca721e24d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-27be5988-d15c-40b6-ba0e-76dca721e24d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-55383a68-2d67-434f-8006-0ba62b83c9fd' class='xr-var-data-in' type='checkbox'><label for='data-55383a68-2d67-434f-8006-0ba62b83c9fd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-2e07cafe-3c0c-45c1-939a-6150afec755e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2e07cafe-3c0c-45c1-939a-6150afec755e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7f7b9e16-ef54-4434-ae79-4db0249764a5' class='xr-var-data-in' type='checkbox'><label for='data-7f7b9e16-ef54-4434-ae79-4db0249764a5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5181,7 +5061,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-0c0dfd25-77b3-4476-ba19-2010b3adb37a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0c0dfd25-77b3-4476-ba19-2010b3adb37a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0c2d878a-265a-49fa-bbe9-63c06223246e' class='xr-var-data-in' type='checkbox'><label for='data-0c2d878a-265a-49fa-bbe9-63c06223246e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a5162d60-ecb0-43d4-b8e0-64953225ae22' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a5162d60-ecb0-43d4-b8e0-64953225ae22' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a6a50434-05b2-45d9-ab54-85383e91b85b' class='xr-var-data-in' type='checkbox'><label for='data-a6a50434-05b2-45d9-ab54-85383e91b85b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5323,7 +5203,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3461ccf5-bd88-445c-99ee-a4121b0f1fa1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3461ccf5-bd88-445c-99ee-a4121b0f1fa1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0c127eee-d872-45ff-a5b3-e8ee64e2f6bc' class='xr-var-data-in' type='checkbox'><label for='data-0c127eee-d872-45ff-a5b3-e8ee64e2f6bc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-5ee13139-8da8-4ca0-a3cd-ec576bb8a7b8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5ee13139-8da8-4ca0-a3cd-ec576bb8a7b8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-96fda146-ee4a-4b1a-b512-b21bf715b68e' class='xr-var-data-in' type='checkbox'><label for='data-96fda146-ee4a-4b1a-b512-b21bf715b68e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5465,7 +5345,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-9916eedc-4dd6-4718-bdcc-7b0866413e8a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9916eedc-4dd6-4718-bdcc-7b0866413e8a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8e093e01-6339-42d3-aa49-db54cb46b193' class='xr-var-data-in' type='checkbox'><label for='data-8e093e01-6339-42d3-aa49-db54cb46b193' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e3bc36e0-1286-434e-83d6-6c961720fed3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e3bc36e0-1286-434e-83d6-6c961720fed3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-285583d6-6fe0-4122-ae68-653ca2695c63' class='xr-var-data-in' type='checkbox'><label for='data-285583d6-6fe0-4122-ae68-653ca2695c63' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5607,7 +5487,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-43e079f7-920d-45e9-a307-a441488ea7cc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-43e079f7-920d-45e9-a307-a441488ea7cc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f259b76b-ba33-420a-8381-4d52f97f1f03' class='xr-var-data-in' type='checkbox'><label for='data-f259b76b-ba33-420a-8381-4d52f97f1f03' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3804f412-9106-41bf-8721-e0ba23e82687' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3804f412-9106-41bf-8721-e0ba23e82687' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bee1b657-0918-4287-b05e-55cb334bf2d9' class='xr-var-data-in' type='checkbox'><label for='data-bee1b657-0918-4287-b05e-55cb334bf2d9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5749,7 +5629,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-7ccacb86-9ea6-42ba-97fc-a5f27c8b9cca' class='xr-section-summary-in' type='checkbox'  ><label for='section-7ccacb86-9ea6-42ba-97fc-a5f27c8b9cca' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:58.202580</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-faa6d25a-c5d7-47ea-96a3-f6aade95ff74' class='xr-section-summary-in' type='checkbox'  ><label for='section-faa6d25a-c5d7-47ea-96a3-f6aade95ff74' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:26:12.089929</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -5771,7 +5651,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:58.202580\n",
+       "    date_created:              2022-06-23T08:26:12.089929\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -5783,7 +5663,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5795,15 +5675,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "id": "237bbf4f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:32.753831Z",
-     "iopub.status.busy": "2022-02-23T14:02:32.753425Z",
-     "iopub.status.idle": "2022-02-23T14:02:34.068899Z",
-     "shell.execute_reply": "2022-02-23T14:02:34.068234Z"
-    },
     "papermill": {
      "duration": 1.391156,
      "end_time": "2022-02-23T14:02:34.075389",
@@ -5817,10 +5691,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fd460369a00>"
+       "<matplotlib.image.AxesImage at 0x7f2c71761d00>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -5844,15 +5718,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "id": "c73dd948",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:34.233854Z",
-     "iopub.status.busy": "2022-02-23T14:02:34.233214Z",
-     "iopub.status.idle": "2022-02-23T14:02:34.245158Z",
-     "shell.execute_reply": "2022-02-23T14:02:34.244156Z"
-    },
     "papermill": {
      "duration": 0.089936,
      "end_time": "2022-02-23T14:02:34.247385",
@@ -5866,13 +5734,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>214.10 ms</td></tr><tr><td>Request duration max:</td><td>578.74 ms</td></tr><tr><td>Request duration median:</td><td>320.63 ms</td></tr><tr><td>Request duration mean:</td><td>337.49 ms</td></tr><tr><td>Request duration std:</td><td>91.78 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>228.43 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>375.19 ms</td></tr><tr><td>Request duration mean:</td><td>445.81 ms</td></tr><tr><td>Request duration std:</td><td>220.63 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7fd4605181f0>"
+       "<xcube_sh.observers._RequestStats at 0x7f2c716e1e20>"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5902,15 +5770,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "id": "fed878d6",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:34.570631Z",
-     "iopub.status.busy": "2022-02-23T14:02:34.570364Z",
-     "iopub.status.idle": "2022-02-23T14:02:34.607987Z",
-     "shell.execute_reply": "2022-02-23T14:02:34.607157Z"
-    },
     "papermill": {
      "duration": 0.119794,
      "end_time": "2022-02-23T14:02:34.610158",
@@ -6283,7 +6145,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Attributes:\n",
        "    long_name:  Maximum Chlorophyll Index\n",
-       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-aa007f84-176d-41b8-8f7d-4e0d781a177a' class='xr-array-in' type='checkbox' checked><label for='section-aa007f84-176d-41b8-8f7d-4e0d781a177a' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-64aa31ad-6620-40a7-a761-c4dfe832548c' class='xr-array-in' type='checkbox' checked><label for='section-64aa31ad-6620-40a7-a761-c4dfe832548c' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -6425,7 +6287,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-8a283d9a-5716-4a63-ac41-62e874349db0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8a283d9a-5716-4a63-ac41-62e874349db0' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-4fcb91c1-3026-46d6-8ad5-b219a9abdbd6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4fcb91c1-3026-46d6-8ad5-b219a9abdbd6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d1659f73-c799-4468-8b57-20815de333d3' class='xr-var-data-in' type='checkbox'><label for='data-d1659f73-c799-4468-8b57-20815de333d3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-46e53d8a-fd00-4d5f-9d56-d5ec44cc5139' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-46e53d8a-fd00-4d5f-9d56-d5ec44cc5139' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a8e090b0-61b9-43b7-a621-7176c8454d05' class='xr-var-data-in' type='checkbox'><label for='data-a8e090b0-61b9-43b7-a621-7176c8454d05' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-2fdc2a6d-4e9c-4701-9042-30deaaf81e7a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2fdc2a6d-4e9c-4701-9042-30deaaf81e7a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fa8c0204-7e22-4768-9440-5e37c499bcc5' class='xr-var-data-in' type='checkbox'><label for='data-fa8c0204-7e22-4768-9440-5e37c499bcc5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-dbeb3fc7-b9c8-4204-8787-95d512efc187' class='xr-section-summary-in' type='checkbox'  checked><label for='section-dbeb3fc7-b9c8-4204-8787-95d512efc187' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-453e49e1-51f8-4331-913a-8ba5ac2128c8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-453e49e1-51f8-4331-913a-8ba5ac2128c8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b4dda620-3d78-4acf-b948-ab900ef831da' class='xr-var-data-in' type='checkbox'><label for='data-b4dda620-3d78-4acf-b948-ab900ef831da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-07863e9d-01f2-4656-8be0-5bdda1edbc29' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-07863e9d-01f2-4656-8be0-5bdda1edbc29' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-536b5a8b-bc5a-4f0f-a40f-f7acb61d7ade' class='xr-var-data-in' type='checkbox'><label for='data-536b5a8b-bc5a-4f0f-a40f-f7acb61d7ade' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-0b5f9bc7-474e-4c1b-9b95-8b6140bc7bb3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0b5f9bc7-474e-4c1b-9b95-8b6140bc7bb3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-21473d59-6237-47a2-ac64-6affeb3373f3' class='xr-var-data-in' type='checkbox'><label for='data-21473d59-6237-47a2-ac64-6affeb3373f3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -6445,7 +6307,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7208c9f2-fdbf-440e-ad48-4e1b2f49abe4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7208c9f2-fdbf-440e-ad48-4e1b2f49abe4' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bbd039cd-370f-4e8e-bb49-ffe5ad4e5f63' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bbd039cd-370f-4e8e-bb49-ffe5ad4e5f63' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray (time: 40, lat: 2048, lon: 5632)>\n",
@@ -6459,7 +6321,7 @@
        "    units:      unitless"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6502,15 +6364,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "id": "26333b09",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:35.048349Z",
-     "iopub.status.busy": "2022-02-23T14:02:35.047314Z",
-     "iopub.status.idle": "2022-02-23T14:02:35.116796Z",
-     "shell.execute_reply": "2022-02-23T14:02:35.115759Z"
-    },
     "papermill": {
      "duration": 0.15091,
      "end_time": "2022-02-23T14:02:35.120069",
@@ -6894,7 +6750,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:58.202580\n",
+       "    date_created:              2022-06-23T08:26:12.089929\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -6903,7 +6759,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1d87c368-85d4-4334-b848-5b31856b5256' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1d87c368-85d4-4334-b848-5b31856b5256' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-e3a5ddd5-a12a-4994-a19b-05c52e9d0b40' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e3a5ddd5-a12a-4994-a19b-05c52e9d0b40' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-7ece49bc-a8f2-4003-a4e3-5ab2eaa2fb15' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7ece49bc-a8f2-4003-a4e3-5ab2eaa2fb15' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-71159c73-17f0-4621-84e5-f4f471abe985' class='xr-var-data-in' type='checkbox'><label for='data-71159c73-17f0-4621-84e5-f4f471abe985' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-90cbe7bf-3fe2-408b-b776-776b5e7683d1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-90cbe7bf-3fe2-408b-b776-776b5e7683d1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a672a1c1-ba68-46c2-a2df-4efaa8666447' class='xr-var-data-in' type='checkbox'><label for='data-a672a1c1-ba68-46c2-a2df-4efaa8666447' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-cb6c1503-f535-4b12-90d3-46468e30c372' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cb6c1503-f535-4b12-90d3-46468e30c372' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-420750c8-9052-4e1c-ae22-3fd4efa33b7b' class='xr-var-data-in' type='checkbox'><label for='data-420750c8-9052-4e1c-ae22-3fd4efa33b7b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-13ce7ee6-edc4-4ec5-bf0c-0c61114b6c6a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-13ce7ee6-edc4-4ec5-bf0c-0c61114b6c6a' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-90d94838-2b47-4851-ac99-f59c71c3566b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-90d94838-2b47-4851-ac99-f59c71c3566b' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-d6b88ea6-45eb-4d18-8fcf-e23045ee814d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d6b88ea6-45eb-4d18-8fcf-e23045ee814d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f58c2d1d-7fff-4d83-9471-670007141bb0' class='xr-var-data-in' type='checkbox'><label for='data-f58c2d1d-7fff-4d83-9471-670007141bb0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-852b8b9f-7e12-4d24-b966-7d7e1bd80ccc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-852b8b9f-7e12-4d24-b966-7d7e1bd80ccc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c248e8f8-24d8-43f8-9001-aa3be90b64b2' class='xr-var-data-in' type='checkbox'><label for='data-c248e8f8-24d8-43f8-9001-aa3be90b64b2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-7eb535cb-149d-4173-b452-d25738f01b42' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7eb535cb-149d-4173-b452-d25738f01b42' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e4d60622-30bb-49cf-a253-86a24c5dd0a2' class='xr-var-data-in' type='checkbox'><label for='data-e4d60622-30bb-49cf-a253-86a24c5dd0a2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -6923,7 +6779,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-692cd9b0-667d-4266-b50b-417516a82216' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-692cd9b0-667d-4266-b50b-417516a82216' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ac702c1f-fadc-4a37-8cb4-145e888d9f44' class='xr-var-data-in' type='checkbox'><label for='data-ac702c1f-fadc-4a37-8cb4-145e888d9f44' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-06f17dc7-719d-40ac-8bda-56186075dce1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06f17dc7-719d-40ac-8bda-56186075dce1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ccf107d-3477-4e90-a864-db81c6536383' class='xr-var-data-in' type='checkbox'><label for='data-2ccf107d-3477-4e90-a864-db81c6536383' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -6980,7 +6836,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-2b36f34c-5955-456f-98b0-bc9850824696' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2b36f34c-5955-456f-98b0-bc9850824696' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-bea5f226-071f-49f6-b311-992d53c91737' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bea5f226-071f-49f6-b311-992d53c91737' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2bea354e-c337-4ea4-9813-d3d3a6369c46' class='xr-var-data-in' type='checkbox'><label for='data-2bea354e-c337-4ea4-9813-d3d3a6369c46' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-b7c16423-5e08-42e9-b4be-24dd22a4a307' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b7c16423-5e08-42e9-b4be-24dd22a4a307' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-684bb5de-941f-477e-822f-69f1c325a858' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-684bb5de-941f-477e-822f-69f1c325a858' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5757dd5c-f162-4398-9122-40bc6c8fff09' class='xr-var-data-in' type='checkbox'><label for='data-5757dd5c-f162-4398-9122-40bc6c8fff09' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7122,7 +6978,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ec8b1290-52d8-45bd-8ab4-50c725501eaf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ec8b1290-52d8-45bd-8ab4-50c725501eaf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-29df5fa1-b054-44c6-bab1-8acfd325e964' class='xr-var-data-in' type='checkbox'><label for='data-29df5fa1-b054-44c6-bab1-8acfd325e964' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-8bf919ba-0456-482e-995a-18447c8a7cd0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8bf919ba-0456-482e-995a-18447c8a7cd0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2f5f386d-c463-4b97-ac30-9530b404de2d' class='xr-var-data-in' type='checkbox'><label for='data-2f5f386d-c463-4b97-ac30-9530b404de2d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7264,7 +7120,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-05ddc292-71bb-43d5-bb39-8eb56cb0398d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-05ddc292-71bb-43d5-bb39-8eb56cb0398d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-20dbf9db-8497-4a92-ae1b-dd744e80fe7d' class='xr-var-data-in' type='checkbox'><label for='data-20dbf9db-8497-4a92-ae1b-dd744e80fe7d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-aa899510-a313-4d9d-8324-f47557f9e034' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aa899510-a313-4d9d-8324-f47557f9e034' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8aef20d-cac3-40e4-837e-951a8f8172b7' class='xr-var-data-in' type='checkbox'><label for='data-f8aef20d-cac3-40e4-837e-951a8f8172b7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7406,7 +7262,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-be15f06e-42f7-4634-9b00-974b72e4371e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-be15f06e-42f7-4634-9b00-974b72e4371e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5a476142-82e3-49e6-ab78-9a18e34d425f' class='xr-var-data-in' type='checkbox'><label for='data-5a476142-82e3-49e6-ab78-9a18e34d425f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a651a34d-e85b-4d89-89df-3d80ea09a8bb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a651a34d-e85b-4d89-89df-3d80ea09a8bb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b5661052-f49f-4046-aec1-a1c5cb495a23' class='xr-var-data-in' type='checkbox'><label for='data-b5661052-f49f-4046-aec1-a1c5cb495a23' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7548,7 +7404,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-d7a61ddd-b221-4aaa-b2a9-e64f66d47d4e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d7a61ddd-b221-4aaa-b2a9-e64f66d47d4e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e85e7235-6d36-45a8-b0a6-fa747ae92dcf' class='xr-var-data-in' type='checkbox'><label for='data-e85e7235-6d36-45a8-b0a6-fa747ae92dcf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-91dab7b5-3646-4a1c-9c69-6ecb62fc2ff2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-91dab7b5-3646-4a1c-9c69-6ecb62fc2ff2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0d193712-47dc-4172-a4d8-0cb445fff277' class='xr-var-data-in' type='checkbox'><label for='data-0d193712-47dc-4172-a4d8-0cb445fff277' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7690,7 +7546,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-8b30dd8a-5a1a-4796-8fe1-58f9fbe8628c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8b30dd8a-5a1a-4796-8fe1-58f9fbe8628c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-25166ac5-2b62-45e2-a440-b73a240462a1' class='xr-var-data-in' type='checkbox'><label for='data-25166ac5-2b62-45e2-a440-b73a240462a1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-344e5d90-ddc6-4de2-9c03-ba490d80f45c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-344e5d90-ddc6-4de2-9c03-ba490d80f45c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0f41ada5-4a61-4f85-b3ef-2a32042ff2ea' class='xr-var-data-in' type='checkbox'><label for='data-0f41ada5-4a61-4f85-b3ef-2a32042ff2ea' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7832,7 +7688,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-a2dbbddd-a06e-4ba7-bf4d-9ac716dbbe3a' class='xr-section-summary-in' type='checkbox'  ><label for='section-a2dbbddd-a06e-4ba7-bf4d-9ac716dbbe3a' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:01:58.202580</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-534e2f99-07e0-425e-b11e-f8b69ebf2a7e' class='xr-section-summary-in' type='checkbox'  ><label for='section-534e2f99-07e0-425e-b11e-f8b69ebf2a7e' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:26:12.089929</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -7854,7 +7710,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-02-23T14:01:58.202580\n",
+       "    date_created:              2022-06-23T08:26:12.089929\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -7866,7 +7722,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7878,15 +7734,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "3e773cd7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:35.292450Z",
-     "iopub.status.busy": "2022-02-23T14:02:35.291747Z",
-     "iopub.status.idle": "2022-02-23T14:02:35.323173Z",
-     "shell.execute_reply": "2022-02-23T14:02:35.322481Z"
-    },
     "papermill": {
      "duration": 0.114288,
      "end_time": "2022-02-23T14:02:35.325381",
@@ -8259,7 +8109,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Attributes:\n",
        "    long_name:  Normalized Difference Vegetation Index\n",
-       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-4939fa1c-8671-41bf-b5e9-f9500bd27ef1' class='xr-array-in' type='checkbox' checked><label for='section-4939fa1c-8671-41bf-b5e9-f9500bd27ef1' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-744957f9-b3dc-48dc-8bd6-74c856803f50' class='xr-array-in' type='checkbox' checked><label for='section-744957f9-b3dc-48dc-8bd6-74c856803f50' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -8401,7 +8251,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-fef2ab4a-222e-4fdc-99c1-bfb8bb813969' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fef2ab4a-222e-4fdc-99c1-bfb8bb813969' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-0c4a00d9-b476-4fa6-b0f1-501115bf7a23' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0c4a00d9-b476-4fa6-b0f1-501115bf7a23' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-30a6944d-7a9c-4fdc-813d-191332ec7fbb' class='xr-var-data-in' type='checkbox'><label for='data-30a6944d-7a9c-4fdc-813d-191332ec7fbb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-939e5b64-b396-4baf-8cd6-77d737842aae' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-939e5b64-b396-4baf-8cd6-77d737842aae' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ac2ed630-7d93-4ae5-b018-7925acccd0f4' class='xr-var-data-in' type='checkbox'><label for='data-ac2ed630-7d93-4ae5-b018-7925acccd0f4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-177d0f7d-5ea9-449a-985f-3f24631bc3c0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-177d0f7d-5ea9-449a-985f-3f24631bc3c0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e64449bd-aa10-4cca-bed2-c7048614535e' class='xr-var-data-in' type='checkbox'><label for='data-e64449bd-aa10-4cca-bed2-c7048614535e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-f790b19d-829d-4b2b-ada4-43c511420975' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f790b19d-829d-4b2b-ada4-43c511420975' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-9b25de73-dbd4-4549-b99e-a0a9247d83d3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9b25de73-dbd4-4549-b99e-a0a9247d83d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9a16a034-e635-4484-9f4a-6e6fdb819c7e' class='xr-var-data-in' type='checkbox'><label for='data-9a16a034-e635-4484-9f4a-6e6fdb819c7e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-cbcdbadd-92aa-46bb-bd6f-b0b61ea09cc4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cbcdbadd-92aa-46bb-bd6f-b0b61ea09cc4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-84b969de-2fe8-4429-b881-89a3d22b4225' class='xr-var-data-in' type='checkbox'><label for='data-84b969de-2fe8-4429-b881-89a3d22b4225' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-83609632-5fcf-4ef6-9ea4-c22fb887d261' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-83609632-5fcf-4ef6-9ea4-c22fb887d261' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0b0b6faa-b958-4e0e-a7e6-94c6a86161ce' class='xr-var-data-in' type='checkbox'><label for='data-0b0b6faa-b958-4e0e-a7e6-94c6a86161ce' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -8421,7 +8271,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d97431b7-2649-4798-a50a-a38859b0dafa' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d97431b7-2649-4798-a50a-a38859b0dafa' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8f5f4432-4a87-45a8-8074-ecd80ee98a73' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8f5f4432-4a87-45a8-8074-ecd80ee98a73' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray (time: 40, lat: 2048, lon: 5632)>\n",
@@ -8435,7 +8285,7 @@
        "    units:      unitless"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8451,15 +8301,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "id": "307c418a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:35.514719Z",
-     "iopub.status.busy": "2022-02-23T14:02:35.514145Z",
-     "iopub.status.idle": "2022-02-23T14:02:35.557720Z",
-     "shell.execute_reply": "2022-02-23T14:02:35.556860Z"
-    },
     "papermill": {
      "duration": 0.134239,
      "end_time": "2022-02-23T14:02:35.559795",
@@ -8832,7 +8676,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Data variables:\n",
        "    mci      (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;\n",
-       "    ndvi     (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-6363c33a-afaa-40f3-9af1-80ed7eafc7dd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-6363c33a-afaa-40f3-9af1-80ed7eafc7dd' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span class='xr-has-index'>time</span>: 40</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-352164e3-5d81-47a9-8176-3d0c869b8be0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-352164e3-5d81-47a9-8176-3d0c869b8be0' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-9cabd3d2-9fce-4bda-a9d4-eb23f5d0b17d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9cabd3d2-9fce-4bda-a9d4-eb23f5d0b17d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c43203fa-76b3-41b2-bbc7-5ba47ec9261d' class='xr-var-data-in' type='checkbox'><label for='data-c43203fa-76b3-41b2-bbc7-5ba47ec9261d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-9a45ad2d-643c-496f-b17b-5dde94a46c54' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9a45ad2d-643c-496f-b17b-5dde94a46c54' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2d6fce4f-010e-4034-bc0d-cb1f851fbbc3' class='xr-var-data-in' type='checkbox'><label for='data-2d6fce4f-010e-4034-bc0d-cb1f851fbbc3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-b07c60e9-58fc-471e-9a86-0f5b800df673' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b07c60e9-58fc-471e-9a86-0f5b800df673' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e4c8dc50-90af-4a92-ba3d-b3235400d16d' class='xr-var-data-in' type='checkbox'><label for='data-e4c8dc50-90af-4a92-ba3d-b3235400d16d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    ndvi     (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-8593947c-41ea-47fd-93a8-4c8d8a6506d7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-8593947c-41ea-47fd-93a8-4c8d8a6506d7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span class='xr-has-index'>time</span>: 40</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-884887b8-81fb-4932-a8c2-32df5d758c71' class='xr-section-summary-in' type='checkbox'  checked><label for='section-884887b8-81fb-4932-a8c2-32df5d758c71' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-b929484b-ad00-4f82-8b4c-6a33008a1f27' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b929484b-ad00-4f82-8b4c-6a33008a1f27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-23042813-248e-4c2a-adb7-0cd5d3f31965' class='xr-var-data-in' type='checkbox'><label for='data-23042813-248e-4c2a-adb7-0cd5d3f31965' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-bb941c30-c391-4607-a62f-4b372a92df43' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bb941c30-c391-4607-a62f-4b372a92df43' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c752d7e8-e342-4786-8ae2-448e08528c4f' class='xr-var-data-in' type='checkbox'><label for='data-c752d7e8-e342-4786-8ae2-448e08528c4f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-21dd0c2c-d49a-41a5-bf99-a80e7e05d361' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-21dd0c2c-d49a-41a5-bf99-a80e7e05d361' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d0fe33ba-77eb-4b50-a93d-a32874e8df75' class='xr-var-data-in' type='checkbox'><label for='data-d0fe33ba-77eb-4b50-a93d-a32874e8df75' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -8852,7 +8696,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e8a90d50-9084-47f4-87fd-3a54576ae310' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e8a90d50-9084-47f4-87fd-3a54576ae310' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>mci</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-dff1d0de-4e5c-436d-9c59-4f9f29473537' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dff1d0de-4e5c-436d-9c59-4f9f29473537' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fe1b5e5c-9b90-4769-8301-34a56fc24192' class='xr-var-data-in' type='checkbox'><label for='data-fe1b5e5c-9b90-4769-8301-34a56fc24192' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1649f110-6350-4bdd-b837-b65e17424470' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1649f110-6350-4bdd-b837-b65e17424470' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>mci</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-7ce22924-30ce-4202-8c5d-7c268fc1495c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7ce22924-30ce-4202-8c5d-7c268fc1495c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-251ccc68-7575-4f0d-b400-afe9ab2c0e1d' class='xr-var-data-in' type='checkbox'><label for='data-251ccc68-7575-4f0d-b400-afe9ab2c0e1d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -8994,7 +8838,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>ndvi</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-d6bbce44-51db-431d-8a7a-bf9545ef8c6b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d6bbce44-51db-431d-8a7a-bf9545ef8c6b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b919b0fc-cd7c-414b-b5e6-cf666b2f8aac' class='xr-var-data-in' type='checkbox'><label for='data-b919b0fc-cd7c-414b-b5e6-cf666b2f8aac' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>ndvi</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e444f4f9-6824-4c2f-8170-ec5407e448b3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e444f4f9-6824-4c2f-8170-ec5407e448b3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-acb426bb-121d-4bed-ab6f-a7cbe38d37e5' class='xr-var-data-in' type='checkbox'><label for='data-acb426bb-121d-4bed-ab6f-a7cbe38d37e5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -9136,7 +8980,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-ee5c8cc5-0f5e-4400-9549-6f983783d964' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-ee5c8cc5-0f5e-4400-9549-6f983783d964' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-0fb5a36d-f1a8-4fe3-8f92-86058624cc9b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-0fb5a36d-f1a8-4fe3-8f92-86058624cc9b' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -9150,7 +8994,7 @@
        "    ndvi     (time, lat, lon) float32 dask.array<chunksize=(1, 512, 512), meta=np.ndarray>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9162,15 +9006,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "id": "d898c3af",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:02:35.744383Z",
-     "iopub.status.busy": "2022-02-23T14:02:35.743097Z",
-     "iopub.status.idle": "2022-02-23T14:03:54.901424Z",
-     "shell.execute_reply": "2022-02-23T14:03:54.900600Z"
-    },
     "papermill": {
      "duration": 79.26467,
      "end_time": "2022-02-23T14:03:54.912452",
@@ -9184,10 +9022,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fd4603989a0>"
+       "<matplotlib.image.AxesImage at 0x7f2c7163afd0>"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -9211,15 +9049,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "id": "0d0aad9d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:03:55.117384Z",
-     "iopub.status.busy": "2022-02-23T14:03:55.116779Z",
-     "iopub.status.idle": "2022-02-23T14:03:55.123613Z",
-     "shell.execute_reply": "2022-02-23T14:03:55.122758Z"
-    },
     "papermill": {
      "duration": 0.108616,
      "end_time": "2022-02-23T14:03:55.125594",
@@ -9233,13 +9065,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>264</td></tr><tr><td>Request duration min:</td><td>190.41 ms</td></tr><tr><td>Request duration max:</td><td>1692.49 ms</td></tr><tr><td>Request duration median:</td><td>363.88 ms</td></tr><tr><td>Request duration mean:</td><td>404.42 ms</td></tr><tr><td>Request duration std:</td><td>195.74 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>264</td></tr><tr><td>Request duration min:</td><td>228.43 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>394.58 ms</td></tr><tr><td>Request duration mean:</td><td>465.00 ms</td></tr><tr><td>Request duration std:</td><td>222.04 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7fd4602946a0>"
+       "<xcube_sh.observers._RequestStats at 0x7f2c7172f4f0>"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9247,13 +9079,21 @@
    "source": [
     "request_collector.stats"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c18f093e-e910-46db-ab3b-f3c9c1e8c8fb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "EDC 2022.02 (Python3)",
    "language": "python",
-   "name": "python3"
+   "name": "edc"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/curated/EDC_Sentinel_Hub-XCUBE_integration.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-XCUBE_integration.ipynb
@@ -6,16 +6,16 @@
    "id": "2a23ff24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:54.016812Z",
-     "iopub.status.busy": "2022-02-23T14:01:54.015939Z",
-     "iopub.status.idle": "2022-02-23T14:01:54.136665Z",
-     "shell.execute_reply": "2022-02-23T14:01:54.135754Z"
+     "iopub.execute_input": "2022-06-23T10:16:04.882514Z",
+     "iopub.status.busy": "2022-06-23T10:16:04.882175Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.466606Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.465966Z"
     },
     "papermill": {
-     "duration": 0.162188,
-     "end_time": "2022-02-23T14:01:54.138783",
+     "duration": 40.639329,
+     "end_time": "2022-06-23T10:16:45.488991",
      "exception": false,
-     "start_time": "2022-02-23T14:01:53.976595",
+     "start_time": "2022-06-23T10:16:04.849662",
      "status": "completed"
     },
     "tags": []
@@ -55,16 +55,16 @@
    "id": "0f94e79d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-02-23T14:01:54.216597Z",
-     "iopub.status.busy": "2022-02-23T14:01:54.216291Z",
-     "iopub.status.idle": "2022-02-23T14:01:54.224920Z",
-     "shell.execute_reply": "2022-02-23T14:01:54.223935Z"
+     "iopub.execute_input": "2022-06-23T10:16:45.535320Z",
+     "iopub.status.busy": "2022-06-23T10:16:45.535057Z",
+     "iopub.status.idle": "2022-06-23T10:16:45.541779Z",
+     "shell.execute_reply": "2022-06-23T10:16:45.541186Z"
     },
     "papermill": {
-     "duration": 0.049153,
-     "end_time": "2022-02-23T14:01:54.226892",
+     "duration": 0.02973,
+     "end_time": "2022-06-23T10:16:45.543157",
      "exception": false,
-     "start_time": "2022-02-23T14:01:54.177739",
+     "start_time": "2022-06-23T10:16:45.513427",
      "status": "completed"
     },
     "tags": []
@@ -128,10 +128,10 @@
    "id": "2eddaa97",
    "metadata": {
     "papermill": {
-     "duration": 0.039174,
-     "end_time": "2022-02-23T14:01:54.309480",
+     "duration": 0.021665,
+     "end_time": "2022-06-23T10:16:45.586126",
      "exception": false,
-     "start_time": "2022-02-23T14:01:54.270306",
+     "start_time": "2022-06-23T10:16:45.564461",
      "status": "completed"
     },
     "tags": []
@@ -150,14 +150,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "63549688",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:45.638167Z",
+     "iopub.status.busy": "2022-06-23T10:16:45.637894Z",
+     "iopub.status.idle": "2022-06-23T10:16:47.247810Z",
+     "shell.execute_reply": "2022-06-23T10:16:47.247206Z"
+    },
     "papermill": {
-     "duration": 1.973116,
-     "end_time": "2022-02-23T14:01:56.323017",
+     "duration": 1.63726,
+     "end_time": "2022-06-23T10:16:47.249547",
      "exception": false,
-     "start_time": "2022-02-23T14:01:54.349901",
+     "start_time": "2022-06-23T10:16:45.612287",
      "status": "completed"
     },
     "tags": []
@@ -186,14 +192,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "b7fbc709",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:47.295353Z",
+     "iopub.status.busy": "2022-06-23T10:16:47.295080Z",
+     "iopub.status.idle": "2022-06-23T10:16:48.609750Z",
+     "shell.execute_reply": "2022-06-23T10:16:48.608961Z"
+    },
     "papermill": {
-     "duration": 0.766252,
-     "end_time": "2022-02-23T14:01:57.139333",
+     "duration": 1.340578,
+     "end_time": "2022-06-23T10:16:48.611551",
      "exception": false,
-     "start_time": "2022-02-23T14:01:56.373081",
+     "start_time": "2022-06-23T10:16:47.270973",
      "status": "completed"
     },
     "tags": []
@@ -210,10 +222,10 @@
    "id": "97124980",
    "metadata": {
     "papermill": {
-     "duration": 0.040031,
-     "end_time": "2022-02-23T14:01:57.229179",
+     "duration": 0.021629,
+     "end_time": "2022-06-23T10:16:48.654572",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.189148",
+     "start_time": "2022-06-23T10:16:48.632943",
      "status": "completed"
     },
     "tags": []
@@ -225,14 +237,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "2308aa69",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:48.700530Z",
+     "iopub.status.busy": "2022-06-23T10:16:48.700232Z",
+     "iopub.status.idle": "2022-06-23T10:16:48.704248Z",
+     "shell.execute_reply": "2022-06-23T10:16:48.703671Z"
+    },
     "papermill": {
-     "duration": 0.048102,
-     "end_time": "2022-02-23T14:01:57.316558",
+     "duration": 0.030256,
+     "end_time": "2022-06-23T10:16:48.705644",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.268456",
+     "start_time": "2022-06-23T10:16:48.675388",
      "status": "completed"
     },
     "tags": []
@@ -249,14 +267,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "5f3c1c3d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:48.758091Z",
+     "iopub.status.busy": "2022-06-23T10:16:48.757806Z",
+     "iopub.status.idle": "2022-06-23T10:16:48.761317Z",
+     "shell.execute_reply": "2022-06-23T10:16:48.760707Z"
+    },
     "papermill": {
-     "duration": 0.045895,
-     "end_time": "2022-02-23T14:01:57.406797",
+     "duration": 0.029013,
+     "end_time": "2022-06-23T10:16:48.762674",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.360902",
+     "start_time": "2022-06-23T10:16:48.733661",
      "status": "completed"
     },
     "tags": []
@@ -271,10 +295,10 @@
    "id": "5c985177",
    "metadata": {
     "papermill": {
-     "duration": 0.038324,
-     "end_time": "2022-02-23T14:01:57.489090",
+     "duration": 0.029108,
+     "end_time": "2022-06-23T10:16:48.822527",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.450766",
+     "start_time": "2022-06-23T10:16:48.793419",
      "status": "completed"
     },
     "tags": []
@@ -288,14 +312,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "d47ddd14",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:48.866199Z",
+     "iopub.status.busy": "2022-06-23T10:16:48.865912Z",
+     "iopub.status.idle": "2022-06-23T10:16:48.869191Z",
+     "shell.execute_reply": "2022-06-23T10:16:48.868523Z"
+    },
     "papermill": {
-     "duration": 0.047398,
-     "end_time": "2022-02-23T14:01:57.575696",
+     "duration": 0.026756,
+     "end_time": "2022-06-23T10:16:48.870556",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.528298",
+     "start_time": "2022-06-23T10:16:48.843800",
      "status": "completed"
     },
     "tags": []
@@ -310,10 +340,10 @@
    "id": "679c8543",
    "metadata": {
     "papermill": {
-     "duration": 0.043362,
-     "end_time": "2022-02-23T14:01:57.659769",
+     "duration": 0.025182,
+     "end_time": "2022-06-23T10:16:48.917662",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.616407",
+     "start_time": "2022-06-23T10:16:48.892480",
      "status": "completed"
     },
     "tags": []
@@ -325,14 +355,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "60ba77bb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:48.962329Z",
+     "iopub.status.busy": "2022-06-23T10:16:48.962050Z",
+     "iopub.status.idle": "2022-06-23T10:16:48.966641Z",
+     "shell.execute_reply": "2022-06-23T10:16:48.966018Z"
+    },
     "papermill": {
-     "duration": 0.048718,
-     "end_time": "2022-02-23T14:01:57.748463",
+     "duration": 0.029183,
+     "end_time": "2022-06-23T10:16:48.967973",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.699745",
+     "start_time": "2022-06-23T10:16:48.938790",
      "status": "completed"
     },
     "tags": []
@@ -353,10 +389,10 @@
    "id": "23923c5d",
    "metadata": {
     "papermill": {
-     "duration": 0.039993,
-     "end_time": "2022-02-23T14:01:57.828662",
+     "duration": 0.028038,
+     "end_time": "2022-06-23T10:16:49.021122",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.788669",
+     "start_time": "2022-06-23T10:16:48.993084",
      "status": "completed"
     },
     "tags": []
@@ -367,14 +403,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "9f12d8ee",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:49.064665Z",
+     "iopub.status.busy": "2022-06-23T10:16:49.064349Z",
+     "iopub.status.idle": "2022-06-23T10:16:49.067574Z",
+     "shell.execute_reply": "2022-06-23T10:16:49.067021Z"
+    },
     "papermill": {
-     "duration": 0.047201,
-     "end_time": "2022-02-23T14:01:57.919100",
+     "duration": 0.026631,
+     "end_time": "2022-06-23T10:16:49.068992",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.871899",
+     "start_time": "2022-06-23T10:16:49.042361",
      "status": "completed"
     },
     "tags": []
@@ -389,10 +431,10 @@
    "id": "bc4a6922",
    "metadata": {
     "papermill": {
-     "duration": 0.038961,
-     "end_time": "2022-02-23T14:01:58.009959",
+     "duration": 0.022943,
+     "end_time": "2022-06-23T10:16:49.117883",
      "exception": false,
-     "start_time": "2022-02-23T14:01:57.970998",
+     "start_time": "2022-06-23T10:16:49.094940",
      "status": "completed"
     },
     "tags": []
@@ -403,14 +445,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "d8f1e05b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:49.162332Z",
+     "iopub.status.busy": "2022-06-23T10:16:49.162038Z",
+     "iopub.status.idle": "2022-06-23T10:16:49.449124Z",
+     "shell.execute_reply": "2022-06-23T10:16:49.448623Z"
+    },
     "papermill": {
-     "duration": 0.241207,
-     "end_time": "2022-02-23T14:01:58.291413",
+     "duration": 0.311363,
+     "end_time": "2022-06-23T10:16:49.450788",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.050206",
+     "start_time": "2022-06-23T10:16:49.139425",
      "status": "completed"
     },
     "tags": []
@@ -422,14 +470,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "7c294ff7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:49.501541Z",
+     "iopub.status.busy": "2022-06-23T10:16:49.501190Z",
+     "iopub.status.idle": "2022-06-23T10:16:49.578154Z",
+     "shell.execute_reply": "2022-06-23T10:16:49.577678Z"
+    },
     "papermill": {
-     "duration": 0.13804,
-     "end_time": "2022-02-23T14:01:58.469743",
+     "duration": 0.108861,
+     "end_time": "2022-06-23T10:16:49.581444",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.331703",
+     "start_time": "2022-06-23T10:16:49.472583",
      "status": "completed"
     },
     "tags": []
@@ -808,7 +862,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:26:12.089929\n",
+       "    date_created:              2022-06-23T10:16:49.312537\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -817,7 +871,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-58c61ac7-4a65-4557-a491-5b0d3a670578' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-58c61ac7-4a65-4557-a491-5b0d3a670578' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-ae4cff08-c3da-4627-97f2-4042064a4369' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ae4cff08-c3da-4627-97f2-4042064a4369' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-dc3535a8-104a-4a7f-b367-edd75b7690b2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dc3535a8-104a-4a7f-b367-edd75b7690b2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c329fa88-bc89-4b1c-a359-207e1f8e4bf2' class='xr-var-data-in' type='checkbox'><label for='data-c329fa88-bc89-4b1c-a359-207e1f8e4bf2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-63dab4cd-c709-47df-960e-dc7fffa4c310' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-63dab4cd-c709-47df-960e-dc7fffa4c310' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-516290ef-a9bf-413b-8d9e-5f5b05762a1d' class='xr-var-data-in' type='checkbox'><label for='data-516290ef-a9bf-413b-8d9e-5f5b05762a1d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-19ae7c77-7c72-4d8d-a54b-991b54504510' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-19ae7c77-7c72-4d8d-a54b-991b54504510' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8ef644ab-a708-4684-bcfb-84123b9821d4' class='xr-var-data-in' type='checkbox'><label for='data-8ef644ab-a708-4684-bcfb-84123b9821d4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-206cfa8e-0036-447f-92ef-8632f00b653b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-206cfa8e-0036-447f-92ef-8632f00b653b' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-57ad5db3-75eb-426e-8dbd-63c82ae300ea' class='xr-section-summary-in' type='checkbox'  checked><label for='section-57ad5db3-75eb-426e-8dbd-63c82ae300ea' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-ee6d942e-7aab-4029-9616-cc8e5e0dd50b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee6d942e-7aab-4029-9616-cc8e5e0dd50b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6560e994-7ac4-4264-9e99-b8a6a8ab7f0f' class='xr-var-data-in' type='checkbox'><label for='data-6560e994-7ac4-4264-9e99-b8a6a8ab7f0f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-23cd0aee-c75f-40d0-a0f3-123049470677' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-23cd0aee-c75f-40d0-a0f3-123049470677' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4482723e-8f57-483c-8961-757584bc1325' class='xr-var-data-in' type='checkbox'><label for='data-4482723e-8f57-483c-8961-757584bc1325' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-bf386b8f-51ad-4e72-ba6b-b93d24c438ed' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bf386b8f-51ad-4e72-ba6b-b93d24c438ed' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4dc5f236-d78d-48d9-9920-5c31fa5fb743' class='xr-var-data-in' type='checkbox'><label for='data-4dc5f236-d78d-48d9-9920-5c31fa5fb743' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -837,7 +891,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-7bfe3d6b-e953-49a2-b339-b1aec7ed14b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7bfe3d6b-e953-49a2-b339-b1aec7ed14b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ed081627-d2bf-4796-a390-011dcd9f60f1' class='xr-var-data-in' type='checkbox'><label for='data-ed081627-d2bf-4796-a390-011dcd9f60f1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-332289c1-a744-4391-8bef-6ca11ef5b9c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-332289c1-a744-4391-8bef-6ca11ef5b9c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1c447a0e-549b-41a1-bb63-ff83d7f522fd' class='xr-var-data-in' type='checkbox'><label for='data-1c447a0e-549b-41a1-bb63-ff83d7f522fd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -894,7 +948,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-331baff0-b883-4905-a890-895e6c3c65dd' class='xr-section-summary-in' type='checkbox'  checked><label for='section-331baff0-b883-4905-a890-895e6c3c65dd' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-1cf38291-cc64-4d08-ad01-a21879022279' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1cf38291-cc64-4d08-ad01-a21879022279' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-34aaa782-463d-47d8-879f-ba83b6f86ece' class='xr-var-data-in' type='checkbox'><label for='data-34aaa782-463d-47d8-879f-ba83b6f86ece' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-c645d1c9-a096-444e-bdc7-b2a35f321000' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c645d1c9-a096-444e-bdc7-b2a35f321000' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e1abc314-20a6-44d3-9a3a-f028fa658943' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e1abc314-20a6-44d3-9a3a-f028fa658943' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-06d15e03-2faa-4934-820c-ceb8e55224ab' class='xr-var-data-in' type='checkbox'><label for='data-06d15e03-2faa-4934-820c-ceb8e55224ab' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1036,7 +1090,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3e104e03-e5b4-4e4e-953b-5843beab077f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3e104e03-e5b4-4e4e-953b-5843beab077f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e78c3406-8466-4443-834e-3bbded5bbf5c' class='xr-var-data-in' type='checkbox'><label for='data-e78c3406-8466-4443-834e-3bbded5bbf5c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ba3f3eb2-b6cb-4430-a8c7-983358e18552' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ba3f3eb2-b6cb-4430-a8c7-983358e18552' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8934deab-7a0b-429e-9992-3c05049fc462' class='xr-var-data-in' type='checkbox'><label for='data-8934deab-7a0b-429e-9992-3c05049fc462' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1178,7 +1232,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c90d90fc-0a69-4147-af48-16ac824b2ef6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c90d90fc-0a69-4147-af48-16ac824b2ef6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7067130e-cf2e-49e5-a711-e101c3a1e099' class='xr-var-data-in' type='checkbox'><label for='data-7067130e-cf2e-49e5-a711-e101c3a1e099' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3155111b-cfa3-48e8-9fab-65a8212acd75' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3155111b-cfa3-48e8-9fab-65a8212acd75' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2a83f132-676f-4bb1-84ca-2144b2ee02b5' class='xr-var-data-in' type='checkbox'><label for='data-2a83f132-676f-4bb1-84ca-2144b2ee02b5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1320,7 +1374,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ac4899cb-23e3-4a3a-87f6-5f22d45cea29' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ac4899cb-23e3-4a3a-87f6-5f22d45cea29' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9aaaf4c5-b868-4682-8669-879dbf3723b9' class='xr-var-data-in' type='checkbox'><label for='data-9aaaf4c5-b868-4682-8669-879dbf3723b9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-fa4980e9-d3e8-4c80-adaa-4bf079a29c0c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fa4980e9-d3e8-4c80-adaa-4bf079a29c0c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f16d7f20-7889-4bf5-8d1d-3a97c98de343' class='xr-var-data-in' type='checkbox'><label for='data-f16d7f20-7889-4bf5-8d1d-3a97c98de343' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1462,7 +1516,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-123d1c6b-0877-47f1-85ef-997984d99363' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-123d1c6b-0877-47f1-85ef-997984d99363' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-db480ab6-7da8-408a-a76f-30e7018e879a' class='xr-var-data-in' type='checkbox'><label for='data-db480ab6-7da8-408a-a76f-30e7018e879a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e250743d-072d-4b4d-bb0e-13809b5436c4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e250743d-072d-4b4d-bb0e-13809b5436c4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fade0a7e-5065-4f11-b8de-665a7ac418c0' class='xr-var-data-in' type='checkbox'><label for='data-fade0a7e-5065-4f11-b8de-665a7ac418c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1604,7 +1658,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-439a6dee-efbc-4375-81bb-4087553d38ec' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-439a6dee-efbc-4375-81bb-4087553d38ec' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-adff8e7a-d0c2-4fbf-9674-676561a0f90d' class='xr-var-data-in' type='checkbox'><label for='data-adff8e7a-d0c2-4fbf-9674-676561a0f90d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e7ee47af-74f3-4a26-9e36-a4f03e89baae' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e7ee47af-74f3-4a26-9e36-a4f03e89baae' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f66921e-e327-4a7a-b579-bfe7eb2031e9' class='xr-var-data-in' type='checkbox'><label for='data-3f66921e-e327-4a7a-b579-bfe7eb2031e9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1746,7 +1800,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-b67c4ffd-cfb3-49d3-ad4d-31821c6eb5dc' class='xr-section-summary-in' type='checkbox'  ><label for='section-b67c4ffd-cfb3-49d3-ad4d-31821c6eb5dc' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:26:12.089929</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9d876d35-c685-44a6-a0fc-41fc812ea767' class='xr-section-summary-in' type='checkbox'  ><label for='section-9d876d35-c685-44a6-a0fc-41fc812ea767' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:16:49.312537</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1768,7 +1822,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:26:12.089929\n",
+       "    date_created:              2022-06-23T10:16:49.312537\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -1780,7 +1834,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1794,10 +1848,10 @@
    "id": "65a16fe9",
    "metadata": {
     "papermill": {
-     "duration": 0.043062,
-     "end_time": "2022-02-23T14:01:58.554298",
+     "duration": 0.023711,
+     "end_time": "2022-06-23T10:16:49.631193",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.511236",
+     "start_time": "2022-06-23T10:16:49.607482",
      "status": "completed"
     },
     "tags": []
@@ -1816,14 +1870,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "fc776f7f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:49.680017Z",
+     "iopub.status.busy": "2022-06-23T10:16:49.679712Z",
+     "iopub.status.idle": "2022-06-23T10:16:49.694255Z",
+     "shell.execute_reply": "2022-06-23T10:16:49.693645Z"
+    },
     "papermill": {
-     "duration": 0.067604,
-     "end_time": "2022-02-23T14:01:58.664824",
+     "duration": 0.040972,
+     "end_time": "2022-06-23T10:16:49.696078",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.597220",
+     "start_time": "2022-06-23T10:16:49.655106",
      "status": "completed"
     },
     "tags": []
@@ -2209,7 +2269,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Attributes:\n",
        "    standard_name:  time\n",
-       "    bounds:         time_bnds</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'time'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-614061d8-8651-4ebd-8f2d-1ecd791665ad' class='xr-array-in' type='checkbox' checked><label for='section-614061d8-8651-4ebd-8f2d-1ecd791665ad' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>2018-05-15 2018-05-17 2018-05-19 ... 2018-07-28 2018-07-30 2018-08-01</span></div><div class='xr-array-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    bounds:         time_bnds</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'time'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-bb3df9b7-fae5-4f09-b699-f3336c8955dc' class='xr-array-in' type='checkbox' checked><label for='section-bb3df9b7-fae5-4f09-b699-f3336c8955dc' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>2018-05-15 2018-05-17 2018-05-19 ... 2018-07-28 2018-07-30 2018-08-01</span></div><div class='xr-array-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2229,7 +2289,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></div></li><li class='xr-section-item'><input id='section-b4fcc68f-c047-477c-8825-b05b8bf5a1ab' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b4fcc68f-c047-477c-8825-b05b8bf5a1ab' class='xr-section-summary' >Coordinates: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-c0855a61-8852-4d5e-a327-852868227cb8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c0855a61-8852-4d5e-a327-852868227cb8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e21a5e7e-01c4-45a7-af53-90391e9e64cc' class='xr-var-data-in' type='checkbox'><label for='data-e21a5e7e-01c4-45a7-af53-90391e9e64cc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></div></li><li class='xr-section-item'><input id='section-35f64f7c-dfe0-4a29-8ef8-d86d11b1a09d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-35f64f7c-dfe0-4a29-8ef8-d86d11b1a09d' class='xr-section-summary' >Coordinates: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-7f78afed-e8ba-4ab4-8197-d00428c9d349' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7f78afed-e8ba-4ab4-8197-d00428c9d349' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87da8413-684e-4863-ad8f-89635f4209e9' class='xr-var-data-in' type='checkbox'><label for='data-87da8413-684e-4863-ad8f-89635f4209e9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2249,7 +2309,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5bdf9300-158c-4ee0-a2e4-3dc02518a84f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5bdf9300-158c-4ee0-a2e4-3dc02518a84f' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b597b432-5661-492b-919d-087980eee225' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b597b432-5661-492b-919d-087980eee225' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'time' (time: 40)>\n",
@@ -2281,7 +2341,7 @@
        "    bounds:         time_bnds"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2295,10 +2355,10 @@
    "id": "be5b5c1b",
    "metadata": {
     "papermill": {
-     "duration": 0.049045,
-     "end_time": "2022-02-23T14:01:58.759753",
+     "duration": 0.034404,
+     "end_time": "2022-06-23T10:16:49.759601",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.710708",
+     "start_time": "2022-06-23T10:16:49.725197",
      "status": "completed"
     },
     "tags": []
@@ -2309,14 +2369,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "568a31d3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:49.823634Z",
+     "iopub.status.busy": "2022-06-23T10:16:49.823367Z",
+     "iopub.status.idle": "2022-06-23T10:16:49.827360Z",
+     "shell.execute_reply": "2022-06-23T10:16:49.826860Z"
+    },
     "papermill": {
-     "duration": 0.052866,
-     "end_time": "2022-02-23T14:01:58.855958",
+     "duration": 0.03677,
+     "end_time": "2022-06-23T10:16:49.829518",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.803092",
+     "start_time": "2022-06-23T10:16:49.792748",
      "status": "completed"
     },
     "tags": []
@@ -2328,10 +2394,10 @@
        "<html><p>No requests made yet.</p></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f2c74277970>"
+       "<xcube_sh.observers._RequestStats at 0x7f4ac085dc70>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2345,10 +2411,10 @@
    "id": "96f35a78",
    "metadata": {
     "papermill": {
-     "duration": 0.051319,
-     "end_time": "2022-02-23T14:01:58.953522",
+     "duration": 0.024816,
+     "end_time": "2022-06-23T10:16:49.879917",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.902203",
+     "start_time": "2022-06-23T10:16:49.855101",
      "status": "completed"
     },
     "tags": []
@@ -2359,14 +2425,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "f60c0ed1",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:49.940716Z",
+     "iopub.status.busy": "2022-06-23T10:16:49.940039Z",
+     "iopub.status.idle": "2022-06-23T10:16:49.963953Z",
+     "shell.execute_reply": "2022-06-23T10:16:49.963482Z"
+    },
     "papermill": {
-     "duration": 0.072284,
-     "end_time": "2022-02-23T14:01:59.069134",
+     "duration": 0.052329,
+     "end_time": "2022-06-23T10:16:49.965988",
      "exception": false,
-     "start_time": "2022-02-23T14:01:58.996850",
+     "start_time": "2022-06-23T10:16:49.913659",
      "status": "completed"
     },
     "tags": []
@@ -2727,7 +2799,7 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray &#x27;B04&#x27; (time: 40, lat: 2048, lon: 5632)&gt;\n",
-       "dask.array&lt;open_dataset-966100863c4431c3f6505c3ef6d688b6B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
+       "dask.array&lt;open_dataset-a6c49585978b4726984b9e29c2f4fc85B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2741,7 +2813,7 @@
        "    bandwidth:     31.0\n",
        "    bandwidth_a:   31\n",
        "    bandwidth_b:   31\n",
-       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-c54bde74-9211-4d07-a04c-f802970ae6ce' class='xr-array-in' type='checkbox' checked><label for='section-c54bde74-9211-4d07-a04c-f802970ae6ce' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    resolution:    10</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'B04'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-60612551-36dc-4a13-8e50-207972009a9b' class='xr-array-in' type='checkbox' checked><label for='section-60612551-36dc-4a13-8e50-207972009a9b' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2883,7 +2955,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-b154c56c-40c6-4f53-8f15-0cfd8d3a4fff' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b154c56c-40c6-4f53-8f15-0cfd8d3a4fff' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-38285b61-e3c6-448c-bfc5-4a9e874a4d3e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-38285b61-e3c6-448c-bfc5-4a9e874a4d3e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-81dfe74b-fa34-4971-82b1-92f1efe5c91e' class='xr-var-data-in' type='checkbox'><label for='data-81dfe74b-fa34-4971-82b1-92f1efe5c91e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-f1c54a68-2d16-4e38-bb5e-934c6708d789' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f1c54a68-2d16-4e38-bb5e-934c6708d789' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-00460e14-ca44-480b-b383-b5201b9447d3' class='xr-var-data-in' type='checkbox'><label for='data-00460e14-ca44-480b-b383-b5201b9447d3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-462667f4-a8b4-42b9-9260-86dbd286f830' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-462667f4-a8b4-42b9-9260-86dbd286f830' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-583e1430-f838-4ca4-a32d-ed15a5ccecdf' class='xr-var-data-in' type='checkbox'><label for='data-583e1430-f838-4ca4-a32d-ed15a5ccecdf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-494851d2-de01-42c7-b2f9-9152870963e2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-494851d2-de01-42c7-b2f9-9152870963e2' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-8ecf9c5b-048b-404c-af2d-e75640c11abe' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8ecf9c5b-048b-404c-af2d-e75640c11abe' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-95cacf4d-df96-4c63-a7a8-8609921b754f' class='xr-var-data-in' type='checkbox'><label for='data-95cacf4d-df96-4c63-a7a8-8609921b754f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-35171c5c-ea9f-4020-91fe-df06d82ea72b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-35171c5c-ea9f-4020-91fe-df06d82ea72b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-946d06ac-f715-4b12-8325-447686e5cedb' class='xr-var-data-in' type='checkbox'><label for='data-946d06ac-f715-4b12-8325-447686e5cedb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-db91d633-4558-463a-a829-3d970314f5f2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-db91d633-4558-463a-a829-3d970314f5f2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-589ace96-d32f-431c-9de2-e674d8848058' class='xr-var-data-in' type='checkbox'><label for='data-589ace96-d32f-431c-9de2-e674d8848058' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -2903,11 +2975,11 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bd79c36d-9de0-4276-9b3d-2b6c4a371d82' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bd79c36d-9de0-4276-9b3d-2b6c4a371d82' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2da77c37-9850-482a-93fa-d454a72a2481' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2da77c37-9850-482a-93fa-d454a72a2481' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'B04' (time: 40, lat: 2048, lon: 5632)>\n",
-       "dask.array<open_dataset-966100863c4431c3f6505c3ef6d688b6B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
+       "dask.array<open_dataset-a6c49585978b4726984b9e29c2f4fc85B04, shape=(40, 2048, 5632), dtype=float32, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -2924,7 +2996,7 @@
        "    resolution:    10"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2935,14 +3007,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "007d305d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:50.031187Z",
+     "iopub.status.busy": "2022-06-23T10:16:50.030915Z",
+     "iopub.status.idle": "2022-06-23T10:17:14.051571Z",
+     "shell.execute_reply": "2022-06-23T10:17:14.051050Z"
+    },
     "papermill": {
-     "duration": 18.96803,
-     "end_time": "2022-02-23T14:02:18.082778",
+     "duration": 24.061958,
+     "end_time": "2022-06-23T10:17:14.063354",
      "exception": false,
-     "start_time": "2022-02-23T14:01:59.114748",
+     "start_time": "2022-06-23T10:16:50.001396",
      "status": "completed"
     },
     "tags": []
@@ -2951,10 +3029,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f2c7427dbe0>"
+       "<matplotlib.image.AxesImage at 0x7f4abb48b370>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2981,10 +3059,10 @@
    "id": "b6ee5085",
    "metadata": {
     "papermill": {
-     "duration": 0.058512,
-     "end_time": "2022-02-23T14:02:18.209925",
+     "duration": 0.042457,
+     "end_time": "2022-06-23T10:17:14.156544",
      "exception": false,
-     "start_time": "2022-02-23T14:02:18.151413",
+     "start_time": "2022-06-23T10:17:14.114087",
      "status": "completed"
     },
     "tags": []
@@ -2995,14 +3073,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "7cadaf83",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:14.243561Z",
+     "iopub.status.busy": "2022-06-23T10:17:14.243291Z",
+     "iopub.status.idle": "2022-06-23T10:17:14.248073Z",
+     "shell.execute_reply": "2022-06-23T10:17:14.247574Z"
+    },
     "papermill": {
-     "duration": 0.069173,
-     "end_time": "2022-02-23T14:02:18.338170",
+     "duration": 0.04995,
+     "end_time": "2022-06-23T10:17:14.249643",
      "exception": false,
-     "start_time": "2022-02-23T14:02:18.268997",
+     "start_time": "2022-06-23T10:17:14.199693",
      "status": "completed"
     },
     "tags": []
@@ -3011,13 +3095,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>330.88 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>465.60 ms</td></tr><tr><td>Request duration mean:</td><td>512.72 ms</td></tr><tr><td>Request duration std:</td><td>212.22 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>44</td></tr><tr><td>Request duration min:</td><td>280.00 ms</td></tr><tr><td>Request duration max:</td><td>1148.51 ms</td></tr><tr><td>Request duration median:</td><td>475.32 ms</td></tr><tr><td>Request duration mean:</td><td>516.37 ms</td></tr><tr><td>Request duration std:</td><td>171.07 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f2c74277c10>"
+       "<xcube_sh.observers._RequestStats at 0x7f4abb3a1460>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3031,10 +3115,10 @@
    "id": "080c0bf1",
    "metadata": {
     "papermill": {
-     "duration": 0.061243,
-     "end_time": "2022-02-23T14:02:18.462422",
+     "duration": 0.046061,
+     "end_time": "2022-06-23T10:17:14.336836",
      "exception": false,
-     "start_time": "2022-02-23T14:02:18.401179",
+     "start_time": "2022-06-23T10:17:14.290775",
      "status": "completed"
     },
     "tags": []
@@ -3045,14 +3129,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "52d2a9a1",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:14.431755Z",
+     "iopub.status.busy": "2022-06-23T10:17:14.431472Z",
+     "iopub.status.idle": "2022-06-23T10:17:14.449567Z",
+     "shell.execute_reply": "2022-06-23T10:17:14.449040Z"
+    },
     "papermill": {
-     "duration": 0.088546,
-     "end_time": "2022-02-23T14:02:18.609981",
+     "duration": 0.068998,
+     "end_time": "2022-06-23T10:17:14.451133",
      "exception": false,
-     "start_time": "2022-02-23T14:02:18.521435",
+     "start_time": "2022-06-23T10:17:14.382135",
      "status": "completed"
     },
     "tags": []
@@ -3413,7 +3503,7 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray &#x27;SCL&#x27; (time: 40, lat: 2048, lon: 5632)&gt;\n",
-       "dask.array&lt;open_dataset-966100863c4431c3f6505c3ef6d688b6SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
+       "dask.array&lt;open_dataset-a6c49585978b4726984b9e29c2f4fc85SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray&gt;\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -3421,7 +3511,7 @@
        "Attributes:\n",
        "    sample_type:    UINT8\n",
        "    flag_values:    0,1,2,3,4,5,6,7,8,9,10,11\n",
-       "    flag_meanings:  no_data saturated_or_defective dark_area_pixels cloud_sha...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'SCL'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-0a9bd1c1-9260-46f2-a25e-3154fc58c6a6' class='xr-array-in' type='checkbox' checked><label for='section-0a9bd1c1-9260-46f2-a25e-3154fc58c6a6' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    flag_meanings:  no_data saturated_or_defective dark_area_pixels cloud_sha...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'SCL'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-157639d9-237c-47e8-bb5a-0563a0b20ca2' class='xr-array-in' type='checkbox' checked><label for='section-157639d9-237c-47e8-bb5a-0563a0b20ca2' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -3563,7 +3653,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-dd71f7ac-9655-4bec-9068-65c6b905edb2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-dd71f7ac-9655-4bec-9068-65c6b905edb2' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-f8b02ae0-597c-4029-a612-665496bfb680' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f8b02ae0-597c-4029-a612-665496bfb680' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5a809a4d-5113-47fe-8410-f812024a4cde' class='xr-var-data-in' type='checkbox'><label for='data-5a809a4d-5113-47fe-8410-f812024a4cde' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-34094e42-c744-4148-b398-05833dfe8ece' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-34094e42-c744-4148-b398-05833dfe8ece' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a27a4c95-71cf-4eb7-8794-9e070d313b92' class='xr-var-data-in' type='checkbox'><label for='data-a27a4c95-71cf-4eb7-8794-9e070d313b92' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-d26c7c9d-f618-4068-a80b-a564893c7bd1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d26c7c9d-f618-4068-a80b-a564893c7bd1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bacba569-1f8e-4390-ab39-5fa50cf149ca' class='xr-var-data-in' type='checkbox'><label for='data-bacba569-1f8e-4390-ab39-5fa50cf149ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-d7a41083-ece6-49ca-b562-17422cfbff94' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d7a41083-ece6-49ca-b562-17422cfbff94' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-883f75c8-1369-498c-bcbf-65c92f523d53' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-883f75c8-1369-498c-bcbf-65c92f523d53' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9296f286-d837-435f-b419-49120b49aa34' class='xr-var-data-in' type='checkbox'><label for='data-9296f286-d837-435f-b419-49120b49aa34' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-8e2df813-e765-412a-8f92-863ce7c7608b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8e2df813-e765-412a-8f92-863ce7c7608b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e03ee993-6614-47b7-b2b2-8c72cad5637b' class='xr-var-data-in' type='checkbox'><label for='data-e03ee993-6614-47b7-b2b2-8c72cad5637b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-7f0c6a65-d85e-4f12-b206-d84845272950' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7f0c6a65-d85e-4f12-b206-d84845272950' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fb080718-b3f8-4365-9f0a-77bfe2deafa0' class='xr-var-data-in' type='checkbox'><label for='data-fb080718-b3f8-4365-9f0a-77bfe2deafa0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -3583,11 +3673,11 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b311f2b0-fed2-4058-a9f5-8b45f0e56ee7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b311f2b0-fed2-4058-a9f5-8b45f0e56ee7' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ab3e0608-1aa2-4848-a363-b6abde652690' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ab3e0608-1aa2-4848-a363-b6abde652690' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'SCL' (time: 40, lat: 2048, lon: 5632)>\n",
-       "dask.array<open_dataset-966100863c4431c3f6505c3ef6d688b6SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
+       "dask.array<open_dataset-a6c49585978b4726984b9e29c2f4fc85SCL, shape=(40, 2048, 5632), dtype=uint8, chunksize=(1, 512, 512), chunktype=numpy.ndarray>\n",
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
@@ -3598,7 +3688,7 @@
        "    flag_meanings:  no_data saturated_or_defective dark_area_pixels cloud_sha..."
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3609,14 +3699,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "78d7ed3a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:14.545669Z",
+     "iopub.status.busy": "2022-06-23T10:17:14.545402Z",
+     "iopub.status.idle": "2022-06-23T10:17:14.549414Z",
+     "shell.execute_reply": "2022-06-23T10:17:14.548885Z"
+    },
     "papermill": {
-     "duration": 0.070175,
-     "end_time": "2022-02-23T14:02:18.758032",
+     "duration": 0.050114,
+     "end_time": "2022-06-23T10:17:14.550777",
      "exception": false,
-     "start_time": "2022-02-23T14:02:18.687857",
+     "start_time": "2022-06-23T10:17:14.500663",
      "status": "completed"
     },
     "tags": []
@@ -3642,10 +3738,10 @@
    "id": "bed8d8a9",
    "metadata": {
     "papermill": {
-     "duration": 0.072237,
-     "end_time": "2022-02-23T14:02:18.892159",
+     "duration": 0.042761,
+     "end_time": "2022-06-23T10:17:14.641333",
      "exception": false,
-     "start_time": "2022-02-23T14:02:18.819922",
+     "start_time": "2022-06-23T10:17:14.598572",
      "status": "completed"
     },
     "tags": []
@@ -3656,14 +3752,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "c50481ca",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:14.731432Z",
+     "iopub.status.busy": "2022-06-23T10:17:14.731162Z",
+     "iopub.status.idle": "2022-06-23T10:17:14.755261Z",
+     "shell.execute_reply": "2022-06-23T10:17:14.754701Z"
+    },
     "papermill": {
-     "duration": 0.095624,
-     "end_time": "2022-02-23T14:02:19.049206",
+     "duration": 0.07259,
+     "end_time": "2022-06-23T10:17:14.756911",
      "exception": false,
-     "start_time": "2022-02-23T14:02:18.953582",
+     "start_time": "2022-06-23T10:17:14.684321",
      "status": "completed"
     },
     "tags": []
@@ -4028,7 +4130,7 @@
        "Coordinates:\n",
        "  * lat      (lat) float64 54.64 54.64 54.64 54.64 ... 54.27 54.27 54.27 54.27\n",
        "  * lon      (lon) float64 10.0 10.0 10.0 10.0 10.0 ... 11.01 11.01 11.01 11.01\n",
-       "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'water'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-d0e35cf2-1e27-481d-82d6-8686fe377992' class='xr-array-in' type='checkbox' checked><label for='section-d0e35cf2-1e27-481d-82d6-8686fe377992' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'water'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-29833f70-a1c3-4113-8454-cf5e17c3735f' class='xr-array-in' type='checkbox' checked><label for='section-29833f70-a1c3-4113-8454-cf5e17c3735f' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4170,7 +4272,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-78512d1b-6bf6-4e83-afb4-1dc18b51d704' class='xr-section-summary-in' type='checkbox'  checked><label for='section-78512d1b-6bf6-4e83-afb4-1dc18b51d704' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-f7efbaa8-b80a-4ca8-a659-12abad5482b5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f7efbaa8-b80a-4ca8-a659-12abad5482b5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8562f02d-9ef7-4e7e-9ded-dd5996ef39de' class='xr-var-data-in' type='checkbox'><label for='data-8562f02d-9ef7-4e7e-9ded-dd5996ef39de' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-9a4e6f47-35e1-4ece-aa1f-7a1266ac8b80' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9a4e6f47-35e1-4ece-aa1f-7a1266ac8b80' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bee1f092-4072-4ff0-805e-29f63ac03df5' class='xr-var-data-in' type='checkbox'><label for='data-bee1f092-4072-4ff0-805e-29f63ac03df5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-ca4e7390-ce73-45a5-b9fe-1d340bdefb6f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ca4e7390-ce73-45a5-b9fe-1d340bdefb6f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b3c0e982-8523-4aa5-a72d-1687185ff893' class='xr-var-data-in' type='checkbox'><label for='data-b3c0e982-8523-4aa5-a72d-1687185ff893' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-3a243c9b-5e25-4717-8cb7-82f1c4453103' class='xr-section-summary-in' type='checkbox'  checked><label for='section-3a243c9b-5e25-4717-8cb7-82f1c4453103' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-c2a65d93-0d66-4549-8cde-feffabe06a4c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c2a65d93-0d66-4549-8cde-feffabe06a4c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e7ec7638-964c-4fb4-9166-f333408794c0' class='xr-var-data-in' type='checkbox'><label for='data-e7ec7638-964c-4fb4-9166-f333408794c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-913b0ca6-0658-4b55-b4c9-299b43d465f8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-913b0ca6-0658-4b55-b4c9-299b43d465f8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0dcd20b-aa90-43e8-b378-9663b3e067df' class='xr-var-data-in' type='checkbox'><label for='data-e0dcd20b-aa90-43e8-b378-9663b3e067df' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-33f8ac5b-49c1-447c-895d-955180e2ec04' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-33f8ac5b-49c1-447c-895d-955180e2ec04' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3c89ad8f-fdcc-4c72-86b8-e337821a07ce' class='xr-var-data-in' type='checkbox'><label for='data-3c89ad8f-fdcc-4c72-86b8-e337821a07ce' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -4190,7 +4292,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-08b0c2ba-fd7a-43f5-b5ee-a5330218ef03' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-08b0c2ba-fd7a-43f5-b5ee-a5330218ef03' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f9d1f608-4a40-4bc0-ba08-2fa30c487de3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f9d1f608-4a40-4bc0-ba08-2fa30c487de3' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'water' (time: 40, lat: 2048, lon: 5632)>\n",
@@ -4201,7 +4303,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4212,14 +4314,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "513b98db",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:14.849973Z",
+     "iopub.status.busy": "2022-06-23T10:17:14.849458Z",
+     "iopub.status.idle": "2022-06-23T10:17:33.416108Z",
+     "shell.execute_reply": "2022-06-23T10:17:33.415559Z"
+    },
     "papermill": {
-     "duration": 13.005206,
-     "end_time": "2022-02-23T14:02:32.116575",
+     "duration": 18.613465,
+     "end_time": "2022-06-23T10:17:33.417720",
      "exception": false,
-     "start_time": "2022-02-23T14:02:19.111369",
+     "start_time": "2022-06-23T10:17:14.804255",
      "status": "completed"
     },
     "tags": []
@@ -4228,10 +4336,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f2c718c5a00>"
+       "<matplotlib.image.AxesImage at 0x7f4abb2ab490>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -4255,14 +4363,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "ce99df81",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:33.508325Z",
+     "iopub.status.busy": "2022-06-23T10:17:33.508038Z",
+     "iopub.status.idle": "2022-06-23T10:17:33.512995Z",
+     "shell.execute_reply": "2022-06-23T10:17:33.512467Z"
+    },
     "papermill": {
-     "duration": 0.074995,
-     "end_time": "2022-02-23T14:02:32.263246",
+     "duration": 0.052386,
+     "end_time": "2022-06-23T10:17:33.514770",
      "exception": false,
-     "start_time": "2022-02-23T14:02:32.188251",
+     "start_time": "2022-06-23T10:17:33.462384",
      "status": "completed"
     },
     "tags": []
@@ -4271,13 +4385,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>228.43 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>375.19 ms</td></tr><tr><td>Request duration mean:</td><td>445.81 ms</td></tr><tr><td>Request duration std:</td><td>220.63 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>233.67 ms</td></tr><tr><td>Request duration max:</td><td>1337.23 ms</td></tr><tr><td>Request duration median:</td><td>417.19 ms</td></tr><tr><td>Request duration mean:</td><td>461.09 ms</td></tr><tr><td>Request duration std:</td><td>208.79 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f2c7183ebb0>"
+       "<xcube_sh.observers._RequestStats at 0x7f4abb3a95e0>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4291,10 +4405,10 @@
    "id": "68133ea3",
    "metadata": {
     "papermill": {
-     "duration": 0.072942,
-     "end_time": "2022-02-23T14:02:32.402239",
+     "duration": 0.048468,
+     "end_time": "2022-06-23T10:17:33.607671",
      "exception": false,
-     "start_time": "2022-02-23T14:02:32.329297",
+     "start_time": "2022-06-23T10:17:33.559203",
      "status": "completed"
     },
     "tags": []
@@ -4305,14 +4419,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "29c335d7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:33.699470Z",
+     "iopub.status.busy": "2022-06-23T10:17:33.699067Z",
+     "iopub.status.idle": "2022-06-23T10:17:33.745888Z",
+     "shell.execute_reply": "2022-06-23T10:17:33.745403Z"
+    },
     "papermill": {
-     "duration": 0.142857,
-     "end_time": "2022-02-23T14:02:32.611247",
+     "duration": 0.096473,
+     "end_time": "2022-06-23T10:17:33.748973",
      "exception": false,
-     "start_time": "2022-02-23T14:02:32.468390",
+     "start_time": "2022-06-23T10:17:33.652500",
      "status": "completed"
     },
     "tags": []
@@ -4691,7 +4811,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:26:12.089929\n",
+       "    date_created:              2022-06-23T10:16:49.312537\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -4700,7 +4820,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-013ca78e-4db5-4512-b4b7-206a58c60422' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-013ca78e-4db5-4512-b4b7-206a58c60422' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-9a44e135-88cb-48af-b0cf-5c44ff52ec38' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9a44e135-88cb-48af-b0cf-5c44ff52ec38' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-95794825-bb1e-4ce6-803a-9ea1e7ae6624' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-95794825-bb1e-4ce6-803a-9ea1e7ae6624' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-98869e5a-8986-4397-818b-4484188ea7da' class='xr-var-data-in' type='checkbox'><label for='data-98869e5a-8986-4397-818b-4484188ea7da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-966bae3d-6d2c-4241-b6e0-70c792fc51ba' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-966bae3d-6d2c-4241-b6e0-70c792fc51ba' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cce9d8f5-201a-4aea-bc5f-0dcb963fb783' class='xr-var-data-in' type='checkbox'><label for='data-cce9d8f5-201a-4aea-bc5f-0dcb963fb783' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-af36d8b4-f209-45ca-9c20-5dc7cb6a1688' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-af36d8b4-f209-45ca-9c20-5dc7cb6a1688' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-76e13112-842d-4220-8566-df97640f599b' class='xr-var-data-in' type='checkbox'><label for='data-76e13112-842d-4220-8566-df97640f599b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-83d732fd-bbb7-458b-808c-d545585331b9' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-83d732fd-bbb7-458b-808c-d545585331b9' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-cc77b4be-b003-4437-8530-db68b38d08c9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cc77b4be-b003-4437-8530-db68b38d08c9' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-773981aa-d2ed-4779-b8f4-931a955e09bc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-773981aa-d2ed-4779-b8f4-931a955e09bc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-676f5e82-a9d1-4ea1-9506-324051de8213' class='xr-var-data-in' type='checkbox'><label for='data-676f5e82-a9d1-4ea1-9506-324051de8213' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-c0ea0af7-cb66-4a26-99b6-d1fdac808d5a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c0ea0af7-cb66-4a26-99b6-d1fdac808d5a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7d699d7c-a24e-44da-a4ee-3a5c6d526ebb' class='xr-var-data-in' type='checkbox'><label for='data-7d699d7c-a24e-44da-a4ee-3a5c6d526ebb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-8c3e511f-135b-4d13-8c1a-721bb021f78d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8c3e511f-135b-4d13-8c1a-721bb021f78d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f1011935-574a-4bb5-87e7-4699a81f9e32' class='xr-var-data-in' type='checkbox'><label for='data-f1011935-574a-4bb5-87e7-4699a81f9e32' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -4720,7 +4840,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-2b248dff-80a8-4bbf-8db7-593c42f4852f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2b248dff-80a8-4bbf-8db7-593c42f4852f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b8410b84-2699-4667-b0d1-0d91fc04cd4e' class='xr-var-data-in' type='checkbox'><label for='data-b8410b84-2699-4667-b0d1-0d91fc04cd4e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-c14782d2-81a5-4c00-aaba-5658b4a80211' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c14782d2-81a5-4c00-aaba-5658b4a80211' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e5a416ca-8715-45ee-9c52-b2a4d0325587' class='xr-var-data-in' type='checkbox'><label for='data-e5a416ca-8715-45ee-9c52-b2a4d0325587' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4777,7 +4897,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-e0317022-c60d-42c8-aefd-fb1a05c44899' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e0317022-c60d-42c8-aefd-fb1a05c44899' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-d3bdb77b-915c-4814-993e-06c3388a2df6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d3bdb77b-915c-4814-993e-06c3388a2df6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2a09c3b3-be8b-4c9f-814d-9972535207d4' class='xr-var-data-in' type='checkbox'><label for='data-2a09c3b3-be8b-4c9f-814d-9972535207d4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-d991339b-5c35-44be-a71c-cbfe138413b8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d991339b-5c35-44be-a71c-cbfe138413b8' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-0ceea3d8-960f-46ac-9ecb-0656335dea00' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0ceea3d8-960f-46ac-9ecb-0656335dea00' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-35036ca0-a034-4959-acae-27f20835b91e' class='xr-var-data-in' type='checkbox'><label for='data-35036ca0-a034-4959-acae-27f20835b91e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -4919,7 +5039,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-2e07cafe-3c0c-45c1-939a-6150afec755e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2e07cafe-3c0c-45c1-939a-6150afec755e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7f7b9e16-ef54-4434-ae79-4db0249764a5' class='xr-var-data-in' type='checkbox'><label for='data-7f7b9e16-ef54-4434-ae79-4db0249764a5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a8f7a2b5-a2b4-47da-90bc-ba41317ce74f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a8f7a2b5-a2b4-47da-90bc-ba41317ce74f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-48c79a3c-ed26-405e-9361-06c0d921a13c' class='xr-var-data-in' type='checkbox'><label for='data-48c79a3c-ed26-405e-9361-06c0d921a13c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5061,7 +5181,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a5162d60-ecb0-43d4-b8e0-64953225ae22' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a5162d60-ecb0-43d4-b8e0-64953225ae22' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a6a50434-05b2-45d9-ab54-85383e91b85b' class='xr-var-data-in' type='checkbox'><label for='data-a6a50434-05b2-45d9-ab54-85383e91b85b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-b90ff284-646d-4706-a944-7252e3f77a9a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b90ff284-646d-4706-a944-7252e3f77a9a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-935d558a-8198-4434-8f3e-43815e8626a8' class='xr-var-data-in' type='checkbox'><label for='data-935d558a-8198-4434-8f3e-43815e8626a8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5203,7 +5323,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-5ee13139-8da8-4ca0-a3cd-ec576bb8a7b8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5ee13139-8da8-4ca0-a3cd-ec576bb8a7b8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-96fda146-ee4a-4b1a-b512-b21bf715b68e' class='xr-var-data-in' type='checkbox'><label for='data-96fda146-ee4a-4b1a-b512-b21bf715b68e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-18ca7b62-fd31-4641-9980-d462b053381f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-18ca7b62-fd31-4641-9980-d462b053381f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-54963b6d-7bfb-438e-8ee1-74e21cfb9c3d' class='xr-var-data-in' type='checkbox'><label for='data-54963b6d-7bfb-438e-8ee1-74e21cfb9c3d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5345,7 +5465,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e3bc36e0-1286-434e-83d6-6c961720fed3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e3bc36e0-1286-434e-83d6-6c961720fed3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-285583d6-6fe0-4122-ae68-653ca2695c63' class='xr-var-data-in' type='checkbox'><label for='data-285583d6-6fe0-4122-ae68-653ca2695c63' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-171c6c5d-a1e0-4f39-9a33-43fbb58713d8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-171c6c5d-a1e0-4f39-9a33-43fbb58713d8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7ad0458c-661d-4a44-935e-2ad0fd78feca' class='xr-var-data-in' type='checkbox'><label for='data-7ad0458c-661d-4a44-935e-2ad0fd78feca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5487,7 +5607,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-3804f412-9106-41bf-8721-e0ba23e82687' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3804f412-9106-41bf-8721-e0ba23e82687' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bee1b657-0918-4287-b05e-55cb334bf2d9' class='xr-var-data-in' type='checkbox'><label for='data-bee1b657-0918-4287-b05e-55cb334bf2d9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-72491ece-6b86-480d-99d0-ec0fcc34c562' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-72491ece-6b86-480d-99d0-ec0fcc34c562' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e4ea791f-6350-42aa-b894-917afaafe405' class='xr-var-data-in' type='checkbox'><label for='data-e4ea791f-6350-42aa-b894-917afaafe405' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -5629,7 +5749,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-faa6d25a-c5d7-47ea-96a3-f6aade95ff74' class='xr-section-summary-in' type='checkbox'  ><label for='section-faa6d25a-c5d7-47ea-96a3-f6aade95ff74' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:26:12.089929</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-bbe15ce2-294f-47a1-8629-1fe49ba95609' class='xr-section-summary-in' type='checkbox'  ><label for='section-bbe15ce2-294f-47a1-8629-1fe49ba95609' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:16:49.312537</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -5651,7 +5771,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:26:12.089929\n",
+       "    date_created:              2022-06-23T10:16:49.312537\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -5663,7 +5783,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5675,14 +5795,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "237bbf4f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:33.851236Z",
+     "iopub.status.busy": "2022-06-23T10:17:33.850965Z",
+     "iopub.status.idle": "2022-06-23T10:17:35.134753Z",
+     "shell.execute_reply": "2022-06-23T10:17:35.134236Z"
+    },
     "papermill": {
-     "duration": 1.391156,
-     "end_time": "2022-02-23T14:02:34.075389",
+     "duration": 1.341654,
+     "end_time": "2022-06-23T10:17:35.141263",
      "exception": false,
-     "start_time": "2022-02-23T14:02:32.684233",
+     "start_time": "2022-06-23T10:17:33.799609",
      "status": "completed"
     },
     "tags": []
@@ -5691,10 +5817,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f2c71761d00>"
+       "<matplotlib.image.AxesImage at 0x7f4abb1bd2e0>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -5718,14 +5844,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "c73dd948",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:35.264640Z",
+     "iopub.status.busy": "2022-06-23T10:17:35.264335Z",
+     "iopub.status.idle": "2022-06-23T10:17:35.269035Z",
+     "shell.execute_reply": "2022-06-23T10:17:35.268554Z"
+    },
     "papermill": {
-     "duration": 0.089936,
-     "end_time": "2022-02-23T14:02:34.247385",
+     "duration": 0.063969,
+     "end_time": "2022-06-23T10:17:35.270335",
      "exception": false,
-     "start_time": "2022-02-23T14:02:34.157449",
+     "start_time": "2022-06-23T10:17:35.206366",
      "status": "completed"
     },
     "tags": []
@@ -5734,13 +5866,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>228.43 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>375.19 ms</td></tr><tr><td>Request duration mean:</td><td>445.81 ms</td></tr><tr><td>Request duration std:</td><td>220.63 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>88</td></tr><tr><td>Request duration min:</td><td>233.67 ms</td></tr><tr><td>Request duration max:</td><td>1337.23 ms</td></tr><tr><td>Request duration median:</td><td>417.19 ms</td></tr><tr><td>Request duration mean:</td><td>461.09 ms</td></tr><tr><td>Request duration std:</td><td>208.79 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f2c716e1e20>"
+       "<xcube_sh.observers._RequestStats at 0x7f4abb0bf4f0>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5754,10 +5886,10 @@
    "id": "416116b6",
    "metadata": {
     "papermill": {
-     "duration": 0.079338,
-     "end_time": "2022-02-23T14:02:34.409478",
+     "duration": 0.05703,
+     "end_time": "2022-06-23T10:17:35.386592",
      "exception": false,
-     "start_time": "2022-02-23T14:02:34.330140",
+     "start_time": "2022-06-23T10:17:35.329562",
      "status": "completed"
     },
     "tags": []
@@ -5770,14 +5902,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "fed878d6",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:35.502254Z",
+     "iopub.status.busy": "2022-06-23T10:17:35.501977Z",
+     "iopub.status.idle": "2022-06-23T10:17:35.527305Z",
+     "shell.execute_reply": "2022-06-23T10:17:35.526777Z"
+    },
     "papermill": {
-     "duration": 0.119794,
-     "end_time": "2022-02-23T14:02:34.610158",
+     "duration": 0.084987,
+     "end_time": "2022-06-23T10:17:35.528775",
      "exception": false,
-     "start_time": "2022-02-23T14:02:34.490364",
+     "start_time": "2022-06-23T10:17:35.443788",
      "status": "completed"
     },
     "tags": []
@@ -6145,7 +6283,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Attributes:\n",
        "    long_name:  Maximum Chlorophyll Index\n",
-       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-64aa31ad-6620-40a7-a761-c4dfe832548c' class='xr-array-in' type='checkbox' checked><label for='section-64aa31ad-6620-40a7-a761-c4dfe832548c' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-4587f622-796a-4d7e-98ac-a57bc4bc48c0' class='xr-array-in' type='checkbox' checked><label for='section-4587f622-796a-4d7e-98ac-a57bc4bc48c0' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -6287,7 +6425,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-dbeb3fc7-b9c8-4204-8787-95d512efc187' class='xr-section-summary-in' type='checkbox'  checked><label for='section-dbeb3fc7-b9c8-4204-8787-95d512efc187' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-453e49e1-51f8-4331-913a-8ba5ac2128c8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-453e49e1-51f8-4331-913a-8ba5ac2128c8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b4dda620-3d78-4acf-b948-ab900ef831da' class='xr-var-data-in' type='checkbox'><label for='data-b4dda620-3d78-4acf-b948-ab900ef831da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-07863e9d-01f2-4656-8be0-5bdda1edbc29' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-07863e9d-01f2-4656-8be0-5bdda1edbc29' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-536b5a8b-bc5a-4f0f-a40f-f7acb61d7ade' class='xr-var-data-in' type='checkbox'><label for='data-536b5a8b-bc5a-4f0f-a40f-f7acb61d7ade' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-0b5f9bc7-474e-4c1b-9b95-8b6140bc7bb3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0b5f9bc7-474e-4c1b-9b95-8b6140bc7bb3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-21473d59-6237-47a2-ac64-6affeb3373f3' class='xr-var-data-in' type='checkbox'><label for='data-21473d59-6237-47a2-ac64-6affeb3373f3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-186aa3f5-373d-4a03-ba37-9207eba7d3a8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-186aa3f5-373d-4a03-ba37-9207eba7d3a8' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-802e3ca6-774a-486f-a647-967ddef25280' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-802e3ca6-774a-486f-a647-967ddef25280' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-39a9d557-ae07-46f3-b621-51339d09c89b' class='xr-var-data-in' type='checkbox'><label for='data-39a9d557-ae07-46f3-b621-51339d09c89b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-1b5f2e3f-848f-4ab7-b8eb-2e06a548768f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1b5f2e3f-848f-4ab7-b8eb-2e06a548768f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-106461e0-7371-4fae-813b-4305f815287a' class='xr-var-data-in' type='checkbox'><label for='data-106461e0-7371-4fae-813b-4305f815287a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-fb124c40-5fc1-43db-a936-f4ab923b3b4a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fb124c40-5fc1-43db-a936-f4ab923b3b4a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-40eaa5c5-da5a-4fe7-828f-e6eb392c82bc' class='xr-var-data-in' type='checkbox'><label for='data-40eaa5c5-da5a-4fe7-828f-e6eb392c82bc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -6307,7 +6445,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bbd039cd-370f-4e8e-bb49-ffe5ad4e5f63' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bbd039cd-370f-4e8e-bb49-ffe5ad4e5f63' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-dc5053c6-0ec2-4f2b-8a17-bb60c512fda7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-dc5053c6-0ec2-4f2b-8a17-bb60c512fda7' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray (time: 40, lat: 2048, lon: 5632)>\n",
@@ -6321,7 +6459,7 @@
        "    units:      unitless"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6348,10 +6486,10 @@
    "id": "ea7288d7",
    "metadata": {
     "papermill": {
-     "duration": 0.178867,
-     "end_time": "2022-02-23T14:02:34.884390",
+     "duration": 0.066689,
+     "end_time": "2022-06-23T10:17:35.653924",
      "exception": false,
-     "start_time": "2022-02-23T14:02:34.705523",
+     "start_time": "2022-06-23T10:17:35.587235",
      "status": "completed"
     },
     "tags": []
@@ -6364,14 +6502,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "26333b09",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:35.770618Z",
+     "iopub.status.busy": "2022-06-23T10:17:35.770105Z",
+     "iopub.status.idle": "2022-06-23T10:17:35.823404Z",
+     "shell.execute_reply": "2022-06-23T10:17:35.822973Z"
+    },
     "papermill": {
-     "duration": 0.15091,
-     "end_time": "2022-02-23T14:02:35.120069",
+     "duration": 0.114732,
+     "end_time": "2022-06-23T10:17:35.826428",
      "exception": false,
-     "start_time": "2022-02-23T14:02:34.969159",
+     "start_time": "2022-06-23T10:17:35.711696",
      "status": "completed"
     },
     "tags": []
@@ -6750,7 +6894,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:26:12.089929\n",
+       "    date_created:              2022-06-23T10:16:49.312537\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -6759,7 +6903,7 @@
        "    geospatial_lat_min:        54.27\n",
        "    geospatial_lon_max:        11.01376\n",
        "    geospatial_lat_max:        54.63864\n",
-       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-13ce7ee6-edc4-4ec5-bf0c-0c61114b6c6a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-13ce7ee6-edc4-4ec5-bf0c-0c61114b6c6a' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-90d94838-2b47-4851-ac99-f59c71c3566b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-90d94838-2b47-4851-ac99-f59c71c3566b' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-d6b88ea6-45eb-4d18-8fcf-e23045ee814d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d6b88ea6-45eb-4d18-8fcf-e23045ee814d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f58c2d1d-7fff-4d83-9471-670007141bb0' class='xr-var-data-in' type='checkbox'><label for='data-f58c2d1d-7fff-4d83-9471-670007141bb0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-852b8b9f-7e12-4d24-b966-7d7e1bd80ccc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-852b8b9f-7e12-4d24-b966-7d7e1bd80ccc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c248e8f8-24d8-43f8-9001-aa3be90b64b2' class='xr-var-data-in' type='checkbox'><label for='data-c248e8f8-24d8-43f8-9001-aa3be90b64b2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-7eb535cb-149d-4173-b452-d25738f01b42' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7eb535cb-149d-4173-b452-d25738f01b42' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e4d60622-30bb-49cf-a253-86a24c5dd0a2' class='xr-var-data-in' type='checkbox'><label for='data-e4d60622-30bb-49cf-a253-86a24c5dd0a2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    processing_level:          L2A</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a416f6ce-842c-4386-a1ef-ea76f02c3698' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a416f6ce-842c-4386-a1ef-ea76f02c3698' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-04bba51f-c906-4ef2-bfec-365106e98c2c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-04bba51f-c906-4ef2-bfec-365106e98c2c' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-2fdf9167-8eb4-4d36-bb80-03cb380cf6f2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2fdf9167-8eb4-4d36-bb80-03cb380cf6f2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4c0a56d5-483d-426f-9f5f-bf09dc62b39b' class='xr-var-data-in' type='checkbox'><label for='data-4c0a56d5-483d-426f-9f5f-bf09dc62b39b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-86236ce3-2d0c-400c-a91d-c61a0896f38e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-86236ce3-2d0c-400c-a91d-c61a0896f38e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1c932e77-e1e5-4c29-a710-c3b9b57f0446' class='xr-var-data-in' type='checkbox'><label for='data-1c932e77-e1e5-4c29-a710-c3b9b57f0446' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-109b3a67-7757-4436-a85e-dc0dd2d4fd0c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-109b3a67-7757-4436-a85e-dc0dd2d4fd0c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-595894e4-cb51-4772-b881-002f1c201c02' class='xr-var-data-in' type='checkbox'><label for='data-595894e4-cb51-4772-b881-002f1c201c02' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -6779,7 +6923,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-06f17dc7-719d-40ac-8bda-56186075dce1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06f17dc7-719d-40ac-8bda-56186075dce1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ccf107d-3477-4e90-a864-db81c6536383' class='xr-var-data-in' type='checkbox'><label for='data-2ccf107d-3477-4e90-a864-db81c6536383' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(40, 2), meta=np.ndarray&gt;</div><input id='attrs-aa59b008-fedc-46ba-b5c1-fea55a932e58' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aa59b008-fedc-46ba-b5c1-fea55a932e58' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-600b2d0f-a141-4b12-b73c-be6369bfcc2b' class='xr-var-data-in' type='checkbox'><label for='data-600b2d0f-a141-4b12-b73c-be6369bfcc2b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -6836,7 +6980,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-b7c16423-5e08-42e9-b4be-24dd22a4a307' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b7c16423-5e08-42e9-b4be-24dd22a4a307' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-684bb5de-941f-477e-822f-69f1c325a858' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-684bb5de-941f-477e-822f-69f1c325a858' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5757dd5c-f162-4398-9122-40bc6c8fff09' class='xr-var-data-in' type='checkbox'><label for='data-5757dd5c-f162-4398-9122-40bc6c8fff09' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-94cb01cf-fa25-43e6-8b6e-f15c8c02e927' class='xr-section-summary-in' type='checkbox'  checked><label for='section-94cb01cf-fa25-43e6-8b6e-f15c8c02e927' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-face9a2e-4f4b-4c19-915e-c950bf8e9510' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-face9a2e-4f4b-4c19-915e-c950bf8e9510' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-54512028-4205-4417-a1cd-ae4f849d054b' class='xr-var-data-in' type='checkbox'><label for='data-54512028-4205-4417-a1cd-ae4f849d054b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -6978,7 +7122,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-8bf919ba-0456-482e-995a-18447c8a7cd0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8bf919ba-0456-482e-995a-18447c8a7cd0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2f5f386d-c463-4b97-ac30-9530b404de2d' class='xr-var-data-in' type='checkbox'><label for='data-2f5f386d-c463-4b97-ac30-9530b404de2d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-030ebbde-e4c1-48f9-a68a-7868a9ee1a52' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-030ebbde-e4c1-48f9-a68a-7868a9ee1a52' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-47b06ad4-4136-4275-8701-cbffba867ea3' class='xr-var-data-in' type='checkbox'><label for='data-47b06ad4-4136-4275-8701-cbffba867ea3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7120,7 +7264,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-aa899510-a313-4d9d-8324-f47557f9e034' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aa899510-a313-4d9d-8324-f47557f9e034' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8aef20d-cac3-40e4-837e-951a8f8172b7' class='xr-var-data-in' type='checkbox'><label for='data-f8aef20d-cac3-40e4-837e-951a8f8172b7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B06</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-05a9aa8b-3189-4bf9-af4b-ff767434f851' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-05a9aa8b-3189-4bf9-af4b-ff767434f851' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-837e151c-4fa8-4114-b242-9bf3e71d0916' class='xr-var-data-in' type='checkbox'><label for='data-837e151c-4fa8-4114-b242-9bf3e71d0916' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>739.8</dd><dt><span>wavelength_a :</span></dt><dd>740.5</dd><dt><span>wavelength_b :</span></dt><dd>739.1</dd><dt><span>bandwidth :</span></dt><dd>15.0</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>15</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7262,7 +7406,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-a651a34d-e85b-4d89-89df-3d80ea09a8bb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a651a34d-e85b-4d89-89df-3d80ea09a8bb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b5661052-f49f-4046-aec1-a1c5cb495a23' class='xr-var-data-in' type='checkbox'><label for='data-b5661052-f49f-4046-aec1-a1c5cb495a23' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B11</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-95c2f1a3-3951-479f-bc03-b2b80e521780' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-95c2f1a3-3951-479f-bc03-b2b80e521780' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d28312be-0383-444c-8d6c-1326598c23b3' class='xr-var-data-in' type='checkbox'><label for='data-d28312be-0383-444c-8d6c-1326598c23b3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>1612.05</dd><dt><span>wavelength_a :</span></dt><dd>1613.7</dd><dt><span>wavelength_b :</span></dt><dd>1610.4</dd><dt><span>bandwidth :</span></dt><dd>92.5</dd><dt><span>bandwidth_a :</span></dt><dd>91</dd><dt><span>bandwidth_b :</span></dt><dd>94</dd><dt><span>resolution :</span></dt><dd>20</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7404,7 +7548,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-91dab7b5-3646-4a1c-9c69-6ecb62fc2ff2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-91dab7b5-3646-4a1c-9c69-6ecb62fc2ff2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0d193712-47dc-4172-a4d8-0cb445fff277' class='xr-var-data-in' type='checkbox'><label for='data-0d193712-47dc-4172-a4d8-0cb445fff277' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CLD</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-9d23e594-663b-4ca9-bfb5-3172e4e4d947' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9d23e594-663b-4ca9-bfb5-3172e4e4d947' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f1217bb1-bb4c-4448-bc8f-d8d26a9cc36b' class='xr-var-data-in' type='checkbox'><label for='data-f1217bb1-bb4c-4448-bc8f-d8d26a9cc36b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7546,7 +7690,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-344e5d90-ddc6-4de2-9c03-ba490d80f45c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-344e5d90-ddc6-4de2-9c03-ba490d80f45c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0f41ada5-4a61-4f85-b3ef-2a32042ff2ea' class='xr-var-data-in' type='checkbox'><label for='data-0f41ada5-4a61-4f85-b3ef-2a32042ff2ea' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-fb3013d7-477c-4234-8fd6-2e49c0ddd371' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fb3013d7-477c-4234-8fd6-2e49c0ddd371' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e28816e5-ad60-4dcb-a362-7c4523382c84' class='xr-var-data-in' type='checkbox'><label for='data-e28816e5-ad60-4dcb-a362-7c4523382c84' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>sample_type :</span></dt><dd>UINT8</dd><dt><span>flag_values :</span></dt><dd>0,1,2,3,4,5,6,7,8,9,10,11</dd><dt><span>flag_meanings :</span></dt><dd>no_data saturated_or_defective dark_area_pixels cloud_shadows vegetation bare_soils water clouds_low_probability_or_unclassified clouds_medium_probability clouds_high_probability cirrus snow_or_ice</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -7688,7 +7832,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-534e2f99-07e0-425e-b11e-f8b69ebf2a7e' class='xr-section-summary-in' type='checkbox'  ><label for='section-534e2f99-07e0-425e-b11e-f8b69ebf2a7e' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:26:12.089929</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-e1bb0628-6453-4380-8c6d-21179e43cbff' class='xr-section-summary-in' type='checkbox'  ><label for='section-e1bb0628-6453-4380-8c6d-21179e43cbff' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd><dt><span>history :</span></dt><dd>[{&#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;, &#x27;cube_config&#x27;: {&#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;, &#x27;B06&#x27;, &#x27;B11&#x27;, &#x27;SCL&#x27;, &#x27;CLD&#x27;], &#x27;band_fill_values&#x27;: None, &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;tile_size&#x27;: [512, 512], &#x27;bbox&#x27;: [10.0, 54.27, 11.01376, 54.63864], &#x27;spatial_res&#x27;: 0.00018, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;time_range&#x27;: [&#x27;2018-05-14T00:00:00+00:00&#x27;, &#x27;2018-07-31T00:00:00+00:00&#x27;], &#x27;time_period&#x27;: &#x27;2 days 00:00:00&#x27;, &#x27;time_tolerance&#x27;: None, &#x27;collection_id&#x27;: None, &#x27;four_d&#x27;: False}}]</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:16:49.312537</dd><dt><span>time_coverage_start :</span></dt><dd>2018-05-14T00:00:00+00:00</dd><dt><span>time_coverage_end :</span></dt><dd>2018-08-02T00:00:00+00:00</dd><dt><span>time_coverage_duration :</span></dt><dd>P80DT0H0M0S</dd><dt><span>time_coverage_resolution :</span></dt><dd>P2DT0H0M0S</dd><dt><span>geospatial_lon_min :</span></dt><dd>10.0</dd><dt><span>geospatial_lat_min :</span></dt><dd>54.27</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.01376</dd><dt><span>geospatial_lat_max :</span></dt><dd>54.63864</dd><dt><span>processing_level :</span></dt><dd>L2A</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -7710,7 +7854,7 @@
        "    Conventions:               CF-1.7\n",
        "    title:                     S2L2A Data Cube Subset\n",
        "    history:                   [{'program': 'xcube_sh.chunkstore.SentinelHubC...\n",
-       "    date_created:              2022-06-23T08:26:12.089929\n",
+       "    date_created:              2022-06-23T10:16:49.312537\n",
        "    time_coverage_start:       2018-05-14T00:00:00+00:00\n",
        "    time_coverage_end:         2018-08-02T00:00:00+00:00\n",
        "    ...                        ...\n",
@@ -7722,7 +7866,7 @@
        "    processing_level:          L2A"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7734,14 +7878,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "3e773cd7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:35.956960Z",
+     "iopub.status.busy": "2022-06-23T10:17:35.956687Z",
+     "iopub.status.idle": "2022-06-23T10:17:35.980494Z",
+     "shell.execute_reply": "2022-06-23T10:17:35.979919Z"
+    },
     "papermill": {
-     "duration": 0.114288,
-     "end_time": "2022-02-23T14:02:35.325381",
+     "duration": 0.096122,
+     "end_time": "2022-06-23T10:17:35.982005",
      "exception": false,
-     "start_time": "2022-02-23T14:02:35.211093",
+     "start_time": "2022-06-23T10:17:35.885883",
      "status": "completed"
     },
     "tags": []
@@ -8109,7 +8259,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Attributes:\n",
        "    long_name:  Normalized Difference Vegetation Index\n",
-       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-744957f9-b3dc-48dc-8bd6-74c856803f50' class='xr-array-in' type='checkbox' checked><label for='section-744957f9-b3dc-48dc-8bd6-74c856803f50' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    units:      unitless</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 40</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-5d9b9920-c97a-409f-8d9d-176ab39b1c1e' class='xr-array-in' type='checkbox' checked><label for='section-5d9b9920-c97a-409f-8d9d-176ab39b1c1e' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -8251,7 +8401,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-f790b19d-829d-4b2b-ada4-43c511420975' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f790b19d-829d-4b2b-ada4-43c511420975' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-9b25de73-dbd4-4549-b99e-a0a9247d83d3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9b25de73-dbd4-4549-b99e-a0a9247d83d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9a16a034-e635-4484-9f4a-6e6fdb819c7e' class='xr-var-data-in' type='checkbox'><label for='data-9a16a034-e635-4484-9f4a-6e6fdb819c7e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-cbcdbadd-92aa-46bb-bd6f-b0b61ea09cc4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cbcdbadd-92aa-46bb-bd6f-b0b61ea09cc4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-84b969de-2fe8-4429-b881-89a3d22b4225' class='xr-var-data-in' type='checkbox'><label for='data-84b969de-2fe8-4429-b881-89a3d22b4225' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-83609632-5fcf-4ef6-9ea4-c22fb887d261' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-83609632-5fcf-4ef6-9ea4-c22fb887d261' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0b0b6faa-b958-4e0e-a7e6-94c6a86161ce' class='xr-var-data-in' type='checkbox'><label for='data-0b0b6faa-b958-4e0e-a7e6-94c6a86161ce' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-c502b837-3707-467b-90e6-5ded37f4d1f5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c502b837-3707-467b-90e6-5ded37f4d1f5' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-4b871450-bc3c-4be7-9574-54d1054fef41' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4b871450-bc3c-4be7-9574-54d1054fef41' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c9c14c9d-2ae3-4b46-811d-1babccced4e7' class='xr-var-data-in' type='checkbox'><label for='data-c9c14c9d-2ae3-4b46-811d-1babccced4e7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-9f013575-08da-43f4-be27-c2d3d8a9285d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9f013575-08da-43f4-be27-c2d3d8a9285d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ce54d30-e92e-4d2a-bf7d-c3719c079162' class='xr-var-data-in' type='checkbox'><label for='data-2ce54d30-e92e-4d2a-bf7d-c3719c079162' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-b9b6ed83-202f-4e33-898f-6479c5d91d48' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b9b6ed83-202f-4e33-898f-6479c5d91d48' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d6deadc3-4009-4483-9442-f2ae3dbfc4ec' class='xr-var-data-in' type='checkbox'><label for='data-d6deadc3-4009-4483-9442-f2ae3dbfc4ec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -8271,7 +8421,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8f5f4432-4a87-45a8-8074-ecd80ee98a73' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8f5f4432-4a87-45a8-8074-ecd80ee98a73' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e72f3456-b2d4-4919-b410-64edf88ed74d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e72f3456-b2d4-4919-b410-64edf88ed74d' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray (time: 40, lat: 2048, lon: 5632)>\n",
@@ -8285,7 +8435,7 @@
        "    units:      unitless"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8301,14 +8451,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "307c418a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:36.111266Z",
+     "iopub.status.busy": "2022-06-23T10:17:36.110721Z",
+     "iopub.status.idle": "2022-06-23T10:17:36.132074Z",
+     "shell.execute_reply": "2022-06-23T10:17:36.131621Z"
+    },
     "papermill": {
-     "duration": 0.134239,
-     "end_time": "2022-02-23T14:02:35.559795",
+     "duration": 0.086949,
+     "end_time": "2022-06-23T10:17:36.133920",
      "exception": false,
-     "start_time": "2022-02-23T14:02:35.425556",
+     "start_time": "2022-06-23T10:17:36.046971",
      "status": "completed"
     },
     "tags": []
@@ -8676,7 +8832,7 @@
        "  * time     (time) datetime64[ns] 2018-05-15 2018-05-17 ... 2018-08-01\n",
        "Data variables:\n",
        "    mci      (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;\n",
-       "    ndvi     (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-8593947c-41ea-47fd-93a8-4c8d8a6506d7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-8593947c-41ea-47fd-93a8-4c8d8a6506d7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span class='xr-has-index'>time</span>: 40</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-884887b8-81fb-4932-a8c2-32df5d758c71' class='xr-section-summary-in' type='checkbox'  checked><label for='section-884887b8-81fb-4932-a8c2-32df5d758c71' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-b929484b-ad00-4f82-8b4c-6a33008a1f27' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b929484b-ad00-4f82-8b4c-6a33008a1f27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-23042813-248e-4c2a-adb7-0cd5d3f31965' class='xr-var-data-in' type='checkbox'><label for='data-23042813-248e-4c2a-adb7-0cd5d3f31965' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-bb941c30-c391-4607-a62f-4b372a92df43' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bb941c30-c391-4607-a62f-4b372a92df43' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c752d7e8-e342-4786-8ae2-448e08528c4f' class='xr-var-data-in' type='checkbox'><label for='data-c752d7e8-e342-4786-8ae2-448e08528c4f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-21dd0c2c-d49a-41a5-bf99-a80e7e05d361' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-21dd0c2c-d49a-41a5-bf99-a80e7e05d361' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d0fe33ba-77eb-4b50-a93d-a32874e8df75' class='xr-var-data-in' type='checkbox'><label for='data-d0fe33ba-77eb-4b50-a93d-a32874e8df75' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
+       "    ndvi     (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-db2a36c5-7604-47f5-94d6-c06bd8092539' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-db2a36c5-7604-47f5-94d6-c06bd8092539' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 5632</li><li><span class='xr-has-index'>time</span>: 40</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-11a4a031-ed64-41cd-a3df-91ce704d278a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-11a4a031-ed64-41cd-a3df-91ce704d278a' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>54.64 54.64 54.64 ... 54.27 54.27</div><input id='attrs-14fa5c50-2ced-4c60-b4a4-8d570d474aea' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-14fa5c50-2ced-4c60-b4a4-8d570d474aea' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6d25883b-344f-4f57-86c6-00dc7b96712d' class='xr-var-data-in' type='checkbox'><label for='data-6d25883b-344f-4f57-86c6-00dc7b96712d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([54.63855, 54.63837, 54.63819, ..., 54.27045, 54.27027, 54.27009])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 ... 11.01 11.01</div><input id='attrs-d71107fd-458a-4772-8418-fd13c5024978' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d71107fd-458a-4772-8418-fd13c5024978' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-860edec6-ee22-4e8e-a3eb-44d22f7bb389' class='xr-var-data-in' type='checkbox'><label for='data-860edec6-ee22-4e8e-a3eb-44d22f7bb389' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>decimal_degrees</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([10.00009, 10.00027, 10.00045, ..., 11.01331, 11.01349, 11.01367])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2018-05-15 ... 2018-08-01</div><input id='attrs-89b8295a-0495-4bf5-8b41-958544d73ab2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-89b8295a-0495-4bf5-8b41-958544d73ab2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d391ca5d-ed74-4ce8-8e52-c0be18ba63b2' class='xr-var-data-in' type='checkbox'><label for='data-d391ca5d-ed74-4ce8-8e52-c0be18ba63b2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2018-05-15T00:00:00.000000000&#x27;, &#x27;2018-05-17T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-19T00:00:00.000000000&#x27;, &#x27;2018-05-21T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-23T00:00:00.000000000&#x27;, &#x27;2018-05-25T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-05-27T00:00:00.000000000&#x27;, &#x27;2018-05-29T00:00:00.000000000&#x27;,\n",
@@ -8696,7 +8852,7 @@
        "       &#x27;2018-07-22T00:00:00.000000000&#x27;, &#x27;2018-07-24T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-26T00:00:00.000000000&#x27;, &#x27;2018-07-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2018-07-30T00:00:00.000000000&#x27;, &#x27;2018-08-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1649f110-6350-4bdd-b837-b65e17424470' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1649f110-6350-4bdd-b837-b65e17424470' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>mci</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-7ce22924-30ce-4202-8c5d-7c268fc1495c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7ce22924-30ce-4202-8c5d-7c268fc1495c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-251ccc68-7575-4f0d-b400-afe9ab2c0e1d' class='xr-var-data-in' type='checkbox'><label for='data-251ccc68-7575-4f0d-b400-afe9ab2c0e1d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bb4cd4f7-cea3-4feb-bfe1-ecba99dc9d76' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bb4cd4f7-cea3-4feb-bfe1-ecba99dc9d76' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>mci</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-26552563-c52b-45de-acc8-ee65c568f6a8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-26552563-c52b-45de-acc8-ee65c568f6a8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ba504055-40b7-47e6-90f7-60ea001f6dc9' class='xr-var-data-in' type='checkbox'><label for='data-ba504055-40b7-47e6-90f7-60ea001f6dc9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Maximum Chlorophyll Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -8838,7 +8994,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>ndvi</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-e444f4f9-6824-4c2f-8170-ec5407e448b3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e444f4f9-6824-4c2f-8170-ec5407e448b3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-acb426bb-121d-4bed-ab6f-a7cbe38d37e5' class='xr-var-data-in' type='checkbox'><label for='data-acb426bb-121d-4bed-ab6f-a7cbe38d37e5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>ndvi</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-41e9f907-ac61-4e6e-bab7-0c3a7fca4504' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-41e9f907-ac61-4e6e-bab7-0c3a7fca4504' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e1b730d9-cf5d-4ede-85ca-2d98d6bdbac1' class='xr-var-data-in' type='checkbox'><label for='data-e1b730d9-cf5d-4ede-85ca-2d98d6bdbac1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Normalized Difference Vegetation Index</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -8980,7 +9136,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-0fb5a36d-f1a8-4fe3-8f92-86058624cc9b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-0fb5a36d-f1a8-4fe3-8f92-86058624cc9b' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-afa0bb74-e6f2-4dd6-b9b3-130e523fef34' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-afa0bb74-e6f2-4dd6-b9b3-130e523fef34' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -8994,7 +9150,7 @@
        "    ndvi     (time, lat, lon) float32 dask.array<chunksize=(1, 512, 512), meta=np.ndarray>"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9006,14 +9162,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "d898c3af",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:36.261508Z",
+     "iopub.status.busy": "2022-06-23T10:17:36.261226Z",
+     "iopub.status.idle": "2022-06-23T10:19:04.049497Z",
+     "shell.execute_reply": "2022-06-23T10:19:04.048962Z"
+    },
     "papermill": {
-     "duration": 79.26467,
-     "end_time": "2022-02-23T14:03:54.912452",
+     "duration": 87.864187,
+     "end_time": "2022-06-23T10:19:04.062283",
      "exception": false,
-     "start_time": "2022-02-23T14:02:35.647782",
+     "start_time": "2022-06-23T10:17:36.198096",
      "status": "completed"
     },
     "tags": []
@@ -9022,10 +9184,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f2c7163afd0>"
+       "<matplotlib.image.AxesImage at 0x7f4abb072d30>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -9049,14 +9211,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "0d0aad9d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:19:04.240811Z",
+     "iopub.status.busy": "2022-06-23T10:19:04.240536Z",
+     "iopub.status.idle": "2022-06-23T10:19:04.245333Z",
+     "shell.execute_reply": "2022-06-23T10:19:04.244602Z"
+    },
     "papermill": {
-     "duration": 0.108616,
-     "end_time": "2022-02-23T14:03:55.125594",
+     "duration": 0.092929,
+     "end_time": "2022-06-23T10:19:04.246758",
      "exception": false,
-     "start_time": "2022-02-23T14:03:55.016978",
+     "start_time": "2022-06-23T10:19:04.153829",
      "status": "completed"
     },
     "tags": []
@@ -9065,13 +9233,13 @@
     {
      "data": {
       "text/html": [
-       "<html><table><tr><td>Number of requests:</td><td>264</td></tr><tr><td>Request duration min:</td><td>228.43 ms</td></tr><tr><td>Request duration max:</td><td>1436.35 ms</td></tr><tr><td>Request duration median:</td><td>394.58 ms</td></tr><tr><td>Request duration mean:</td><td>465.00 ms</td></tr><tr><td>Request duration std:</td><td>222.04 ms</td></tr></table></html>"
+       "<html><table><tr><td>Number of requests:</td><td>264</td></tr><tr><td>Request duration min:</td><td>225.97 ms</td></tr><tr><td>Request duration max:</td><td>1471.60 ms</td></tr><tr><td>Request duration median:</td><td>403.95 ms</td></tr><tr><td>Request duration mean:</td><td>478.54 ms</td></tr><tr><td>Request duration std:</td><td>223.78 ms</td></tr></table></html>"
       ],
       "text/plain": [
-       "<xcube_sh.observers._RequestStats at 0x7f2c7172f4f0>"
+       "<xcube_sh.observers._RequestStats at 0x7f4abb10cb20>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9084,7 +9252,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c18f093e-e910-46db-ab3b-f3c9c1e8c8fb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.079544,
+     "end_time": "2022-06-23T10:19:04.408958",
+     "exception": false,
+     "start_time": "2022-06-23T10:19:04.329414",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
@@ -9108,14 +9285,14 @@
    "version": "3.8.12"
   },
   "papermill": {
-   "duration": 123.022906,
-   "end_time": "2022-02-23T14:03:55.750213",
+   "duration": 181.587309,
+   "end_time": "2022-06-23T10:19:05.107837",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/tmp/tmpuvugad0r",
-   "output_path": "/tmp/cur_notebook.ipynb",
+   "input_path": "/tmp/tmpwerxy6qb",
+   "output_path": "/tmp/notebook_output.ipynb",
    "parameters": {},
-   "start_time": "2022-02-23T14:01:52.727307",
+   "start_time": "2022-06-23T10:16:03.520528",
    "version": "2.1.0"
   },
   "properties": {

--- a/notebooks/curated/EDC_Sentinel_Hub-XCUBE_integration.ipynb
+++ b/notebooks/curated/EDC_Sentinel_Hub-XCUBE_integration.ipynb
@@ -9121,6 +9121,7 @@
   "properties": {
    "description": "Euro Data Cube Sentinel Hub - XCUBE integration",
    "id": "sh-xcube-integration",
+   "license": null,
    "name": "Sentinel Hub - XCUBE integration",
    "requirements": [
     "eurodatacube"

--- a/notebooks/curated/EDC_xcube_generator_service.ipynb
+++ b/notebooks/curated/EDC_xcube_generator_service.ipynb
@@ -6,16 +6,16 @@
    "id": "12a2b516",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:11.507009Z",
-     "iopub.status.busy": "2022-02-23T14:10:11.506649Z",
-     "iopub.status.idle": "2022-02-23T14:10:11.584171Z",
-     "shell.execute_reply": "2022-02-23T14:10:11.583383Z"
+     "iopub.execute_input": "2022-06-23T10:16:04.945661Z",
+     "iopub.status.busy": "2022-06-23T10:16:04.945212Z",
+     "iopub.status.idle": "2022-06-23T10:16:05.031046Z",
+     "shell.execute_reply": "2022-06-23T10:16:05.030426Z"
     },
     "papermill": {
-     "duration": 0.146693,
-     "end_time": "2022-02-23T14:10:11.586089",
+     "duration": 0.154214,
+     "end_time": "2022-06-23T10:16:05.041449",
      "exception": false,
-     "start_time": "2022-02-23T14:10:11.439396",
+     "start_time": "2022-06-23T10:16:04.887235",
      "status": "completed"
     },
     "tags": []
@@ -79,10 +79,10 @@
    "id": "886e7a56-37e9-4082-b435-2215a3db5aae",
    "metadata": {
     "papermill": {
-     "duration": 0.065119,
-     "end_time": "2022-02-23T14:10:11.722479",
+     "duration": 0.038866,
+     "end_time": "2022-06-23T10:16:05.125734",
      "exception": false,
-     "start_time": "2022-02-23T14:10:11.657360",
+     "start_time": "2022-06-23T10:16:05.086868",
      "status": "completed"
     },
     "tags": []
@@ -108,10 +108,10 @@
    "id": "b8feb5f4-f14d-4f6a-87f9-fcff9284c964",
    "metadata": {
     "papermill": {
-     "duration": 0.065849,
-     "end_time": "2022-02-23T14:10:11.855883",
+     "duration": 0.049633,
+     "end_time": "2022-06-23T10:16:05.212938",
      "exception": false,
-     "start_time": "2022-02-23T14:10:11.790034",
+     "start_time": "2022-06-23T10:16:05.163305",
      "status": "completed"
     },
     "tags": []
@@ -122,14 +122,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "d0b57b19-ac46-4d62-9bc3-e632771255c3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:05.303661Z",
+     "iopub.status.busy": "2022-06-23T10:16:05.302986Z",
+     "iopub.status.idle": "2022-06-23T10:16:08.782575Z",
+     "shell.execute_reply": "2022-06-23T10:16:08.781973Z"
+    },
     "papermill": {
-     "duration": 4.516794,
-     "end_time": "2022-02-23T14:10:16.440564",
+     "duration": 3.527602,
+     "end_time": "2022-06-23T10:16:08.784453",
      "exception": false,
-     "start_time": "2022-02-23T14:10:11.923770",
+     "start_time": "2022-06-23T10:16:05.256851",
      "status": "completed"
     },
     "tags": []
@@ -159,10 +165,10 @@
    "id": "312a9878-cf69-4017-8a54-e5170a7e029f",
    "metadata": {
     "papermill": {
-     "duration": 0.067469,
-     "end_time": "2022-02-23T14:10:16.731336",
+     "duration": 0.034296,
+     "end_time": "2022-06-23T10:16:08.854016",
      "exception": false,
-     "start_time": "2022-02-23T14:10:16.663867",
+     "start_time": "2022-06-23T10:16:08.819720",
      "status": "completed"
     },
     "tags": []
@@ -173,14 +179,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "a8369528-957d-485b-b727-ce359cbe5653",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:08.926007Z",
+     "iopub.status.busy": "2022-06-23T10:16:08.925706Z",
+     "iopub.status.idle": "2022-06-23T10:16:08.930465Z",
+     "shell.execute_reply": "2022-06-23T10:16:08.929861Z"
+    },
     "papermill": {
-     "duration": 0.075691,
-     "end_time": "2022-02-23T14:10:16.874232",
+     "duration": 0.044019,
+     "end_time": "2022-06-23T10:16:08.931883",
      "exception": false,
-     "start_time": "2022-02-23T14:10:16.798541",
+     "start_time": "2022-06-23T10:16:08.887864",
      "status": "completed"
     },
     "tags": []
@@ -189,10 +201,10 @@
     {
      "data": {
       "text/plain": [
-       "'0.11.2'"
+       "'0.10.1'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -207,10 +219,10 @@
    "id": "d29d0423-101c-49ea-a945-8560ef1ce4ea",
    "metadata": {
     "papermill": {
-     "duration": 0.068089,
-     "end_time": "2022-02-23T14:10:17.014234",
+     "duration": 0.037156,
+     "end_time": "2022-06-23T10:16:09.002619",
      "exception": false,
-     "start_time": "2022-02-23T14:10:16.946145",
+     "start_time": "2022-06-23T10:16:08.965463",
      "status": "completed"
     },
     "tags": []
@@ -221,14 +233,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "afbbfb3a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:09.071958Z",
+     "iopub.status.busy": "2022-06-23T10:16:09.071683Z",
+     "iopub.status.idle": "2022-06-23T10:16:09.075034Z",
+     "shell.execute_reply": "2022-06-23T10:16:09.074541Z"
+    },
     "papermill": {
-     "duration": 0.076175,
-     "end_time": "2022-02-23T14:10:17.158193",
+     "duration": 0.039189,
+     "end_time": "2022-06-23T10:16:09.076291",
      "exception": false,
-     "start_time": "2022-02-23T14:10:17.082018",
+     "start_time": "2022-06-23T10:16:09.037102",
      "status": "completed"
     },
     "tags": []
@@ -244,14 +262,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "918f5d38",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:09.145159Z",
+     "iopub.status.busy": "2022-06-23T10:16:09.144877Z",
+     "iopub.status.idle": "2022-06-23T10:16:09.151368Z",
+     "shell.execute_reply": "2022-06-23T10:16:09.150874Z"
+    },
     "papermill": {
-     "duration": 0.098098,
-     "end_time": "2022-02-23T14:10:17.327273",
+     "duration": 0.042368,
+     "end_time": "2022-06-23T10:16:09.152678",
      "exception": false,
-     "start_time": "2022-02-23T14:10:17.229175",
+     "start_time": "2022-06-23T10:16:09.110310",
      "status": "completed"
     },
     "tags": []
@@ -266,10 +290,10 @@
    "id": "25beea30-5515-471f-a9eb-0c1c0bdeae96",
    "metadata": {
     "papermill": {
-     "duration": 0.068309,
-     "end_time": "2022-02-23T14:10:17.462245",
+     "duration": 0.038069,
+     "end_time": "2022-06-23T10:16:09.224214",
      "exception": false,
-     "start_time": "2022-02-23T14:10:17.393936",
+     "start_time": "2022-06-23T10:16:09.186145",
      "status": "completed"
     },
     "tags": []
@@ -283,10 +307,10 @@
    "id": "732ae632-5c21-4a01-ba0a-36ad936fdb72",
    "metadata": {
     "papermill": {
-     "duration": 0.067166,
-     "end_time": "2022-02-23T14:10:17.595291",
+     "duration": 0.0349,
+     "end_time": "2022-06-23T10:16:09.292914",
      "exception": false,
-     "start_time": "2022-02-23T14:10:17.528125",
+     "start_time": "2022-06-23T10:16:09.258014",
      "status": "completed"
     },
     "tags": []
@@ -297,14 +321,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "4ba8c114-1b18-43c6-bba5-eba72ddedc94",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:09.363914Z",
+     "iopub.status.busy": "2022-06-23T10:16:09.363610Z",
+     "iopub.status.idle": "2022-06-23T10:16:09.366914Z",
+     "shell.execute_reply": "2022-06-23T10:16:09.366427Z"
+    },
     "papermill": {
-     "duration": 0.074534,
-     "end_time": "2022-02-23T14:10:17.737772",
+     "duration": 0.041454,
+     "end_time": "2022-06-23T10:16:09.368220",
      "exception": false,
-     "start_time": "2022-02-23T14:10:17.663238",
+     "start_time": "2022-06-23T10:16:09.326766",
      "status": "completed"
     },
     "tags": []
@@ -324,10 +354,10 @@
    "id": "bd2dc5c1-1220-458c-aad0-49b65cdbbfee",
    "metadata": {
     "papermill": {
-     "duration": 0.068098,
-     "end_time": "2022-02-23T14:10:17.876678",
+     "duration": 0.033998,
+     "end_time": "2022-06-23T10:16:09.438781",
      "exception": false,
-     "start_time": "2022-02-23T14:10:17.808580",
+     "start_time": "2022-06-23T10:16:09.404783",
      "status": "completed"
     },
     "tags": []
@@ -338,14 +368,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c1bec9e7-4b6a-43d7-8737-4a757322e4bf",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:09.507118Z",
+     "iopub.status.busy": "2022-06-23T10:16:09.506838Z",
+     "iopub.status.idle": "2022-06-23T10:16:09.511863Z",
+     "shell.execute_reply": "2022-06-23T10:16:09.511411Z"
+    },
     "papermill": {
-     "duration": 0.079784,
-     "end_time": "2022-02-23T14:10:18.024896",
+     "duration": 0.040813,
+     "end_time": "2022-06-23T10:16:09.513282",
      "exception": false,
-     "start_time": "2022-02-23T14:10:17.945112",
+     "start_time": "2022-06-23T10:16:09.472469",
      "status": "completed"
     },
     "tags": []
@@ -357,24 +393,24 @@
        "coordinates": [
         [
          [
-          11,
-          53
+          11.0,
+          53.0
          ],
          [
-          11,
-          55
+          11.0,
+          55.0
          ],
          [
-          7,
-          55
+          7.0,
+          55.0
          ],
          [
-          7,
-          53
+          7.0,
+          53.0
          ],
          [
-          11,
-          53
+          11.0,
+          53.0
          ]
         ]
        ],
@@ -402,10 +438,10 @@
    "id": "cb40d726-244d-4fb1-9f79-e77fdb26241c",
    "metadata": {
     "papermill": {
-     "duration": 0.069867,
-     "end_time": "2022-02-23T14:10:18.170635",
+     "duration": 0.033954,
+     "end_time": "2022-06-23T10:16:09.581109",
      "exception": false,
-     "start_time": "2022-02-23T14:10:18.100768",
+     "start_time": "2022-06-23T10:16:09.547155",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +462,10 @@
    "id": "98b53ae2-5206-406d-8c48-3dd46cf9cd83",
    "metadata": {
     "papermill": {
-     "duration": 0.070744,
-     "end_time": "2022-02-23T14:10:18.309361",
+     "duration": 0.033744,
+     "end_time": "2022-06-23T10:16:09.651925",
      "exception": false,
-     "start_time": "2022-02-23T14:10:18.238617",
+     "start_time": "2022-06-23T10:16:09.618181",
      "status": "completed"
     },
     "tags": []
@@ -458,14 +494,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "01906a83",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:09.722139Z",
+     "iopub.status.busy": "2022-06-23T10:16:09.721864Z",
+     "iopub.status.idle": "2022-06-23T10:16:09.726221Z",
+     "shell.execute_reply": "2022-06-23T10:16:09.725627Z"
+    },
     "papermill": {
-     "duration": 0.0766,
-     "end_time": "2022-02-23T14:10:18.454527",
+     "duration": 0.041757,
+     "end_time": "2022-06-23T10:16:09.727554",
      "exception": false,
-     "start_time": "2022-02-23T14:10:18.377927",
+     "start_time": "2022-06-23T10:16:09.685797",
      "status": "completed"
     },
     "tags": []
@@ -494,14 +536,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d22dfb04",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:09.800116Z",
+     "iopub.status.busy": "2022-06-23T10:16:09.799599Z",
+     "iopub.status.idle": "2022-06-23T10:16:09.802970Z",
+     "shell.execute_reply": "2022-06-23T10:16:09.802327Z"
+    },
     "papermill": {
-     "duration": 0.082883,
-     "end_time": "2022-02-23T14:10:18.612865",
+     "duration": 0.042569,
+     "end_time": "2022-06-23T10:16:09.804356",
      "exception": false,
-     "start_time": "2022-02-23T14:10:18.529982",
+     "start_time": "2022-06-23T10:16:09.761787",
      "status": "completed"
     },
     "tags": []
@@ -520,10 +568,10 @@
    "id": "df4c15bd-9609-4949-ade5-4a2fe2cebc27",
    "metadata": {
     "papermill": {
-     "duration": 0.067822,
-     "end_time": "2022-02-23T14:10:18.754185",
+     "duration": 0.034635,
+     "end_time": "2022-06-23T10:16:09.873183",
      "exception": false,
-     "start_time": "2022-02-23T14:10:18.686363",
+     "start_time": "2022-06-23T10:16:09.838548",
      "status": "completed"
     },
     "tags": []
@@ -534,14 +582,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "f3f74fab-dc02-4e92-932f-82713a63b988",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:09.947332Z",
+     "iopub.status.busy": "2022-06-23T10:16:09.946984Z",
+     "iopub.status.idle": "2022-06-23T10:16:09.950986Z",
+     "shell.execute_reply": "2022-06-23T10:16:09.950280Z"
+    },
     "papermill": {
-     "duration": 0.074383,
-     "end_time": "2022-02-23T14:10:18.896556",
+     "duration": 0.040474,
+     "end_time": "2022-06-23T10:16:09.952359",
      "exception": false,
-     "start_time": "2022-02-23T14:10:18.822173",
+     "start_time": "2022-06-23T10:16:09.911885",
      "status": "completed"
     },
     "tags": []
@@ -553,14 +607,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "053e1fcc-7007-496d-9b0a-c50caf597df7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:10.024226Z",
+     "iopub.status.busy": "2022-06-23T10:16:10.023907Z",
+     "iopub.status.idle": "2022-06-23T10:16:21.810598Z",
+     "shell.execute_reply": "2022-06-23T10:16:21.810088Z"
+    },
     "papermill": {
-     "duration": 8.916904,
-     "end_time": "2022-02-23T14:10:27.886375",
+     "duration": 11.825216,
+     "end_time": "2022-06-23T10:16:21.812188",
      "exception": false,
-     "start_time": "2022-02-23T14:10:18.969471",
+     "start_time": "2022-06-23T10:16:09.986972",
      "status": "completed"
     },
     "tags": []
@@ -570,10 +630,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-06-23 08:34:48 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-97806c7d-4866-4eb0.yaml.",
-        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-97806c7d-4866-4eb0.json",
-        "2022-06-23 08:34:52 XCUBE GEN END"
+        "2022-06-23 10:16:14 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-5cb9b7c8-3544-45a8.yaml.",
+        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-5cb9b7c8-3544-45a8.json",
+        "2022-06-23 10:16:20 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -583,10 +643,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          7,
-          53,
-          11,
-          55
+          7.0,
+          53.0,
+          11.0,
+          55.0
          ],
          "crs": "WGS84",
          "data_id": "SH_demo.zarr",
@@ -645,10 +705,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff35ac33a00>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7fef2ba09df0>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -662,10 +722,10 @@
    "id": "73e17d90-0874-4461-a6df-36819f45d099",
    "metadata": {
     "papermill": {
-     "duration": 0.068322,
-     "end_time": "2022-02-23T14:10:28.037581",
+     "duration": 0.035759,
+     "end_time": "2022-06-23T10:16:21.882792",
      "exception": false,
-     "start_time": "2022-02-23T14:10:27.969259",
+     "start_time": "2022-06-23T10:16:21.847033",
      "status": "completed"
     },
     "tags": []
@@ -676,33 +736,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "bb136bf0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:16:21.955508Z",
+     "iopub.status.busy": "2022-06-23T10:16:21.955234Z",
+     "iopub.status.idle": "2022-06-23T10:17:28.798430Z",
+     "shell.execute_reply": "2022-06-23T10:17:28.797839Z"
+    },
     "papermill": {
-     "duration": 60.113048,
-     "end_time": "2022-02-23T14:11:28.220937",
+     "duration": 66.91971,
+     "end_time": "2022-06-23T10:17:28.838713",
      "exception": false,
-     "start_time": "2022-02-23T14:10:28.107889",
+     "start_time": "2022-06-23T10:16:21.919003",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - done.\n"
+     ]
+    }
+   ],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "0a50db04-9d2b-4671-b5c6-b97a5cce0887",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:28.917621Z",
+     "iopub.status.busy": "2022-06-23T10:17:28.917262Z",
+     "iopub.status.idle": "2022-06-23T10:17:28.928763Z",
+     "shell.execute_reply": "2022-06-23T10:17:28.928057Z"
+    },
     "papermill": {
-     "duration": 0.088492,
-     "end_time": "2022-02-23T14:11:28.383649",
+     "duration": 0.054078,
+     "end_time": "2022-06-23T10:17:28.930170",
      "exception": false,
-     "start_time": "2022-02-23T14:11:28.295157",
+     "start_time": "2022-06-23T10:17:28.876092",
      "status": "completed"
     },
     "tags": []
@@ -711,12 +798,12 @@
     {
      "data": {
       "application/json": {
-       "message": "Cube generated successfully after 35.59 seconds",
+       "message": "Cube generated successfully after 46.95 seconds",
        "output": [
-        "2022-06-23 08:35:12 XCUBE GEN START",
+        "2022-06-23 10:16:34 XCUBE GEN START",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/pandas/core/tools/timedeltas.py:148: FutureWarning: Units 'M', 'Y' and 'y' do not represent unambiguous timedelta values and will be removed in a future version.",
         "  return _coerce_scalar_to_timedelta_type(arg, unit=unit, errors=errors)",
-        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-5d0702a8-5118-467e.yaml.",
+        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-843d85bb-d736-4a33.yaml.",
         "Generating cube - ...",
         "Generating cube - 0.0%: reading cube - ...",
         "Generating cube - 2.4%: reading cube - 33.3%",
@@ -1258,8 +1345,8 @@
         "Generating cube - 99.1%: writing cube - 99.8%",
         "Generating cube - 99.1%: writing cube - done.",
         "Generating cube - done.",
-        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-5d0702a8-5118-467e.json",
-        "2022-06-23 08:35:54 XCUBE GEN END"
+        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-843d85bb-d736-4a33.json",
+        "2022-06-23 10:17:27 XCUBE GEN END"
        ],
        "result": {
         "data_id": "SH_demo.zarr"
@@ -1268,10 +1355,10 @@
        "status_code": 201
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff35ac33670>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7fef4c1267c0>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1285,10 +1372,10 @@
    "id": "1f99dda3-f2f7-4006-9421-64be6a7f4939",
    "metadata": {
     "papermill": {
-     "duration": 0.070715,
-     "end_time": "2022-02-23T14:11:28.549096",
+     "duration": 0.039635,
+     "end_time": "2022-06-23T10:17:29.006569",
      "exception": false,
-     "start_time": "2022-02-23T14:11:28.478381",
+     "start_time": "2022-06-23T10:17:28.966934",
      "status": "completed"
     },
     "tags": []
@@ -1299,14 +1386,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "0523fd2e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:29.082323Z",
+     "iopub.status.busy": "2022-06-23T10:17:29.082023Z",
+     "iopub.status.idle": "2022-06-23T10:17:29.117191Z",
+     "shell.execute_reply": "2022-06-23T10:17:29.116598Z"
+    },
     "papermill": {
-     "duration": 0.125014,
-     "end_time": "2022-02-23T14:11:28.744668",
+     "duration": 0.075236,
+     "end_time": "2022-06-23T10:17:29.119365",
      "exception": false,
-     "start_time": "2022-02-23T14:11:28.619654",
+     "start_time": "2022-06-23T10:17:29.044129",
      "status": "completed"
     },
     "tags": []
@@ -1318,14 +1411,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "1703da74",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:29.197969Z",
+     "iopub.status.busy": "2022-06-23T10:17:29.197647Z",
+     "iopub.status.idle": "2022-06-23T10:17:29.332562Z",
+     "shell.execute_reply": "2022-06-23T10:17:29.331971Z"
+    },
     "papermill": {
-     "duration": 0.214667,
-     "end_time": "2022-02-23T14:11:29.037230",
+     "duration": 0.175596,
+     "end_time": "2022-06-23T10:17:29.334315",
      "exception": false,
-     "start_time": "2022-02-23T14:11:28.822563",
+     "start_time": "2022-06-23T10:17:29.158719",
      "status": "completed"
     },
     "tags": []
@@ -1337,14 +1436,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "baf12155-4656-4ef1-a09f-55053b7a5e0e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:29.419069Z",
+     "iopub.status.busy": "2022-06-23T10:17:29.418792Z",
+     "iopub.status.idle": "2022-06-23T10:17:29.422726Z",
+     "shell.execute_reply": "2022-06-23T10:17:29.422225Z"
+    },
     "papermill": {
-     "duration": 0.096944,
-     "end_time": "2022-02-23T14:11:29.206135",
+     "duration": 0.05272,
+     "end_time": "2022-06-23T10:17:29.424160",
      "exception": false,
-     "start_time": "2022-02-23T14:11:29.109191",
+     "start_time": "2022-06-23T10:17:29.371440",
      "status": "completed"
     },
     "tags": []
@@ -1353,10 +1458,14 @@
     {
      "data": {
       "text/plain": [
-       "['SH_demo.zarr', 'sh-S2L2A_BYOA.zarr']"
+       "['COP_demo_v2.zarr',\n",
+       " 'SH_demo.zarr',\n",
+       " 'cci-chlor_a.zarr',\n",
+       " 'sh-S2L2A_BYOA.zarr',\n",
+       " 'volumetric_surface_soil_moisture.zarr']"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1370,10 +1479,10 @@
    "id": "aa1a7282-3490-4d87-a689-a6ce3de3de5d",
    "metadata": {
     "papermill": {
-     "duration": 0.079016,
-     "end_time": "2022-02-23T14:11:29.373651",
+     "duration": 0.046514,
+     "end_time": "2022-06-23T10:17:29.507842",
      "exception": false,
-     "start_time": "2022-02-23T14:11:29.294635",
+     "start_time": "2022-06-23T10:17:29.461328",
      "status": "completed"
     },
     "tags": []
@@ -1384,14 +1493,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "55c221ab",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:29.583966Z",
+     "iopub.status.busy": "2022-06-23T10:17:29.583679Z",
+     "iopub.status.idle": "2022-06-23T10:17:29.935234Z",
+     "shell.execute_reply": "2022-06-23T10:17:29.934606Z"
+    },
     "papermill": {
-     "duration": 0.350804,
-     "end_time": "2022-02-23T14:11:29.794929",
+     "duration": 0.392169,
+     "end_time": "2022-06-23T10:17:29.937671",
      "exception": false,
-     "start_time": "2022-02-23T14:11:29.444125",
+     "start_time": "2022-06-23T10:17:29.545502",
      "status": "completed"
     },
     "tags": []
@@ -1764,7 +1879,7 @@
        "    B05        (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-06-23T08:35:16.830469\n",
+       "    date_created:               2022-06-23T10:16:39.577988\n",
        "    geospatial_bounds:          POLYGON((7 53, 7 55.048, 11.096 55.048, 11.09...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         55.048\n",
@@ -1775,9 +1890,9 @@
        "    time_coverage_duration:     P3DT23H40M56S\n",
        "    time_coverage_end:          2021-03-05T10:36:25+00:00\n",
        "    time_coverage_start:        2021-03-01T10:55:29+00:00\n",
-       "    title:                      S2L2A Data Cube Subset</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-cdf7198d-5d89-4736-b07d-ce17d770f358' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-cdf7198d-5d89-4736-b07d-ce17d770f358' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 4</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 4096</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-7801716a-329f-418e-853c-09611f61df89' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7801716a-329f-418e-853c-09611f61df89' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>55.05 55.05 55.05 ... 53.0 53.0</div><input id='attrs-49fa6cd1-e25f-4276-8b82-abd7b4a521e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-49fa6cd1-e25f-4276-8b82-abd7b4a521e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-10d6a1b0-d5f2-43f2-8e23-b665c7bdcc4f' class='xr-var-data-in' type='checkbox'><label for='data-10d6a1b0-d5f2-43f2-8e23-b665c7bdcc4f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([55.0475, 55.0465, 55.0455, ..., 53.0025, 53.0015, 53.0005])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>7.0 7.002 7.002 ... 11.09 11.1</div><input id='attrs-bd736ac6-3933-49c0-b31d-a24ca5d571fa' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bd736ac6-3933-49c0-b31d-a24ca5d571fa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8af02625-1bc8-4bd7-9442-ea2ccb01421d' class='xr-var-data-in' type='checkbox'><label for='data-8af02625-1bc8-4bd7-9442-ea2ccb01421d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([ 7.0005,  7.0015,  7.0025, ..., 11.0935, 11.0945, 11.0955])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2021-03-01T10:55:53 ... 2021-03-...</div><input id='attrs-06c0b320-e989-4a0a-b3d7-8eacf5e75136' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06c0b320-e989-4a0a-b3d7-8eacf5e75136' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a399a657-525d-47a2-84e4-3ac70437c299' class='xr-var-data-in' type='checkbox'><label for='data-a399a657-525d-47a2-84e4-3ac70437c299' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2021-03-01T10:55:53.000000000&#x27;, &#x27;2021-03-02T10:25:53.000000000&#x27;,\n",
+       "    title:                      S2L2A Data Cube Subset</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-d06df829-780c-43d2-922b-745f7a3641ad' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d06df829-780c-43d2-922b-745f7a3641ad' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 4</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 4096</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-341525ab-2775-4244-9fb2-291a84762924' class='xr-section-summary-in' type='checkbox'  checked><label for='section-341525ab-2775-4244-9fb2-291a84762924' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>55.05 55.05 55.05 ... 53.0 53.0</div><input id='attrs-56b2944f-7b6d-4bc6-819b-da6fd38ffde8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-56b2944f-7b6d-4bc6-819b-da6fd38ffde8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c15873d1-c187-4c90-9dd8-afb470f60aa8' class='xr-var-data-in' type='checkbox'><label for='data-c15873d1-c187-4c90-9dd8-afb470f60aa8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([55.0475, 55.0465, 55.0455, ..., 53.0025, 53.0015, 53.0005])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>7.0 7.002 7.002 ... 11.09 11.1</div><input id='attrs-ee1b2506-b7bb-4472-b114-d705c1b14d39' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee1b2506-b7bb-4472-b114-d705c1b14d39' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4e336760-e578-44a6-9908-75e47e7b0bc5' class='xr-var-data-in' type='checkbox'><label for='data-4e336760-e578-44a6-9908-75e47e7b0bc5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([ 7.0005,  7.0015,  7.0025, ..., 11.0935, 11.0945, 11.0955])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2021-03-01T10:55:53 ... 2021-03-...</div><input id='attrs-a5c2bcc5-8b13-4241-a8bb-d845db78b0e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a5c2bcc5-8b13-4241-a8bb-d845db78b0e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1efd295b-7635-43f2-8cfd-0c70590cd2b4' class='xr-var-data-in' type='checkbox'><label for='data-1efd295b-7635-43f2-8cfd-0c70590cd2b4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2021-03-01T10:55:53.000000000&#x27;, &#x27;2021-03-02T10:25:53.000000000&#x27;,\n",
        "       &#x27;2021-03-03T10:45:53.000000000&#x27;, &#x27;2021-03-05T10:35:56.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(4, 2), meta=np.ndarray&gt;</div><input id='attrs-dd33c3ba-a40b-47b1-88cd-1ca0048175fa' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dd33c3ba-a40b-47b1-88cd-1ca0048175fa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-67ba2750-487a-4afe-b133-179b88d08b3f' class='xr-var-data-in' type='checkbox'><label for='data-67ba2750-487a-4afe-b133-179b88d08b3f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(4, 2), meta=np.ndarray&gt;</div><input id='attrs-f7a97ee5-5d07-4e5c-86f2-826d6f7be0f2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f7a97ee5-5d07-4e5c-86f2-826d6f7be0f2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3341a117-3051-488f-a8c8-40b8e08c2b2e' class='xr-var-data-in' type='checkbox'><label for='data-3341a117-3051-488f-a8c8-40b8e08c2b2e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1834,7 +1949,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-0bbdcce8-b7d4-4912-9071-0d9f46ecf52a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0bbdcce8-b7d4-4912-9071-0d9f46ecf52a' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-5b878594-6a86-4b9d-b910-d065bfa82f1c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5b878594-6a86-4b9d-b910-d065bfa82f1c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6addeda-f95f-4269-9c81-bd47e3736aee' class='xr-var-data-in' type='checkbox'><label for='data-e6addeda-f95f-4269-9c81-bd47e3736aee' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-f6ee365a-6b30-4da4-8344-b38756bbf0f1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f6ee365a-6b30-4da4-8344-b38756bbf0f1' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-86b42ed8-c224-4272-903b-6e9c50380639' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-86b42ed8-c224-4272-903b-6e9c50380639' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f11ecbb-91c0-4b9b-9b43-c8d5b7d9736c' class='xr-var-data-in' type='checkbox'><label for='data-3f11ecbb-91c0-4b9b-9b43-c8d5b7d9736c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -1940,7 +2055,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-56cb0706-a4de-4776-b71b-33dfb8524f11' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-56cb0706-a4de-4776-b71b-33dfb8524f11' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f57c79f3-9b32-400d-a030-40eeae37a6ca' class='xr-var-data-in' type='checkbox'><label for='data-f57c79f3-9b32-400d-a030-40eeae37a6ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-aeda17a3-f1bd-455f-9b1d-339be39256d9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-aeda17a3-f1bd-455f-9b1d-339be39256d9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f443609f-738b-4979-b5ce-3567fc68d971' class='xr-var-data-in' type='checkbox'><label for='data-f443609f-738b-4979-b5ce-3567fc68d971' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2046,7 +2161,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-4fa5f3d4-1954-42cf-8c3b-b3e80017632b' class='xr-section-summary-in' type='checkbox'  ><label for='section-4fa5f3d4-1954-42cf-8c3b-b3e80017632b' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:35:16.830469</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((7 53, 7 55.048, 11.096 55.048, 11.096 53, 7 53))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>55.048</dd><dt><span>geospatial_lat_min :</span></dt><dd>53</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.096</dd><dt><span>geospatial_lon_min :</span></dt><dd>7</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_config&#x27;: {&#x27;band_fill_values&#x27;: None, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;], &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;bbox&#x27;: [7.0, 53.0, 11.096, 55.048], &#x27;collection_id&#x27;: None, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;four_d&#x27;: False, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: None, &#x27;time_range&#x27;: [&#x27;2021-03-01T00:00:00+00:00&#x27;, &#x27;2021-03-06T00:00:00+00:00&#x27;], &#x27;time_tolerance&#x27;: &#x27;0 days 00:10:00&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;}, &#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [7.0, 53.0, 11.0, 55.0], &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2021-03-01&#x27;, &#x27;2021-03-06&#x27;], &#x27;variable_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L2A</dd><dt><span>time_coverage_duration :</span></dt><dd>P3DT23H40M56S</dd><dt><span>time_coverage_end :</span></dt><dd>2021-03-05T10:36:25+00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2021-03-01T10:55:29+00:00</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-5f99be3c-939d-4b3c-9757-1df1499d9413' class='xr-section-summary-in' type='checkbox'  ><label for='section-5f99be3c-939d-4b3c-9757-1df1499d9413' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:16:39.577988</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((7 53, 7 55.048, 11.096 55.048, 11.096 53, 7 53))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>55.048</dd><dt><span>geospatial_lat_min :</span></dt><dd>53</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.096</dd><dt><span>geospatial_lon_min :</span></dt><dd>7</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_config&#x27;: {&#x27;band_fill_values&#x27;: None, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;], &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;bbox&#x27;: [7.0, 53.0, 11.096, 55.048], &#x27;collection_id&#x27;: None, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;four_d&#x27;: False, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: None, &#x27;time_range&#x27;: [&#x27;2021-03-01T00:00:00+00:00&#x27;, &#x27;2021-03-06T00:00:00+00:00&#x27;], &#x27;time_tolerance&#x27;: &#x27;0 days 00:10:00&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;}, &#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [7.0, 53.0, 11.0, 55.0], &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2021-03-01&#x27;, &#x27;2021-03-06&#x27;], &#x27;variable_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L2A</dd><dt><span>time_coverage_duration :</span></dt><dd>P3DT23H40M56S</dd><dt><span>time_coverage_end :</span></dt><dd>2021-03-05T10:36:25+00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2021-03-01T10:55:29+00:00</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2062,7 +2177,7 @@
        "    B05        (time, lat, lon) float32 dask.array<chunksize=(1, 512, 512), meta=np.ndarray>\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-06-23T08:35:16.830469\n",
+       "    date_created:               2022-06-23T10:16:39.577988\n",
        "    geospatial_bounds:          POLYGON((7 53, 7 55.048, 11.096 55.048, 11.09...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         55.048\n",
@@ -2076,7 +2191,7 @@
        "    title:                      S2L2A Data Cube Subset"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2091,10 +2206,10 @@
    "id": "266116db-6cc6-4486-a771-184c9a02efd8",
    "metadata": {
     "papermill": {
-     "duration": 0.073586,
-     "end_time": "2022-02-23T14:11:29.946055",
+     "duration": 0.042879,
+     "end_time": "2022-06-23T10:17:30.019618",
      "exception": false,
-     "start_time": "2022-02-23T14:11:29.872469",
+     "start_time": "2022-06-23T10:17:29.976739",
      "status": "completed"
     },
     "tags": []
@@ -2105,14 +2220,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "55a0ba76",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:30.102044Z",
+     "iopub.status.busy": "2022-06-23T10:17:30.101757Z",
+     "iopub.status.idle": "2022-06-23T10:17:38.793529Z",
+     "shell.execute_reply": "2022-06-23T10:17:38.793022Z"
+    },
     "papermill": {
-     "duration": 10.788239,
-     "end_time": "2022-02-23T14:11:40.807185",
+     "duration": 8.742659,
+     "end_time": "2022-06-23T10:17:38.803353",
      "exception": false,
-     "start_time": "2022-02-23T14:11:30.018946",
+     "start_time": "2022-06-23T10:17:30.060694",
      "status": "completed"
     },
     "tags": []
@@ -2121,10 +2242,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7ff35862d040>"
+       "<matplotlib.collections.QuadMesh at 0x7feecf3d75e0>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2150,10 +2271,10 @@
    "id": "fe2c92ef-82e9-4a44-9134-8e03f0cad28f",
    "metadata": {
     "papermill": {
-     "duration": 0.085169,
-     "end_time": "2022-02-23T14:11:40.982674",
+     "duration": 0.054686,
+     "end_time": "2022-06-23T10:17:38.908858",
      "exception": false,
-     "start_time": "2022-02-23T14:11:40.897505",
+     "start_time": "2022-06-23T10:17:38.854172",
      "status": "completed"
     },
     "tags": []
@@ -2177,10 +2298,10 @@
    "id": "6bb2d3cf-4102-4a9d-ac6d-828053f4f0b9",
    "metadata": {
     "papermill": {
-     "duration": 0.089322,
-     "end_time": "2022-02-23T14:11:41.158549",
+     "duration": 0.050459,
+     "end_time": "2022-06-23T10:17:39.009372",
      "exception": false,
-     "start_time": "2022-02-23T14:11:41.069227",
+     "start_time": "2022-06-23T10:17:38.958913",
      "status": "completed"
     },
     "tags": []
@@ -2191,14 +2312,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "f5fd0289-5b14-4671-ad77-e697d274c832",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:39.158058Z",
+     "iopub.status.busy": "2022-06-23T10:17:39.157776Z",
+     "iopub.status.idle": "2022-06-23T10:17:39.162069Z",
+     "shell.execute_reply": "2022-06-23T10:17:39.161549Z"
+    },
     "papermill": {
-     "duration": 0.094111,
-     "end_time": "2022-02-23T14:11:41.337615",
+     "duration": 0.103499,
+     "end_time": "2022-06-23T10:17:39.163503",
      "exception": false,
-     "start_time": "2022-02-23T14:11:41.243504",
+     "start_time": "2022-06-23T10:17:39.060004",
      "status": "completed"
     },
     "tags": []
@@ -2228,14 +2355,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "d58453b0-08b9-4324-9665-cf04b9762ef5",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:39.265775Z",
+     "iopub.status.busy": "2022-06-23T10:17:39.265495Z",
+     "iopub.status.idle": "2022-06-23T10:17:39.268672Z",
+     "shell.execute_reply": "2022-06-23T10:17:39.268099Z"
+    },
     "papermill": {
-     "duration": 0.094478,
-     "end_time": "2022-02-23T14:11:41.524593",
+     "duration": 0.056288,
+     "end_time": "2022-06-23T10:17:39.270025",
      "exception": false,
-     "start_time": "2022-02-23T14:11:41.430115",
+     "start_time": "2022-06-23T10:17:39.213737",
      "status": "completed"
     },
     "tags": []
@@ -2251,14 +2384,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "8565a1c1-19d7-4bca-9f48-d0b96e23e92f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:39.375473Z",
+     "iopub.status.busy": "2022-06-23T10:17:39.375202Z",
+     "iopub.status.idle": "2022-06-23T10:17:39.378308Z",
+     "shell.execute_reply": "2022-06-23T10:17:39.377820Z"
+    },
     "papermill": {
-     "duration": 0.091608,
-     "end_time": "2022-02-23T14:11:41.707538",
+     "duration": 0.055958,
+     "end_time": "2022-06-23T10:17:39.379631",
      "exception": false,
-     "start_time": "2022-02-23T14:11:41.615930",
+     "start_time": "2022-06-23T10:17:39.323673",
      "status": "completed"
     },
     "tags": []
@@ -2270,14 +2409,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "226cb89b-1589-4097-9050-e9f2592481c8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:39.485451Z",
+     "iopub.status.busy": "2022-06-23T10:17:39.485043Z",
+     "iopub.status.idle": "2022-06-23T10:17:50.140952Z",
+     "shell.execute_reply": "2022-06-23T10:17:50.140403Z"
+    },
     "papermill": {
-     "duration": 10.011616,
-     "end_time": "2022-02-23T14:11:51.809171",
+     "duration": 10.708827,
+     "end_time": "2022-06-23T10:17:50.142354",
      "exception": false,
-     "start_time": "2022-02-23T14:11:41.797555",
+     "start_time": "2022-06-23T10:17:39.433527",
      "status": "completed"
     },
     "tags": []
@@ -2287,10 +2432,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-06-23 08:36:41 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-ab26f2e4-ea5e-4bb6.yaml.",
-        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-ab26f2e4-ea5e-4bb6.json",
-        "2022-06-23 08:36:47 XCUBE GEN END"
+        "2022-06-23 10:17:43 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-0450c969-ea1f-4b17.yaml.",
+        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-0450c969-ea1f-4b17.json",
+        "2022-06-23 10:17:48 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -2300,10 +2445,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          0,
-          35,
-          10,
-          45
+          0.0,
+          35.0,
+          10.0,
+          45.0
          ],
          "crs": "WGS84",
          "data_id": "COP_demo_v2.zarr",
@@ -2353,10 +2498,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff3584c13a0>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7fef29328880>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2367,33 +2512,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "6dd8fb94-02d2-4b4d-aa51-220eb537ff03",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:17:50.250175Z",
+     "iopub.status.busy": "2022-06-23T10:17:50.249902Z",
+     "iopub.status.idle": "2022-06-23T10:20:47.936958Z",
+     "shell.execute_reply": "2022-06-23T10:20:47.936273Z"
+    },
     "papermill": {
-     "duration": 196.036289,
-     "end_time": "2022-02-23T14:15:07.930177",
+     "duration": 177.795832,
+     "end_time": "2022-06-23T10:20:47.991801",
      "exception": false,
-     "start_time": "2022-02-23T14:11:51.893888",
+     "start_time": "2022-06-23T10:17:50.195969",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - ...\n",
+      "Generating cube - ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - done.\n",
+      "Generating cube - done.\n"
+     ]
+    }
+   ],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "53e17d61-cafa-47eb-acf0-a31faeaf4d00",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:48.104415Z",
+     "iopub.status.busy": "2022-06-23T10:20:48.104117Z",
+     "iopub.status.idle": "2022-06-23T10:20:48.187034Z",
+     "shell.execute_reply": "2022-06-23T10:20:48.186413Z"
+    },
     "papermill": {
-     "duration": 0.269853,
-     "end_time": "2022-02-23T14:15:08.303726",
+     "duration": 0.152908,
+     "end_time": "2022-06-23T10:20:48.201435",
      "exception": false,
-     "start_time": "2022-02-23T14:15:08.033873",
+     "start_time": "2022-06-23T10:20:48.048527",
      "status": "completed"
     },
     "tags": []
@@ -2402,10 +2576,10 @@
     {
      "data": {
       "application/json": {
-       "message": "Cube generated successfully after 128.71 seconds",
+       "message": "Cube generated successfully after 158.74 seconds",
        "output": [
-        "2022-06-23 08:37:01 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-c0d377a6-62fe-48f7.yaml.",
+        "2022-06-23 10:18:01 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-d2788987-d5a0-4545.yaml.",
         "Generating cube - ...",
         "Generating cube - 0.0%: reading cube - ...",
         "Generating cube - 2.4%: reading cube - 33.3%",
@@ -16383,8 +16557,8 @@
         "Generating cube - 99.3%: writing cube - 100.0%",
         "Generating cube - 99.3%: writing cube - done.",
         "Generating cube - done.",
-        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-c0d377a6-62fe-48f7.json",
-        "2022-06-23 08:39:15 XCUBE GEN END"
+        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-d2788987-d5a0-4545.json",
+        "2022-06-23 10:20:46 XCUBE GEN END"
        ],
        "result": {
         "data_id": "COP_demo_v2.zarr"
@@ -16393,10 +16567,10 @@
        "status_code": 201
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff3584844c0>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7fef292eaca0>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16407,14 +16581,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "5ec47967",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:48.347051Z",
+     "iopub.status.busy": "2022-06-23T10:20:48.346757Z",
+     "iopub.status.idle": "2022-06-23T10:20:48.351364Z",
+     "shell.execute_reply": "2022-06-23T10:20:48.350698Z"
+    },
     "papermill": {
-     "duration": 0.125932,
-     "end_time": "2022-02-23T14:15:08.557102",
+     "duration": 0.077841,
+     "end_time": "2022-06-23T10:20:48.353020",
      "exception": false,
-     "start_time": "2022-02-23T14:15:08.431170",
+     "start_time": "2022-06-23T10:20:48.275179",
      "status": "completed"
     },
     "tags": []
@@ -16426,7 +16606,7 @@
        "'COP_demo_v2.zarr'"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16437,14 +16617,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "84924427-0ede-4acc-bfe5-535a51b1210f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:48.501399Z",
+     "iopub.status.busy": "2022-06-23T10:20:48.501043Z",
+     "iopub.status.idle": "2022-06-23T10:20:48.507835Z",
+     "shell.execute_reply": "2022-06-23T10:20:48.507174Z"
+    },
     "papermill": {
-     "duration": 0.152138,
-     "end_time": "2022-02-23T14:15:08.849369",
+     "duration": 0.083288,
+     "end_time": "2022-06-23T10:20:48.509426",
      "exception": false,
-     "start_time": "2022-02-23T14:15:08.697231",
+     "start_time": "2022-06-23T10:20:48.426138",
      "status": "completed"
     },
     "tags": []
@@ -16456,14 +16642,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "9057c983-4f8f-44d3-a91c-b229bd636e6b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:48.666001Z",
+     "iopub.status.busy": "2022-06-23T10:20:48.665719Z",
+     "iopub.status.idle": "2022-06-23T10:20:48.750928Z",
+     "shell.execute_reply": "2022-06-23T10:20:48.750184Z"
+    },
     "papermill": {
-     "duration": 0.189529,
-     "end_time": "2022-02-23T14:15:09.163575",
+     "duration": 0.170953,
+     "end_time": "2022-06-23T10:20:48.752953",
      "exception": false,
-     "start_time": "2022-02-23T14:15:08.974046",
+     "start_time": "2022-06-23T10:20:48.582000",
      "status": "completed"
     },
     "tags": []
@@ -16472,10 +16664,14 @@
     {
      "data": {
       "text/plain": [
-       "['COP_demo_v2.zarr', 'SH_demo.zarr', 'sh-S2L2A_BYOA.zarr']"
+       "['COP_demo_v2.zarr',\n",
+       " 'SH_demo.zarr',\n",
+       " 'cci-chlor_a.zarr',\n",
+       " 'sh-S2L2A_BYOA.zarr',\n",
+       " 'volumetric_surface_soil_moisture.zarr']"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16487,14 +16683,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "83137f7b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:48.901052Z",
+     "iopub.status.busy": "2022-06-23T10:20:48.900782Z",
+     "iopub.status.idle": "2022-06-23T10:20:49.036750Z",
+     "shell.execute_reply": "2022-06-23T10:20:49.036257Z"
+    },
     "papermill": {
-     "duration": 0.27143,
-     "end_time": "2022-02-23T14:15:09.553565",
+     "duration": 0.20974,
+     "end_time": "2022-06-23T10:20:49.038436",
      "exception": false,
-     "start_time": "2022-02-23T14:15:09.282135",
+     "start_time": "2022-06-23T10:20:48.828696",
      "status": "completed"
     },
     "tags": []
@@ -16506,14 +16708,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "4c404c39",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:49.184579Z",
+     "iopub.status.busy": "2022-06-23T10:20:49.184259Z",
+     "iopub.status.idle": "2022-06-23T10:20:49.203580Z",
+     "shell.execute_reply": "2022-06-23T10:20:49.203098Z"
+    },
     "papermill": {
-     "duration": 0.150455,
-     "end_time": "2022-02-23T14:15:09.813968",
+     "duration": 0.095691,
+     "end_time": "2022-06-23T10:20:49.205549",
      "exception": false,
-     "start_time": "2022-02-23T14:15:09.663513",
+     "start_time": "2022-06-23T10:20:49.109858",
      "status": "completed"
     },
     "tags": []
@@ -16894,11 +17102,11 @@
        "    stop_date:                  2021-03-15\n",
        "    stop_time:                  14:00:00 UTC\n",
        "    title:                      dataset-oc-med-chl-multi-l4-interp_1km_daily-...\n",
-       "    westernmost_longitude:      -6.0</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a90ba2c1-08d4-4806-92cb-3f7498f54ac7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a90ba2c1-08d4-4806-92cb-3f7498f54ac7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 206</li><li><span class='xr-has-index'>lat</span>: 779</li><li><span class='xr-has-index'>lon</span>: 779</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0bc125b1-0e11-4472-ad09-9713e2f7668b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0bc125b1-0e11-4472-ad09-9713e2f7668b' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.01 35.02 35.03 ... 44.98 45.0</div><input id='attrs-3b9464a7-a014-4e5c-a1dd-bec97bf318cd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3b9464a7-a014-4e5c-a1dd-bec97bf318cd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8d4e4c27-bb6e-49bc-b2ed-dd06e549c660' class='xr-var-data-in' type='checkbox'><label for='data-8d4e4c27-bb6e-49bc-b2ed-dd06e549c660' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([35.00642, 35.01926, 35.0321 , ..., 44.97026, 44.9831 , 44.99594])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.00642 0.01926 ... 9.983 9.996</div><input id='attrs-c86346e8-c231-4398-b886-cc9b7672c9f1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c86346e8-c231-4398-b886-cc9b7672c9f1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1dd553ab-1e2d-4558-98b9-1fc640cc6280' class='xr-var-data-in' type='checkbox'><label for='data-1dd553ab-1e2d-4558-98b9-1fc640cc6280' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([6.42000e-03, 1.92600e-02, 3.21000e-02, ..., 9.97026e+00, 9.98310e+00,\n",
-       "       9.99594e+00])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-06-01 ... 2020-01-01</div><input id='attrs-963f454a-97ff-44eb-8e7b-9a6df69b25e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-963f454a-97ff-44eb-8e7b-9a6df69b25e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d57bb9de-0ac4-4228-88a2-f28d4883c706' class='xr-var-data-in' type='checkbox'><label for='data-d57bb9de-0ac4-4228-88a2-f28d4883c706' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>T</dd><dt><span>long_name :</span></dt><dd>reference time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-06-01T00:00:00.000000000&#x27;, &#x27;2019-06-02T00:00:00.000000000&#x27;,\n",
+       "    westernmost_longitude:      -6.0</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f935cafb-e651-4edd-a5a7-68f3996aa8e6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f935cafb-e651-4edd-a5a7-68f3996aa8e6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 206</li><li><span class='xr-has-index'>lat</span>: 779</li><li><span class='xr-has-index'>lon</span>: 779</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-42eef819-01cd-46a7-b848-2b2d78bef2de' class='xr-section-summary-in' type='checkbox'  checked><label for='section-42eef819-01cd-46a7-b848-2b2d78bef2de' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.01 35.02 35.03 ... 44.98 45.0</div><input id='attrs-0858ee1b-0041-4f4f-aa1c-2d595435a59d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0858ee1b-0041-4f4f-aa1c-2d595435a59d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-403c8631-e723-4348-a132-eb22d69a2db2' class='xr-var-data-in' type='checkbox'><label for='data-403c8631-e723-4348-a132-eb22d69a2db2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([35.00642, 35.01926, 35.0321 , ..., 44.97026, 44.9831 , 44.99594])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.00642 0.01926 ... 9.983 9.996</div><input id='attrs-d1046e40-4eb1-41bd-ba37-4ad15fc1f4f8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d1046e40-4eb1-41bd-ba37-4ad15fc1f4f8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-151e3f14-a79e-4267-8890-3d84435ebc67' class='xr-var-data-in' type='checkbox'><label for='data-151e3f14-a79e-4267-8890-3d84435ebc67' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([6.42000e-03, 1.92600e-02, 3.21000e-02, ..., 9.97026e+00, 9.98310e+00,\n",
+       "       9.99594e+00])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-06-01 ... 2020-01-01</div><input id='attrs-0065db90-b058-49fb-afcf-78c45cff9cdd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0065db90-b058-49fb-afcf-78c45cff9cdd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-83ac9cca-682e-4b05-9eae-4efe95b04b23' class='xr-var-data-in' type='checkbox'><label for='data-83ac9cca-682e-4b05-9eae-4efe95b04b23' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>T</dd><dt><span>long_name :</span></dt><dd>reference time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-06-01T00:00:00.000000000&#x27;, &#x27;2019-06-02T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-06-03T00:00:00.000000000&#x27;, ..., &#x27;2019-12-30T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-12-31T00:00:00.000000000&#x27;, &#x27;2020-01-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-82980698-4a0e-4126-b4e0-1e1ecd5cb285' class='xr-section-summary-in' type='checkbox'  checked><label for='section-82980698-4a0e-4126-b4e0-1e1ecd5cb285' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>CHL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ef1456b1-bccf-4136-aced-477b51f2b053' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ef1456b1-bccf-4136-aced-477b51f2b053' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fde790ad-8774-4475-adee-8132a9b3cdc2' class='xr-var-data-in' type='checkbox'><label for='data-fde790ad-8774-4475-adee-8132a9b3cdc2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Multi-sensor, multi water-type, interpolated Chlorophyll a concentration</dd><dt><span>source :</span></dt><dd>MODISA Aqua - Level2,VIIRSN Suomi-NPP - Level2</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>type :</span></dt><dd>surface</dd><dt><span>units :</span></dt><dd>milligram m^-3</dd><dt><span>valid_max :</span></dt><dd>100.0</dd><dt><span>valid_min :</span></dt><dd>0.009999999776482582</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6858fee9-99f0-4da5-9d74-b4339347acc9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6858fee9-99f0-4da5-9d74-b4339347acc9' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>CHL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c4ba898c-c5e7-481b-87e9-a380e04ed66a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c4ba898c-c5e7-481b-87e9-a380e04ed66a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d599d2ba-fd41-4d9e-887a-085759ebbc5e' class='xr-var-data-in' type='checkbox'><label for='data-d599d2ba-fd41-4d9e-887a-085759ebbc5e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Multi-sensor, multi water-type, interpolated Chlorophyll a concentration</dd><dt><span>source :</span></dt><dd>MODISA Aqua - Level2,VIIRSN Suomi-NPP - Level2</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>type :</span></dt><dd>surface</dd><dt><span>units :</span></dt><dd>milligram m^-3</dd><dt><span>valid_max :</span></dt><dd>100.0</dd><dt><span>valid_min :</span></dt><dd>0.009999999776482582</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -17018,7 +17226,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6b24059b-63a7-4bb0-8564-e8f674bd588e' class='xr-section-summary-in' type='checkbox'  ><label for='section-6b24059b-63a7-4bb0-8564-e8f674bd588e' class='xr-section-summary' >Attributes: <span>(52)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>citation :</span></dt><dd> </dd><dt><span>cmems_product_id :</span></dt><dd>OCEANCOLOUR_MED_CHL_L4_NRT_OBSERVATIONS_009_041</dd><dt><span>cmems_production_unit :</span></dt><dd>OC-CNR-ROMA-IT</dd><dt><span>comment :</span></dt><dd>r=log10(max([rrs443,rrs490,rrs510])/rrs555) ; chlcase1=10^[0.4567-4.2484r+2.0171r^2+2.6202r^3-2.8978r^4] ; r=log10(rrs490/rrs555) ; chlcase2=10.^[0.091-2.620r-1.148r^2-4.949r^3]. Interpolation is made via iterative EOF using the climatology as first guess. WTM and SENSORMASK fields provide the original data coverage.</dd><dt><span>contact :</span></dt><dd>technical@gos.artov.isac.cnr.it</dd><dt><span>creation_date :</span></dt><dd>Thu Apr 08 2021</dd><dt><span>creation_time :</span></dt><dd>06:04:30 UTC</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:37:37.767616</dd><dt><span>days_in_the_future :</span></dt><dd> 5</dd><dt><span>days_in_the_past :</span></dt><dd> 10</dd><dt><span>distribution_statement :</span></dt><dd>See CMEMS Data License</dd><dt><span>easternmost_longitude :</span></dt><dd>36.5</dd><dt><span>file_quality_index :</span></dt><dd>0</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((0 35, 0 45.00236, 10.002360000000001 45.00236, 10.002360000000001 35, 0 35))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>45.00236</dd><dt><span>geospatial_lat_min :</span></dt><dd>35</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.002360000000001</dd><dt><span>geospatial_lon_min :</span></dt><dd>0</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>grid_mapping :</span></dt><dd>Equirectangular</dd><dt><span>grid_resolution :</span></dt><dd>  1 Km</dd><dt><span>history :</span></dt><dd>[&#x27; &#x27;, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [0.0, 35.0, 10.0, 45.0], &#x27;spatial_res&#x27;: 0.01284, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: &#x27;1D&#x27;, &#x27;time_range&#x27;: [&#x27;2019-06-01&#x27;, &#x27;2019-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;CHL&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>institution :</span></dt><dd>CNR-GOS</dd><dt><span>naming_authority :</span></dt><dd>CMEMS</dd><dt><span>netcdf_version :</span></dt><dd>v4</dd><dt><span>northernmost_latitude :</span></dt><dd>46.0</dd><dt><span>parameter :</span></dt><dd>chlorophyll-a concentration</dd><dt><span>parameter_code :</span></dt><dd>CHL</dd><dt><span>platform :</span></dt><dd>Aqua,JPSS-1,Sentinel-3a,Suomi-NPP</dd><dt><span>product_level :</span></dt><dd>L4</dd><dt><span>product_version :</span></dt><dd>v02QL</dd><dt><span>references :</span></dt><dd>1) Volpe, G., Colella, S., Brando, V., Forneris, V., La Padula, F., Di Cicco, A., Sammartino, M., Bracaglia, M., Artuso, F., and Santoleri, R. (2019). The Mediterranean Ocean Colour Level 3 Operational Multi-Sensor Processing, Ocean Sci., 15, 127–146, https://doi.org/10.5194/os-15-127-2019. - 2) Berthon, J. F., and G. Zibordi (2004), Bio-optical relationships for the northern Adriatic Sea, International Journal of Remote Sensing, 25, 7-8, 1527-1532. - 3) Volpe, G., Buongiorno Nardelli, B., Colella, S., Pisano, A. and Santoleri, R. (2018). An Operational Interpolated Ocean Colour Product in the Mediterranean Sea, in New Frontiers in Operational Oceanography, edited by E. P. Chassignet, A. Pascual, J. Tintorè, and J. Verron, pp. 227–244</dd><dt><span>sensor :</span></dt><dd>MODISA Moderate Resolution Imaging Spectroradiometer,VIIRSJ Visible Infrared Imaging Radiometer Suite,OLCI Ocean and Land Colour Instrument,VIIRSN Visible Infrared Imaging Radiometer Suite</dd><dt><span>sensor_name :</span></dt><dd>MODISA,VIIRSJ,OLCI,VIIRSN</dd><dt><span>site_name :</span></dt><dd>MED</dd><dt><span>software_name :</span></dt><dd>GOS Processing chain</dd><dt><span>software_version :</span></dt><dd>v3.0</dd><dt><span>source :</span></dt><dd>surface observation</dd><dt><span>source_files :</span></dt><dd>X2021065-chl-med-hr.nc X2021066-chl-med-hr.nc X2021067-chl-med-hr.nc X2021068-chl-med-hr.nc X2021069-chl-med-hr.nc X2021070-chl-med-hr.nc X2021071-chl-med-hr.nc X2021072-chl-med-hr.nc X2021073-chl-med-hr.nc X2021074-chl-med-hr.nc X2021075-chl-med-hr.nc X2021076-chl-med-hr.nc X2021077-chl-med-hr.nc X2021078-chl-med-hr.nc</dd><dt><span>southernmost_latitude :</span></dt><dd>30.0</dd><dt><span>st_location :</span></dt><dd> 4  0</dd><dt><span>start_date :</span></dt><dd>2021-03-15</dd><dt><span>start_time :</span></dt><dd>08:00:00 UTC</dd><dt><span>stop_date :</span></dt><dd>2021-03-15</dd><dt><span>stop_time :</span></dt><dd>14:00:00 UTC</dd><dt><span>title :</span></dt><dd>dataset-oc-med-chl-multi-l4-interp_1km_daily-rt-v02</dd><dt><span>westernmost_longitude :</span></dt><dd>-6.0</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-7054bb15-dc6d-449d-9964-03645d24951d' class='xr-section-summary-in' type='checkbox'  ><label for='section-7054bb15-dc6d-449d-9964-03645d24951d' class='xr-section-summary' >Attributes: <span>(52)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>citation :</span></dt><dd> </dd><dt><span>cmems_product_id :</span></dt><dd>OCEANCOLOUR_MED_CHL_L4_NRT_OBSERVATIONS_009_041</dd><dt><span>cmems_production_unit :</span></dt><dd>OC-CNR-ROMA-IT</dd><dt><span>comment :</span></dt><dd>r=log10(max([rrs443,rrs490,rrs510])/rrs555) ; chlcase1=10^[0.4567-4.2484r+2.0171r^2+2.6202r^3-2.8978r^4] ; r=log10(rrs490/rrs555) ; chlcase2=10.^[0.091-2.620r-1.148r^2-4.949r^3]. Interpolation is made via iterative EOF using the climatology as first guess. WTM and SENSORMASK fields provide the original data coverage.</dd><dt><span>contact :</span></dt><dd>technical@gos.artov.isac.cnr.it</dd><dt><span>creation_date :</span></dt><dd>Thu Apr 08 2021</dd><dt><span>creation_time :</span></dt><dd>06:04:30 UTC</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:18:40.997899</dd><dt><span>days_in_the_future :</span></dt><dd> 5</dd><dt><span>days_in_the_past :</span></dt><dd> 10</dd><dt><span>distribution_statement :</span></dt><dd>See CMEMS Data License</dd><dt><span>easternmost_longitude :</span></dt><dd>36.5</dd><dt><span>file_quality_index :</span></dt><dd>0</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((0 35, 0 45.00236, 10.002360000000001 45.00236, 10.002360000000001 35, 0 35))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>45.00236</dd><dt><span>geospatial_lat_min :</span></dt><dd>35</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.002360000000001</dd><dt><span>geospatial_lon_min :</span></dt><dd>0</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>grid_mapping :</span></dt><dd>Equirectangular</dd><dt><span>grid_resolution :</span></dt><dd>  1 Km</dd><dt><span>history :</span></dt><dd>[&#x27; &#x27;, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [0.0, 35.0, 10.0, 45.0], &#x27;spatial_res&#x27;: 0.01284, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: &#x27;1D&#x27;, &#x27;time_range&#x27;: [&#x27;2019-06-01&#x27;, &#x27;2019-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;CHL&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>institution :</span></dt><dd>CNR-GOS</dd><dt><span>naming_authority :</span></dt><dd>CMEMS</dd><dt><span>netcdf_version :</span></dt><dd>v4</dd><dt><span>northernmost_latitude :</span></dt><dd>46.0</dd><dt><span>parameter :</span></dt><dd>chlorophyll-a concentration</dd><dt><span>parameter_code :</span></dt><dd>CHL</dd><dt><span>platform :</span></dt><dd>Aqua,JPSS-1,Sentinel-3a,Suomi-NPP</dd><dt><span>product_level :</span></dt><dd>L4</dd><dt><span>product_version :</span></dt><dd>v02QL</dd><dt><span>references :</span></dt><dd>1) Volpe, G., Colella, S., Brando, V., Forneris, V., La Padula, F., Di Cicco, A., Sammartino, M., Bracaglia, M., Artuso, F., and Santoleri, R. (2019). The Mediterranean Ocean Colour Level 3 Operational Multi-Sensor Processing, Ocean Sci., 15, 127–146, https://doi.org/10.5194/os-15-127-2019. - 2) Berthon, J. F., and G. Zibordi (2004), Bio-optical relationships for the northern Adriatic Sea, International Journal of Remote Sensing, 25, 7-8, 1527-1532. - 3) Volpe, G., Buongiorno Nardelli, B., Colella, S., Pisano, A. and Santoleri, R. (2018). An Operational Interpolated Ocean Colour Product in the Mediterranean Sea, in New Frontiers in Operational Oceanography, edited by E. P. Chassignet, A. Pascual, J. Tintorè, and J. Verron, pp. 227–244</dd><dt><span>sensor :</span></dt><dd>MODISA Moderate Resolution Imaging Spectroradiometer,VIIRSJ Visible Infrared Imaging Radiometer Suite,OLCI Ocean and Land Colour Instrument,VIIRSN Visible Infrared Imaging Radiometer Suite</dd><dt><span>sensor_name :</span></dt><dd>MODISA,VIIRSJ,OLCI,VIIRSN</dd><dt><span>site_name :</span></dt><dd>MED</dd><dt><span>software_name :</span></dt><dd>GOS Processing chain</dd><dt><span>software_version :</span></dt><dd>v3.0</dd><dt><span>source :</span></dt><dd>surface observation</dd><dt><span>source_files :</span></dt><dd>X2021065-chl-med-hr.nc X2021066-chl-med-hr.nc X2021067-chl-med-hr.nc X2021068-chl-med-hr.nc X2021069-chl-med-hr.nc X2021070-chl-med-hr.nc X2021071-chl-med-hr.nc X2021072-chl-med-hr.nc X2021073-chl-med-hr.nc X2021074-chl-med-hr.nc X2021075-chl-med-hr.nc X2021076-chl-med-hr.nc X2021077-chl-med-hr.nc X2021078-chl-med-hr.nc</dd><dt><span>southernmost_latitude :</span></dt><dd>30.0</dd><dt><span>st_location :</span></dt><dd> 4  0</dd><dt><span>start_date :</span></dt><dd>2021-03-15</dd><dt><span>start_time :</span></dt><dd>08:00:00 UTC</dd><dt><span>stop_date :</span></dt><dd>2021-03-15</dd><dt><span>stop_time :</span></dt><dd>14:00:00 UTC</dd><dt><span>title :</span></dt><dd>dataset-oc-med-chl-multi-l4-interp_1km_daily-rt-v02</dd><dt><span>westernmost_longitude :</span></dt><dd>-6.0</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -17045,7 +17253,7 @@
        "    westernmost_longitude:      -6.0"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17056,14 +17264,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "7375f4cb-37a9-48db-9d18-7996b2ac6689",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:49.359004Z",
+     "iopub.status.busy": "2022-06-23T10:20:49.358362Z",
+     "iopub.status.idle": "2022-06-23T10:20:50.321411Z",
+     "shell.execute_reply": "2022-06-23T10:20:50.320778Z"
+    },
     "papermill": {
-     "duration": 1.465683,
-     "end_time": "2022-02-23T14:15:11.403592",
+     "duration": 1.043654,
+     "end_time": "2022-06-23T10:20:50.324252",
      "exception": false,
-     "start_time": "2022-02-23T14:15:09.937909",
+     "start_time": "2022-06-23T10:20:49.280598",
      "status": "completed"
     },
     "tags": []
@@ -17072,10 +17286,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7ff35832f6a0>"
+       "<matplotlib.collections.QuadMesh at 0x7fef29215a30>"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -17098,14 +17312,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "id": "3bbb1d0a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:50.475310Z",
+     "iopub.status.busy": "2022-06-23T10:20:50.475013Z",
+     "iopub.status.idle": "2022-06-23T10:20:56.473177Z",
+     "shell.execute_reply": "2022-06-23T10:20:56.472722Z"
+    },
     "papermill": {
-     "duration": 8.638378,
-     "end_time": "2022-02-23T14:15:20.162144",
+     "duration": 6.076302,
+     "end_time": "2022-06-23T10:20:56.475262",
      "exception": false,
-     "start_time": "2022-02-23T14:15:11.523766",
+     "start_time": "2022-06-23T10:20:50.398960",
      "status": "completed"
     },
     "tags": []
@@ -17114,10 +17334,10 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7ff35826a2b0>]"
+       "[<matplotlib.lines.Line2D at 0x7fef28e64f70>]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -17143,10 +17363,10 @@
    "id": "e858f9a1-e43f-4e23-a887-75cd6385ac9a",
    "metadata": {
     "papermill": {
-     "duration": 0.218192,
-     "end_time": "2022-02-23T14:15:20.497058",
+     "duration": 0.079145,
+     "end_time": "2022-06-23T10:20:56.633623",
      "exception": false,
-     "start_time": "2022-02-23T14:15:20.278866",
+     "start_time": "2022-06-23T10:20:56.554478",
      "status": "completed"
     },
     "tags": []
@@ -17162,10 +17382,10 @@
    "id": "1cd39ffa-ec69-4b7c-8c24-1ac7406dab50",
    "metadata": {
     "papermill": {
-     "duration": 0.115824,
-     "end_time": "2022-02-23T14:15:20.729421",
+     "duration": 0.075149,
+     "end_time": "2022-06-23T10:20:56.789659",
      "exception": false,
-     "start_time": "2022-02-23T14:15:20.613597",
+     "start_time": "2022-06-23T10:20:56.714510",
      "status": "completed"
     },
     "tags": []
@@ -17176,14 +17396,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "id": "32efee83-7e63-49af-b281-8c34f9832043",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:56.946868Z",
+     "iopub.status.busy": "2022-06-23T10:20:56.946574Z",
+     "iopub.status.idle": "2022-06-23T10:20:56.951009Z",
+     "shell.execute_reply": "2022-06-23T10:20:56.950355Z"
+    },
     "papermill": {
-     "duration": 0.124513,
-     "end_time": "2022-02-23T14:15:20.967787",
+     "duration": 0.083562,
+     "end_time": "2022-06-23T10:20:56.952539",
      "exception": false,
-     "start_time": "2022-02-23T14:15:20.843274",
+     "start_time": "2022-06-23T10:20:56.868977",
      "status": "completed"
     },
     "tags": []
@@ -17211,14 +17437,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "id": "29d072ae-73fe-4fc8-9767-d6885fdacbc4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:57.115881Z",
+     "iopub.status.busy": "2022-06-23T10:20:57.115585Z",
+     "iopub.status.idle": "2022-06-23T10:20:57.119278Z",
+     "shell.execute_reply": "2022-06-23T10:20:57.118739Z"
+    },
     "papermill": {
-     "duration": 0.12625,
-     "end_time": "2022-02-23T14:15:21.212950",
+     "duration": 0.086719,
+     "end_time": "2022-06-23T10:20:57.121201",
      "exception": false,
-     "start_time": "2022-02-23T14:15:21.086700",
+     "start_time": "2022-06-23T10:20:57.034482",
      "status": "completed"
     },
     "tags": []
@@ -17234,14 +17466,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "id": "570dca46-4f6f-4a5a-b9db-4231d7db3f13",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:20:57.279606Z",
+     "iopub.status.busy": "2022-06-23T10:20:57.278988Z",
+     "iopub.status.idle": "2022-06-23T10:21:04.906718Z",
+     "shell.execute_reply": "2022-06-23T10:21:04.906051Z"
+    },
     "papermill": {
-     "duration": 7.693573,
-     "end_time": "2022-02-23T14:15:29.035226",
+     "duration": 7.706896,
+     "end_time": "2022-06-23T10:21:04.908636",
      "exception": false,
-     "start_time": "2022-02-23T14:15:21.341653",
+     "start_time": "2022-06-23T10:20:57.201740",
      "status": "completed"
     },
     "tags": []
@@ -17251,10 +17489,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-06-23 08:39:45 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-8481c262-f103-4ec9.yaml.",
-        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-8481c262-f103-4ec9.json",
-        "2022-06-23 08:39:51 XCUBE GEN END"
+        "2022-06-23 10:20:59 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-79a322bf-df37-4b98.yaml.",
+        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-79a322bf-df37-4b98.json",
+        "2022-06-23 10:21:03 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -17264,10 +17502,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          -180,
-          -90,
-          180,
-          90
+          -180.0,
+          -90.0,
+          180.0,
+          90.0
          ],
          "crs": "WGS84",
          "data_id": "volumetric_surface_soil_moisture.zarr",
@@ -17317,10 +17555,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff3582c3e80>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7fef28e74850>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17331,14 +17569,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "id": "90de43bb-e669-4eea-bccf-b026d7828153",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:05.070975Z",
+     "iopub.status.busy": "2022-06-23T10:21:05.070689Z",
+     "iopub.status.idle": "2022-06-23T10:21:05.074080Z",
+     "shell.execute_reply": "2022-06-23T10:21:05.073425Z"
+    },
     "papermill": {
-     "duration": 0.123631,
-     "end_time": "2022-02-23T14:15:29.280174",
+     "duration": 0.088878,
+     "end_time": "2022-06-23T10:21:05.075485",
      "exception": false,
-     "start_time": "2022-02-23T14:15:29.156543",
+     "start_time": "2022-06-23T10:21:04.986607",
      "status": "completed"
     },
     "tags": []
@@ -17350,33 +17594,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "id": "a5f493c2-b6d5-4467-a4e0-3776bb516a74",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:05.234331Z",
+     "iopub.status.busy": "2022-06-23T10:21:05.234045Z",
+     "iopub.status.idle": "2022-06-23T10:21:52.476470Z",
+     "shell.execute_reply": "2022-06-23T10:21:52.475892Z"
+    },
     "papermill": {
-     "duration": 78.823121,
-     "end_time": "2022-02-23T14:16:48.224150",
+     "duration": 47.399969,
+     "end_time": "2022-06-23T10:21:52.555768",
      "exception": false,
-     "start_time": "2022-02-23T14:15:29.401029",
+     "start_time": "2022-06-23T10:21:05.155799",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - ...\n",
+      "Generating cube - ...\n",
+      "Generating cube - ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - done.\n",
+      "Generating cube - done.\n",
+      "Generating cube - done.\n"
+     ]
+    }
+   ],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "id": "960ddf7c-2921-4f27-8059-cf5fd501c421",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:52.713484Z",
+     "iopub.status.busy": "2022-06-23T10:21:52.713199Z",
+     "iopub.status.idle": "2022-06-23T10:21:52.724543Z",
+     "shell.execute_reply": "2022-06-23T10:21:52.723967Z"
+    },
     "papermill": {
-     "duration": 0.136563,
-     "end_time": "2022-02-23T14:16:48.484753",
+     "duration": 0.092746,
+     "end_time": "2022-06-23T10:21:52.726081",
      "exception": false,
-     "start_time": "2022-02-23T14:16:48.348190",
+     "start_time": "2022-06-23T10:21:52.633335",
      "status": "completed"
     },
     "tags": []
@@ -17385,51 +17660,33 @@
     {
      "data": {
       "application/json": {
-       "message": "Cube generated successfully after 64.35 seconds",
+       "message": "Cube generated successfully after 29.63 seconds",
        "output": [
-        "2022-06-23 08:40:07 XCUBE GEN START",
+        "2022-06-23 10:21:16 XCUBE GEN START",
         "xcube-cds version 0.9.1",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-06-23 08:40:11,511 INFO Welcome to the CDS",
-        "2022-06-23 08:40:11,511 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/satellite-soil-moisture",
+        "2022-06-23 10:21:20,143 INFO Welcome to the CDS",
+        "2022-06-23 10:21:20,144 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/satellite-soil-moisture",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-06-23 08:40:11,558 INFO Request is queued",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "2022-06-23 08:40:12,581 INFO Request is running",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "2022-06-23 08:41:01,107 INFO Request is completed",
-        "2022-06-23 08:41:01,108 INFO Downloading https://download-0010-clone.copernicus-climate.eu/cache-compute-0010/cache/data6/dataset-satellite-soil-moisture-6f9d0a9b-2dd5-4c8f-bee5-a4ccd2538a04.tar.gz to /tmp/tmpppjfkdv_/tmpuoosxaut/data (9.1M)",
+        "2022-06-23 10:21:20,285 INFO Request is completed",
+        "2022-06-23 10:21:20,285 INFO Downloading https://download-0010-clone.copernicus-climate.eu/cache-compute-0010/cache/data6/dataset-satellite-soil-moisture-6f9d0a9b-2dd5-4c8f-bee5-a4ccd2538a04.tar.gz to /tmp/tmpztgxe463/tmp7qawj5gt/data (9.1M)",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'download-0010-clone.copernicus-climate.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-c4f97203-fdcc-4097.yaml.",
+        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-829d2626-7799-4495.yaml.",
         "Generating cube - ...",
         "Generating cube - 0.0%: reading cube - ...",
         "Generating cube - 2.4%: reading cube - 33.3%",
         "",
         "  0%|          | 0.00/9.11M [00:00<?, ?B/s]",
-        "  8%|▊         | 705k/9.11M [00:00<00:01, 7.22MB/s]",
-        " 62%|██████▏   | 5.62M/9.11M [00:00<00:00, 33.4MB/s]",
+        "  6%|▌         | 548k/9.11M [00:00<00:01, 4.86MB/s]",
+        " 72%|███████▏  | 6.56M/9.11M [00:00<00:00, 36.7MB/s]",
         "                                                    ",
-        "2022-06-23 08:41:01,584 INFO Download rate 19.1M/s",
+        "2022-06-23 10:21:20,888 INFO Download rate 15.1M/s",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-06-23 08:41:02,442 INFO Found credentials in environment variables.",
+        "2022-06-23 10:21:21,449 INFO Found credentials in environment variables.",
         "Generating cube - 4.9%: reading cube - 66.7%",
         "Generating cube - 7.3%: reading cube - 100.0%",
         "Generating cube - 7.3%: reading cube - done.",
@@ -18128,8 +18385,8 @@
         "Generating cube - 99.2%: writing cube - 99.9%",
         "Generating cube - 99.2%: writing cube - done.",
         "Generating cube - done.",
-        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-c4f97203-fdcc-4097.json",
-        "2022-06-23 08:41:16 XCUBE GEN END"
+        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-829d2626-7799-4495.json",
+        "2022-06-23 10:21:51 XCUBE GEN END"
        ],
        "result": {
         "data_id": "volumetric_surface_soil_moisture.zarr"
@@ -18138,10 +18395,10 @@
        "status_code": 201
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff35851fd00>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7fef28e29a60>"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18152,14 +18409,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "id": "210f154f-e897-4631-8f08-50a3f8b8f96a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:52.891598Z",
+     "iopub.status.busy": "2022-06-23T10:21:52.889153Z",
+     "iopub.status.idle": "2022-06-23T10:21:52.897874Z",
+     "shell.execute_reply": "2022-06-23T10:21:52.897289Z"
+    },
     "papermill": {
-     "duration": 0.157695,
-     "end_time": "2022-02-23T14:16:48.766006",
+     "duration": 0.09064,
+     "end_time": "2022-06-23T10:21:52.899836",
      "exception": false,
-     "start_time": "2022-02-23T14:16:48.608311",
+     "start_time": "2022-06-23T10:21:52.809196",
      "status": "completed"
     },
     "tags": []
@@ -18171,14 +18434,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "id": "28ebcef2-6b2c-4ddc-b0c2-c3edf586531f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:53.063761Z",
+     "iopub.status.busy": "2022-06-23T10:21:53.063119Z",
+     "iopub.status.idle": "2022-06-23T10:21:53.164721Z",
+     "shell.execute_reply": "2022-06-23T10:21:53.164209Z"
+    },
     "papermill": {
-     "duration": 0.201407,
-     "end_time": "2022-02-23T14:16:49.097951",
+     "duration": 0.187423,
+     "end_time": "2022-06-23T10:21:53.166598",
      "exception": false,
-     "start_time": "2022-02-23T14:16:48.896544",
+     "start_time": "2022-06-23T10:21:52.979175",
      "status": "completed"
     },
     "tags": []
@@ -18190,14 +18459,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 40,
    "id": "3c8eaa3d-88a9-437a-a04d-609f5edf8c01",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:53.347569Z",
+     "iopub.status.busy": "2022-06-23T10:21:53.347267Z",
+     "iopub.status.idle": "2022-06-23T10:21:53.351508Z",
+     "shell.execute_reply": "2022-06-23T10:21:53.350914Z"
+    },
     "papermill": {
-     "duration": 0.133884,
-     "end_time": "2022-02-23T14:16:49.348794",
+     "duration": 0.09753,
+     "end_time": "2022-06-23T10:21:53.353341",
      "exception": false,
-     "start_time": "2022-02-23T14:16:49.214910",
+     "start_time": "2022-06-23T10:21:53.255811",
      "status": "completed"
     },
     "tags": []
@@ -18208,11 +18483,12 @@
       "text/plain": [
        "['COP_demo_v2.zarr',\n",
        " 'SH_demo.zarr',\n",
+       " 'cci-chlor_a.zarr',\n",
        " 'sh-S2L2A_BYOA.zarr',\n",
        " 'volumetric_surface_soil_moisture.zarr']"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18223,14 +18499,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 41,
    "id": "d1a38dad-ef4f-480d-a936-cd69491ca742",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:53.534182Z",
+     "iopub.status.busy": "2022-06-23T10:21:53.533889Z",
+     "iopub.status.idle": "2022-06-23T10:21:53.842517Z",
+     "shell.execute_reply": "2022-06-23T10:21:53.841974Z"
+    },
     "papermill": {
-     "duration": 0.344825,
-     "end_time": "2022-02-23T14:16:49.817205",
+     "duration": 0.401076,
+     "end_time": "2022-06-23T10:21:53.844334",
      "exception": false,
-     "start_time": "2022-02-23T14:16:49.472380",
+     "start_time": "2022-06-23T10:21:53.443258",
      "status": "completed"
     },
     "tags": []
@@ -18242,14 +18524,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 42,
    "id": "9e39f6ec-86c8-4c51-bf3f-8b11614b0cfa",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:54.005514Z",
+     "iopub.status.busy": "2022-06-23T10:21:54.005098Z",
+     "iopub.status.idle": "2022-06-23T10:21:54.035081Z",
+     "shell.execute_reply": "2022-06-23T10:21:54.034603Z"
+    },
     "papermill": {
-     "duration": 0.162581,
-     "end_time": "2022-02-23T14:16:50.099990",
+     "duration": 0.113364,
+     "end_time": "2022-06-23T10:21:54.037542",
      "exception": false,
-     "start_time": "2022-02-23T14:16:49.937409",
+     "start_time": "2022-06-23T10:21:53.924178",
      "status": "completed"
     },
     "tags": []
@@ -18633,15 +18921,15 @@
        "    time_coverage_resolution:   P1D\n",
        "    time_coverage_start:        2014-12-31T12:00:00Z\n",
        "    title:                      C3S Surface Soil Moisture merged COMBINED Pro...\n",
-       "    tracking_id:                4d788889-b8c0-43b3-a622-f61b22adfc51</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-127ed7f3-801a-4451-b7d2-0d1348488ae5' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-127ed7f3-801a-4451-b7d2-0d1348488ae5' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>lat</span>: 720</li><li><span class='xr-has-index'>lon</span>: 1440</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-e3715adc-3cf3-42e2-97d3-5e790ad214ba' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e3715adc-3cf3-42e2-97d3-5e790ad214ba' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.88 89.62 89.38 ... -89.62 -89.88</div><input id='attrs-9f50685e-7e0b-45bc-856c-d52c322086b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9f50685e-7e0b-45bc-856c-d52c322086b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0cee7c1f-3e10-4515-99e0-6500f26ccc6c' class='xr-var-data-in' type='checkbox'><label for='data-0cee7c1f-3e10-4515-99e0-6500f26ccc6c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_range :</span></dt><dd>[-90.0, 90.0]</dd></dl></div><div class='xr-var-data'><pre>array([ 89.875,  89.625,  89.375, ..., -89.375, -89.625, -89.875],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-179.9 -179.6 ... 179.6 179.9</div><input id='attrs-61dc2e72-cd46-48d8-90a0-543af073311b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-61dc2e72-cd46-48d8-90a0-543af073311b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7ba1e4d6-314c-4f78-a045-2323c6ac3057' class='xr-var-data-in' type='checkbox'><label for='data-7ba1e4d6-314c-4f78-a045-2323c6ac3057' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_range :</span></dt><dd>[-180.0, 180.0]</dd></dl></div><div class='xr-var-data'><pre>array([-179.875, -179.625, -179.375, ...,  179.375,  179.625,  179.875],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2015-01-01 ... 2015-12-01</div><input id='attrs-335d9ff0-c980-418a-94db-335232acb737' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-335d9ff0-c980-418a-94db-335232acb737' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-00e9c4da-009b-4e2d-9b72-bfa918e2253c' class='xr-var-data-in' type='checkbox'><label for='data-00e9c4da-009b-4e2d-9b72-bfa918e2253c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2015-01-01T00:00:00.000000000&#x27;, &#x27;2015-02-01T00:00:00.000000000&#x27;,\n",
+       "    tracking_id:                4d788889-b8c0-43b3-a622-f61b22adfc51</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-06e7e83a-6d93-448a-b03a-d2c1c6e04e6f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-06e7e83a-6d93-448a-b03a-d2c1c6e04e6f' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>lat</span>: 720</li><li><span class='xr-has-index'>lon</span>: 1440</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-45c1f265-2d9d-46f4-bcb3-1d2569aeede6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-45c1f265-2d9d-46f4-bcb3-1d2569aeede6' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.88 89.62 89.38 ... -89.62 -89.88</div><input id='attrs-516e2a7b-0708-4aa5-8ec6-de1564738aa4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-516e2a7b-0708-4aa5-8ec6-de1564738aa4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-feaab49d-8984-4435-804d-b9da61437f5e' class='xr-var-data-in' type='checkbox'><label for='data-feaab49d-8984-4435-804d-b9da61437f5e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_range :</span></dt><dd>[-90.0, 90.0]</dd></dl></div><div class='xr-var-data'><pre>array([ 89.875,  89.625,  89.375, ..., -89.375, -89.625, -89.875],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-179.9 -179.6 ... 179.6 179.9</div><input id='attrs-0bf19bf6-a1c3-4919-9419-5b122a6cc899' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0bf19bf6-a1c3-4919-9419-5b122a6cc899' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-98aa3bb3-29b8-491b-9f5a-449597282c79' class='xr-var-data-in' type='checkbox'><label for='data-98aa3bb3-29b8-491b-9f5a-449597282c79' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_range :</span></dt><dd>[-180.0, 180.0]</dd></dl></div><div class='xr-var-data'><pre>array([-179.875, -179.625, -179.375, ...,  179.375,  179.625,  179.875],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2015-01-01 ... 2015-12-01</div><input id='attrs-9890fb47-1107-4c1c-b6ee-98d20a70fd4a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9890fb47-1107-4c1c-b6ee-98d20a70fd4a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-00669862-5960-4a70-8d0b-408aceeace97' class='xr-var-data-in' type='checkbox'><label for='data-00669862-5960-4a70-8d0b-408aceeace97' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2015-01-01T00:00:00.000000000&#x27;, &#x27;2015-02-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-03-01T00:00:00.000000000&#x27;, &#x27;2015-04-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-05-01T00:00:00.000000000&#x27;, &#x27;2015-06-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-07-01T00:00:00.000000000&#x27;, &#x27;2015-08-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-09-01T00:00:00.000000000&#x27;, &#x27;2015-10-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-11-01T00:00:00.000000000&#x27;, &#x27;2015-12-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d749560e-221b-4b6e-9b60-bfef5c98f860' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d749560e-221b-4b6e-9b60-bfef5c98f860' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>freqbandID</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-b0f1250a-ce04-445b-a35d-6c2a7009cdbd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b0f1250a-ce04-445b-a35d-6c2a7009cdbd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-778a0eed-519b-4af7-88f0-a4bd4e0d8e49' class='xr-var-data-in' type='checkbox'><label for='data-778a0eed-519b-4af7-88f0-a4bd4e0d8e49' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN L14 C53 L14+C53 C66 C68 L14+C68 C53+C68 L14+C53+C68 C69 L14+C69 C53+C69 L14+C53+C69 C68+C69 L14+C68+C69 C53+C68+C69 L14+C53+C68+C69 C73 L14+C73 C53+C73 L14+C53+C73 X107 L14+X107 C53+X107 L14+C53+X107 C68+X107 L14+C68+X107 C53+C68+X107 L14+C53+C68+X107 C69+X107 L14+C69+X107 C53+C69+X107 L14+C53+C69+X107 K194 C53+K194</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 3, 4, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27, 32, 33, 34, 35, 64, 65, 66, 67, 72, 73, 74, 75, 80, 81, 82, 83, 128, 130]</dd><dt><span>long_name :</span></dt><dd>Frequency Band Identification</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-64979d66-dade-429b-bac3-61dc55a7ba73' class='xr-section-summary-in' type='checkbox'  checked><label for='section-64979d66-dade-429b-bac3-61dc55a7ba73' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>freqbandID</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-57dd1f9b-ea46-4966-b18b-17ca2fd074f7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-57dd1f9b-ea46-4966-b18b-17ca2fd074f7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c6ee85d4-8917-4be2-85f2-d4d8f33d15da' class='xr-var-data-in' type='checkbox'><label for='data-c6ee85d4-8917-4be2-85f2-d4d8f33d15da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN L14 C53 L14+C53 C66 C68 L14+C68 C53+C68 L14+C53+C68 C69 L14+C69 C53+C69 L14+C53+C69 C68+C69 L14+C68+C69 C53+C68+C69 L14+C53+C68+C69 C73 L14+C73 C53+C73 L14+C53+C73 X107 L14+X107 C53+X107 L14+C53+X107 C68+X107 L14+C68+X107 C53+C68+X107 L14+C53+C68+X107 C69+X107 L14+C69+X107 C53+C69+X107 L14+C53+C69+X107 K194 C53+K194</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 3, 4, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27, 32, 33, 34, 35, 64, 65, 66, 67, 72, 73, 74, 75, 80, 81, 82, 83, 128, 130]</dd><dt><span>long_name :</span></dt><dd>Frequency Band Identification</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -18749,7 +19037,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>nobs</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c6b60131-d6c3-40aa-9da1-cd68e19ec70a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c6b60131-d6c3-40aa-9da1-cd68e19ec70a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5101b185-0e93-4372-9230-03e81f551405' class='xr-var-data-in' type='checkbox'><label for='data-5101b185-0e93-4372-9230-03e81f551405' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Number of valid observation</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>nobs</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-6a823ae1-8812-4bf7-a34f-8e164d0e67de' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6a823ae1-8812-4bf7-a34f-8e164d0e67de' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a5e1fdd4-5bf6-4279-b009-eef502ae7ccd' class='xr-var-data-in' type='checkbox'><label for='data-a5e1fdd4-5bf6-4279-b009-eef502ae7ccd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Number of valid observation</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -18857,7 +19145,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sensor</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-7be8e1a0-3962-4fff-884a-af327ba97911' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7be8e1a0-3962-4fff-884a-af327ba97911' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f0fb2254-adb3-4faf-b4b8-e4a57a2c310f' class='xr-var-data-in' type='checkbox'><label for='data-f0fb2254-adb3-4faf-b4b8-e4a57a2c310f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN SMMR SSMI TMI AMSRE WindSat AMSRE+WindSat AMSR2 AMSRE+AMSR2 WindSat+AMSR2 AMSRE+WindSat+AMSR2 AMIWS SSMI+AMIWS TMI+AMIWS AMSRE+AMIWS ASCATA AMSRE+ASCATA WindSat+ASCATA AMSRE+WindSat+ASCATA AMSR2+ASCATA AMSRE+AMSR2+ASCATA WindSat+AMSR2+ASCATA AMSRE+WindSat+AMSR2+ASCATA ASCATB AMSR2+ASCATB ASCATA+ASCATB AMSR2+ASCATA+ASCATB</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 128, 130, 132, 136, 256, 264, 272, 280, 288, 296, 304, 312, 512, 544, 768, 800]</dd><dt><span>long_name :</span></dt><dd>Sensor</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sensor</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-b02a98c6-52a6-447b-802f-4b17ca87fde1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b02a98c6-52a6-447b-802f-4b17ca87fde1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-233360d9-56a2-4e84-9f6b-d28d4de2e103' class='xr-var-data-in' type='checkbox'><label for='data-233360d9-56a2-4e84-9f6b-d28d4de2e103' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN SMMR SSMI TMI AMSRE WindSat AMSRE+WindSat AMSR2 AMSRE+AMSR2 WindSat+AMSR2 AMSRE+WindSat+AMSR2 AMIWS SSMI+AMIWS TMI+AMIWS AMSRE+AMIWS ASCATA AMSRE+ASCATA WindSat+ASCATA AMSRE+WindSat+ASCATA AMSR2+ASCATA AMSRE+AMSR2+ASCATA WindSat+AMSR2+ASCATA AMSRE+WindSat+AMSR2+ASCATA ASCATB AMSR2+ASCATB ASCATA+ASCATB AMSR2+ASCATA+ASCATB</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 128, 130, 132, 136, 256, 264, 272, 280, 288, 296, 304, 312, 512, 544, 768, 800]</dd><dt><span>long_name :</span></dt><dd>Sensor</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -18965,7 +19253,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sm</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-cd75ad82-1913-4be0-904c-757068dac31c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cd75ad82-1913-4be0-904c-757068dac31c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dab62a61-b578-442d-8201-818939248960' class='xr-var-data-in' type='checkbox'><label for='data-dab62a61-b578-442d-8201-818939248960' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Volumetric Soil Moisture</dd><dt><span>units :</span></dt><dd>m3 m-3</dd><dt><span>valid_range :</span></dt><dd>[0.0, 1.0]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sm</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-d70b11ad-3339-43c8-b21a-cb16910cc16a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d70b11ad-3339-43c8-b21a-cb16910cc16a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-278c3976-670b-4359-abf9-085958f676a3' class='xr-var-data-in' type='checkbox'><label for='data-278c3976-670b-4359-abf9-085958f676a3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Volumetric Soil Moisture</dd><dt><span>units :</span></dt><dd>m3 m-3</dd><dt><span>valid_range :</span></dt><dd>[0.0, 1.0]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -19073,7 +19361,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-e282490f-fdf2-4a1e-bb77-5e91ce9fc8c8' class='xr-section-summary-in' type='checkbox'  ><label for='section-e282490f-fdf2-4a1e-bb77-5e91ce9fc8c8' class='xr-section-summary' >Attributes: <span>(42)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>cdm_data_type :</span></dt><dd>Grid</dd><dt><span>comment :</span></dt><dd>These data were produced as part of the Copernicus Climate Change Service. Service Contract No 2018/C3S_312b_LOT4_EODC/SC2</dd><dt><span>contact :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_email :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_name :</span></dt><dd>Earth Observation Data Center (EODC)</dd><dt><span>creator_url :</span></dt><dd>https://www.eodc.eu</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:41:02.408660</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>geospatial_vertical_max :</span></dt><dd>0.0</dd><dt><span>geospatial_vertical_min :</span></dt><dd>0.0</dd><dt><span>history :</span></dt><dd>[&#x27;2020-05-13T12:34:34.419747 mean calculated&#x27;, {&#x27;cube_config&#x27;: {&#x27;spatial_res&#x27;: 0.25, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2015-01-01&#x27;, &#x27;2015-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;volumetric_surface_soil_moisture&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>id :</span></dt><dd>C3S-SOILMOISTURE-L3S-SSMV-COMBINED-MONTHLY-20150101000000-TCDR-v201912.0.0.nc</dd><dt><span>institution :</span></dt><dd>EODC (AUT); TU Wien (AUT); VanderSat B.V. (NL)</dd><dt><span>keywords :</span></dt><dd>Soil Moisture/Water Content</dd><dt><span>keywords_vocabulary :</span></dt><dd>NASA Global Change Master Directory (GCMD) Science Keywords</dd><dt><span>license :</span></dt><dd>Copernicus Data License</dd><dt><span>naming_authority :</span></dt><dd>EODC</dd><dt><span>platform :</span></dt><dd>Nimbus 7, DMSP, TRMM, AQUA, Coriolis, GCOM-W1, SMOS; ERS-1, ERS-2, METOP-A, METOP-B</dd><dt><span>product_version :</span></dt><dd>v201912.0.0</dd><dt><span>project :</span></dt><dd>Copernicus Climate Change Service.</dd><dt><span>references :</span></dt><dd>http://www.esa-soilmoisture-cci.org; Liu, Y.Y., Dorigo, W.A., Parinussa, R.M., de Jeu, R.A.M. , Wagner, W., McCabe, M.F., Evans, J.P., van Dijk, A.I.J.M. (2012). Trend-preserving blending of passive and active microwave soil moisture retrievals, Remote Sensing of Environment, 123, 280-297, doi: 10.1016/j.rse.2012.03.014.; Liu, Y.Y., Parinussa, R.M., Dorigo, W.A., De Jeu, R.A.M., Wagner, W., van Dijk, A.I.J.M., McCabe, M.F., &amp; Evans, J.P. (2011). Developing an improved soil moisture dataset by blending passive and active microwave satellite based retrievals. Hydrology and Earth System Sciences, 15, 425-436.; Wagner, W., W. Dorigo, R. de Jeu, D. Fernandez, J. Benveniste, E. Haas, M. Ertl (2012). Fusion of active and passive microwave observations to create an Essential Climate Variable data record on soil moisture. ISPRS Annals of the Photogrammetry, Remote Sensing and Spatial Information Sciences, Volume I-7, 2012. XXII ISPRS Congress, 25 August - 01 September 2012, Melbourne, Australia.; Gruber, A., Dorigo, W. Crow, W., &amp; Wagner, W. (2017). Triple collocation-based merging of satellite soil moisture retrievals. IEEE Transactions on Geoscience and Remote Sensing, 1-13.; Dorigo, W.A., Wagner, W., Albergel, C., Albrecht, F., Balsamo, G., Brocca, L., Chung, D., Ertl, M., Forkel, M., Gruber, A., Haas, E., Hamer, P. D., Hirschi, M., Ikonen, J., de Jeu, R., Kidd, R., Lahoz, W., Liu, Y. Y.,Miralles, D., Mistelbauer, T., Nicolai-Shaw, N., Parinussa, R., Pratola, C., Reimer, C., van der Schalie, R., Seneviratne, S. I. Smolander, T., Lecomte, P. (2017). ESA CCI Soil Moisture for improved Earth system understanding: State-of-the art and future directions, Remote Sensing of Environment. https://doi.org/10.1016/j.rse.2017.07.001.</dd><dt><span>sensor :</span></dt><dd>SMMR, SSM/I, TMI, AMSR-E, WindSat, AMSR2, MIRAS; AMI-WS, AMI-WS, ASCAT-A, ASCAT-B</dd><dt><span>source :</span></dt><dd>WARP 5.5R1.1/AMI-WS/ERS12 Level 2 Soil Moisture; WARP 5.4R1.0/AMI-WS/ERS2 Level 2 Soil Moisture; ASCSMR02/ASCAT/MetOp-A SSM Swath Grid 12.5 km sampling; ASCSMR02/ASCAT/MetOp-B SSM Swath Grid 12.5 km sampling; LPRMv05/SMMR/Nimbus 7 L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/SSMI/F08, F11, F13 DMSP L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/TMI/TRMM L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR-E/Aqua L2B Surface Soil Moisture, Ancillary Params, and QC; LPRMv05/WINDSAT/CORIOLIS L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR2/GCOM-W1 L3 Surface Soil Moisture, Ancillary Params; LPRMv06/SMOS/MIRAS L3 Surface Soil Moisture, CATDS Level 3 Brightness Temperatures (L3TB) version 300 RE03 &amp; RE04;</dd><dt><span>spatial_resolution :</span></dt><dd>25km</dd><dt><span>standard_name_vocabulary :</span></dt><dd>NetCDF Climate and Forecast (CF) Metadata Convention</dd><dt><span>summary :</span></dt><dd>The data set was produced with funding from the Copernicus Climate Change Service.</dd><dt><span>time_coverage_duration :</span></dt><dd>P1M</dd><dt><span>time_coverage_end :</span></dt><dd>2015-12-31T12:00:00Z</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1D</dd><dt><span>time_coverage_start :</span></dt><dd>2014-12-31T12:00:00Z</dd><dt><span>title :</span></dt><dd>C3S Surface Soil Moisture merged COMBINED Product</dd><dt><span>tracking_id :</span></dt><dd>4d788889-b8c0-43b3-a622-f61b22adfc51</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6bda20c6-79a6-4be9-9cd7-b3f9fe260f98' class='xr-section-summary-in' type='checkbox'  ><label for='section-6bda20c6-79a6-4be9-9cd7-b3f9fe260f98' class='xr-section-summary' >Attributes: <span>(42)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>cdm_data_type :</span></dt><dd>Grid</dd><dt><span>comment :</span></dt><dd>These data were produced as part of the Copernicus Climate Change Service. Service Contract No 2018/C3S_312b_LOT4_EODC/SC2</dd><dt><span>contact :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_email :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_name :</span></dt><dd>Earth Observation Data Center (EODC)</dd><dt><span>creator_url :</span></dt><dd>https://www.eodc.eu</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:21:21.428167</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>geospatial_vertical_max :</span></dt><dd>0.0</dd><dt><span>geospatial_vertical_min :</span></dt><dd>0.0</dd><dt><span>history :</span></dt><dd>[&#x27;2020-05-13T12:34:34.419747 mean calculated&#x27;, {&#x27;cube_config&#x27;: {&#x27;spatial_res&#x27;: 0.25, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2015-01-01&#x27;, &#x27;2015-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;volumetric_surface_soil_moisture&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>id :</span></dt><dd>C3S-SOILMOISTURE-L3S-SSMV-COMBINED-MONTHLY-20150101000000-TCDR-v201912.0.0.nc</dd><dt><span>institution :</span></dt><dd>EODC (AUT); TU Wien (AUT); VanderSat B.V. (NL)</dd><dt><span>keywords :</span></dt><dd>Soil Moisture/Water Content</dd><dt><span>keywords_vocabulary :</span></dt><dd>NASA Global Change Master Directory (GCMD) Science Keywords</dd><dt><span>license :</span></dt><dd>Copernicus Data License</dd><dt><span>naming_authority :</span></dt><dd>EODC</dd><dt><span>platform :</span></dt><dd>Nimbus 7, DMSP, TRMM, AQUA, Coriolis, GCOM-W1, SMOS; ERS-1, ERS-2, METOP-A, METOP-B</dd><dt><span>product_version :</span></dt><dd>v201912.0.0</dd><dt><span>project :</span></dt><dd>Copernicus Climate Change Service.</dd><dt><span>references :</span></dt><dd>http://www.esa-soilmoisture-cci.org; Liu, Y.Y., Dorigo, W.A., Parinussa, R.M., de Jeu, R.A.M. , Wagner, W., McCabe, M.F., Evans, J.P., van Dijk, A.I.J.M. (2012). Trend-preserving blending of passive and active microwave soil moisture retrievals, Remote Sensing of Environment, 123, 280-297, doi: 10.1016/j.rse.2012.03.014.; Liu, Y.Y., Parinussa, R.M., Dorigo, W.A., De Jeu, R.A.M., Wagner, W., van Dijk, A.I.J.M., McCabe, M.F., &amp; Evans, J.P. (2011). Developing an improved soil moisture dataset by blending passive and active microwave satellite based retrievals. Hydrology and Earth System Sciences, 15, 425-436.; Wagner, W., W. Dorigo, R. de Jeu, D. Fernandez, J. Benveniste, E. Haas, M. Ertl (2012). Fusion of active and passive microwave observations to create an Essential Climate Variable data record on soil moisture. ISPRS Annals of the Photogrammetry, Remote Sensing and Spatial Information Sciences, Volume I-7, 2012. XXII ISPRS Congress, 25 August - 01 September 2012, Melbourne, Australia.; Gruber, A., Dorigo, W. Crow, W., &amp; Wagner, W. (2017). Triple collocation-based merging of satellite soil moisture retrievals. IEEE Transactions on Geoscience and Remote Sensing, 1-13.; Dorigo, W.A., Wagner, W., Albergel, C., Albrecht, F., Balsamo, G., Brocca, L., Chung, D., Ertl, M., Forkel, M., Gruber, A., Haas, E., Hamer, P. D., Hirschi, M., Ikonen, J., de Jeu, R., Kidd, R., Lahoz, W., Liu, Y. Y.,Miralles, D., Mistelbauer, T., Nicolai-Shaw, N., Parinussa, R., Pratola, C., Reimer, C., van der Schalie, R., Seneviratne, S. I. Smolander, T., Lecomte, P. (2017). ESA CCI Soil Moisture for improved Earth system understanding: State-of-the art and future directions, Remote Sensing of Environment. https://doi.org/10.1016/j.rse.2017.07.001.</dd><dt><span>sensor :</span></dt><dd>SMMR, SSM/I, TMI, AMSR-E, WindSat, AMSR2, MIRAS; AMI-WS, AMI-WS, ASCAT-A, ASCAT-B</dd><dt><span>source :</span></dt><dd>WARP 5.5R1.1/AMI-WS/ERS12 Level 2 Soil Moisture; WARP 5.4R1.0/AMI-WS/ERS2 Level 2 Soil Moisture; ASCSMR02/ASCAT/MetOp-A SSM Swath Grid 12.5 km sampling; ASCSMR02/ASCAT/MetOp-B SSM Swath Grid 12.5 km sampling; LPRMv05/SMMR/Nimbus 7 L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/SSMI/F08, F11, F13 DMSP L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/TMI/TRMM L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR-E/Aqua L2B Surface Soil Moisture, Ancillary Params, and QC; LPRMv05/WINDSAT/CORIOLIS L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR2/GCOM-W1 L3 Surface Soil Moisture, Ancillary Params; LPRMv06/SMOS/MIRAS L3 Surface Soil Moisture, CATDS Level 3 Brightness Temperatures (L3TB) version 300 RE03 &amp; RE04;</dd><dt><span>spatial_resolution :</span></dt><dd>25km</dd><dt><span>standard_name_vocabulary :</span></dt><dd>NetCDF Climate and Forecast (CF) Metadata Convention</dd><dt><span>summary :</span></dt><dd>The data set was produced with funding from the Copernicus Climate Change Service.</dd><dt><span>time_coverage_duration :</span></dt><dd>P1M</dd><dt><span>time_coverage_end :</span></dt><dd>2015-12-31T12:00:00Z</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1D</dd><dt><span>time_coverage_start :</span></dt><dd>2014-12-31T12:00:00Z</dd><dt><span>title :</span></dt><dd>C3S Surface Soil Moisture merged COMBINED Product</dd><dt><span>tracking_id :</span></dt><dd>4d788889-b8c0-43b3-a622-f61b22adfc51</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -19103,7 +19391,7 @@
        "    tracking_id:                4d788889-b8c0-43b3-a622-f61b22adfc51"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19114,14 +19402,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 43,
    "id": "0d49174a-ddd6-4607-9ebd-f43c987ee04a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:54.219748Z",
+     "iopub.status.busy": "2022-06-23T10:21:54.219321Z",
+     "iopub.status.idle": "2022-06-23T10:21:57.795758Z",
+     "shell.execute_reply": "2022-06-23T10:21:57.795271Z"
+    },
     "papermill": {
-     "duration": 4.816474,
-     "end_time": "2022-02-23T14:16:55.046600",
+     "duration": 3.674322,
+     "end_time": "2022-06-23T10:21:57.804175",
      "exception": false,
-     "start_time": "2022-02-23T14:16:50.230126",
+     "start_time": "2022-06-23T10:21:54.129853",
      "status": "completed"
     },
     "tags": []
@@ -19130,10 +19424,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7ff358098d30>"
+       "<matplotlib.collections.QuadMesh at 0x7feece83c220>"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -19159,10 +19453,10 @@
    "id": "c5ba2a4f-8418-431e-9b42-ec032805456a",
    "metadata": {
     "papermill": {
-     "duration": 0.134508,
-     "end_time": "2022-02-23T14:16:55.318205",
+     "duration": 0.091585,
+     "end_time": "2022-06-23T10:21:57.989908",
      "exception": false,
-     "start_time": "2022-02-23T14:16:55.183697",
+     "start_time": "2022-06-23T10:21:57.898323",
      "status": "completed"
     },
     "tags": []
@@ -19178,10 +19472,10 @@
    "id": "36d6b962-2d3a-4a69-bb06-118754a98d5e",
    "metadata": {
     "papermill": {
-     "duration": 0.129679,
-     "end_time": "2022-02-23T14:16:55.592926",
+     "duration": 0.093637,
+     "end_time": "2022-06-23T10:21:58.180042",
      "exception": false,
-     "start_time": "2022-02-23T14:16:55.463247",
+     "start_time": "2022-06-23T10:21:58.086405",
      "status": "completed"
     },
     "tags": []
@@ -19192,14 +19486,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 44,
    "id": "f29aff1b-d619-4bcc-8857-6d4fc8436405",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:58.366032Z",
+     "iopub.status.busy": "2022-06-23T10:21:58.365742Z",
+     "iopub.status.idle": "2022-06-23T10:21:58.372340Z",
+     "shell.execute_reply": "2022-06-23T10:21:58.370844Z"
+    },
     "papermill": {
-     "duration": 0.14125,
-     "end_time": "2022-02-23T14:16:55.866838",
+     "duration": 0.100242,
+     "end_time": "2022-06-23T10:21:58.374066",
      "exception": false,
-     "start_time": "2022-02-23T14:16:55.725588",
+     "start_time": "2022-06-23T10:21:58.273824",
      "status": "completed"
     },
     "tags": []
@@ -19232,14 +19532,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 45,
    "id": "8b104198-54f3-4848-96b0-bf33fd860c23",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:58.573099Z",
+     "iopub.status.busy": "2022-06-23T10:21:58.572350Z",
+     "iopub.status.idle": "2022-06-23T10:21:58.576350Z",
+     "shell.execute_reply": "2022-06-23T10:21:58.575818Z"
+    },
     "papermill": {
-     "duration": 0.142735,
-     "end_time": "2022-02-23T14:16:56.145916",
+     "duration": 0.1069,
+     "end_time": "2022-06-23T10:21:58.579839",
      "exception": false,
-     "start_time": "2022-02-23T14:16:56.003181",
+     "start_time": "2022-06-23T10:21:58.472939",
      "status": "completed"
     },
     "tags": []
@@ -19255,14 +19561,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 46,
    "id": "041b458e-6aa9-4451-b532-c691c16d7aa3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:58.773044Z",
+     "iopub.status.busy": "2022-06-23T10:21:58.772755Z",
+     "iopub.status.idle": "2022-06-23T10:21:58.776286Z",
+     "shell.execute_reply": "2022-06-23T10:21:58.775629Z"
+    },
     "papermill": {
-     "duration": 0.141617,
-     "end_time": "2022-02-23T14:16:56.422646",
+     "duration": 0.102868,
+     "end_time": "2022-06-23T10:21:58.778190",
      "exception": false,
-     "start_time": "2022-02-23T14:16:56.281029",
+     "start_time": "2022-06-23T10:21:58.675322",
      "status": "completed"
     },
     "tags": []
@@ -19274,14 +19586,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 47,
    "id": "74dc014b-50c0-4573-b96d-68f203be8a02",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:21:58.974826Z",
+     "iopub.status.busy": "2022-06-23T10:21:58.974222Z",
+     "iopub.status.idle": "2022-06-23T10:22:10.582176Z",
+     "shell.execute_reply": "2022-06-23T10:22:10.581600Z"
+    },
     "papermill": {
-     "duration": 13.821138,
-     "end_time": "2022-02-23T14:17:10.376966",
+     "duration": 11.706095,
+     "end_time": "2022-06-23T10:22:10.583770",
      "exception": false,
-     "start_time": "2022-02-23T14:16:56.555828",
+     "start_time": "2022-06-23T10:21:58.877675",
      "status": "completed"
     },
     "tags": []
@@ -19291,10 +19609,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-06-23 08:43:37 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-e927215e-cd74-498c.yaml.",
-        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-e927215e-cd74-498c.json",
-        "2022-06-23 08:43:46 XCUBE GEN END"
+        "2022-06-23 10:22:02 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-9c03befd-2791-4907.yaml.",
+        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-9c03befd-2791-4907.json",
+        "2022-06-23 10:22:08 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -19304,10 +19622,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          -180,
-          -90,
-          180,
-          90
+          -180.0,
+          -90.0,
+          180.0,
+          90.0
          ],
          "crs": "OGC:CRS84",
          "data_id": "cci-chlor_a.zarr",
@@ -19357,10 +19675,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff358083850>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7feece89a130>"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19371,33 +19689,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 48,
    "id": "76cca29d-6be4-46af-a92f-857468d65f26",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:22:10.770587Z",
+     "iopub.status.busy": "2022-06-23T10:22:10.770313Z",
+     "iopub.status.idle": "2022-06-23T10:24:04.928079Z",
+     "shell.execute_reply": "2022-06-23T10:24:04.927464Z"
+    },
     "papermill": {
-     "duration": 133.195956,
-     "end_time": "2022-02-23T14:19:23.706505",
+     "duration": 114.350597,
+     "end_time": "2022-06-23T10:24:05.026835",
      "exception": false,
-     "start_time": "2022-02-23T14:17:10.510549",
+     "start_time": "2022-06-23T10:22:10.676238",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - ...\n",
+      "Generating cube - ...\n",
+      "Generating cube - ...\n",
+      "Generating cube - ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating cube - done.\n",
+      "Generating cube - done.\n",
+      "Generating cube - done.\n",
+      "Generating cube - done.\n"
+     ]
+    }
+   ],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 49,
    "id": "0491e72d-28c9-425d-ad74-24b12a42c095",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:24:05.226729Z",
+     "iopub.status.busy": "2022-06-23T10:24:05.226323Z",
+     "iopub.status.idle": "2022-06-23T10:24:05.230869Z",
+     "shell.execute_reply": "2022-06-23T10:24:05.230338Z"
+    },
     "papermill": {
-     "duration": 0.139177,
-     "end_time": "2022-02-23T14:19:23.985676",
+     "duration": 0.111763,
+     "end_time": "2022-06-23T10:24:05.232727",
      "exception": false,
-     "start_time": "2022-02-23T14:19:23.846499",
+     "start_time": "2022-06-23T10:24:05.120964",
      "status": "completed"
     },
     "tags": []
@@ -19409,7 +19760,7 @@
        "'cci-chlor_a.zarr'"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19420,14 +19771,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "id": "84eecdf5-a597-4678-8397-8df5d4762056",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:24:05.452581Z",
+     "iopub.status.busy": "2022-06-23T10:24:05.452265Z",
+     "iopub.status.idle": "2022-06-23T10:24:05.458568Z",
+     "shell.execute_reply": "2022-06-23T10:24:05.457958Z"
+    },
     "papermill": {
-     "duration": 0.142771,
-     "end_time": "2022-02-23T14:19:24.266364",
+     "duration": 0.108633,
+     "end_time": "2022-06-23T10:24:05.460672",
      "exception": false,
-     "start_time": "2022-02-23T14:19:24.123593",
+     "start_time": "2022-06-23T10:24:05.352039",
      "status": "completed"
     },
     "tags": []
@@ -19439,14 +19796,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "id": "25c5a1e3-696c-4e32-923a-8881e061e293",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:24:05.685217Z",
+     "iopub.status.busy": "2022-06-23T10:24:05.684743Z",
+     "iopub.status.idle": "2022-06-23T10:24:05.764779Z",
+     "shell.execute_reply": "2022-06-23T10:24:05.764149Z"
+    },
     "papermill": {
-     "duration": 0.219796,
-     "end_time": "2022-02-23T14:19:24.618772",
+     "duration": 0.18893,
+     "end_time": "2022-06-23T10:24:05.766954",
      "exception": false,
-     "start_time": "2022-02-23T14:19:24.398976",
+     "start_time": "2022-06-23T10:24:05.578024",
      "status": "completed"
     },
     "tags": []
@@ -19462,7 +19825,7 @@
        " 'volumetric_surface_soil_moisture.zarr']"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19474,14 +19837,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 52,
    "id": "3b93f23c-8a6d-4f9a-afd8-d4cee1120c0b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:24:06.039621Z",
+     "iopub.status.busy": "2022-06-23T10:24:06.039148Z",
+     "iopub.status.idle": "2022-06-23T10:24:06.192540Z",
+     "shell.execute_reply": "2022-06-23T10:24:06.191771Z"
+    },
     "papermill": {
-     "duration": 0.314181,
-     "end_time": "2022-02-23T14:19:25.068904",
+     "duration": 0.303402,
+     "end_time": "2022-06-23T10:24:06.194850",
      "exception": false,
-     "start_time": "2022-02-23T14:19:24.754723",
+     "start_time": "2022-06-23T10:24:05.891448",
      "status": "completed"
     },
     "tags": []
@@ -19493,14 +19862,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 53,
    "id": "9de93352-7ac1-47f1-9b27-c597422fb445",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:24:06.403917Z",
+     "iopub.status.busy": "2022-06-23T10:24:06.403612Z",
+     "iopub.status.idle": "2022-06-23T10:24:06.425311Z",
+     "shell.execute_reply": "2022-06-23T10:24:06.424746Z"
+    },
     "papermill": {
-     "duration": 0.166707,
-     "end_time": "2022-02-23T14:19:25.380519",
+     "duration": 0.121229,
+     "end_time": "2022-06-23T10:24:06.426996",
      "exception": false,
-     "start_time": "2022-02-23T14:19:25.213812",
+     "start_time": "2022-06-23T10:24:06.305767",
      "status": "completed"
     },
     "tags": []
@@ -19872,7 +20247,7 @@
        "    chlor_a    (time, lat, lon) float32 dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-06-23T08:44:09.505830\n",
+       "    date_created:               2022-06-23T10:22:30.985526\n",
        "    geospatial_bounds:          POLYGON((-180 -90, -180 90, 180 90, 180 -90, ...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         90\n",
@@ -19883,12 +20258,12 @@
        "    time_coverage_duration:     P213DT0H0M0S\n",
        "    time_coverage_end:          2008-08-01T00:00:00\n",
        "    time_coverage_start:        2008-01-01T00:00:00\n",
-       "    title:                      esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a49ea0bd-a506-460b-9f43-5d79383cad92' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a49ea0bd-a506-460b-9f43-5d79383cad92' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lat</span>: 4320</li><li><span class='xr-has-index'>lon</span>: 8640</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-62f3002f-08e6-4233-ab94-ab3a41e81a89' class='xr-section-summary-in' type='checkbox'  checked><label for='section-62f3002f-08e6-4233-ab94-ab3a41e81a89' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.98 89.94 89.9 ... -89.94 -89.98</div><input id='attrs-eb71ad8c-3ffd-4369-a859-d6dd9c22fe31' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eb71ad8c-3ffd-4369-a859-d6dd9c22fe31' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fc5d43e8-670a-4abd-8646-e63afadb57a6' class='xr-var-data-in' type='checkbox'><label for='data-fc5d43e8-670a-4abd-8646-e63afadb57a6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>chunk_sizes :</span></dt><dd>4320</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>4320</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[4320]</dd><dt><span>size :</span></dt><dd>4320</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_max :</span></dt><dd>89.979164</dd><dt><span>valid_min :</span></dt><dd>-89.979164</dd></dl></div><div class='xr-var-data'><pre>array([ 89.979164,  89.9375  ,  89.895836, ..., -89.895836, -89.9375  ,\n",
-       "       -89.979164], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-180.0 -179.9 ... 179.9 180.0</div><input id='attrs-e7c438c7-fb10-45b3-9f4b-392f71aa18e0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e7c438c7-fb10-45b3-9f4b-392f71aa18e0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-89458fc8-0c6e-41b3-9615-75ad2a374019' class='xr-var-data-in' type='checkbox'><label for='data-89458fc8-0c6e-41b3-9615-75ad2a374019' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>chunk_sizes :</span></dt><dd>8640</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>8640</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[8640]</dd><dt><span>size :</span></dt><dd>8640</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_max :</span></dt><dd>179.97917</dd><dt><span>valid_min :</span></dt><dd>-179.97917</dd></dl></div><div class='xr-var-data'><pre>array([-179.97917, -179.9375 , -179.89583, ...,  179.89583,  179.9375 ,\n",
-       "        179.97917], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2008-01-16T12:00:00 ... 2008-07-...</div><input id='attrs-d96bd81d-dbe8-486d-a849-54c80670f1dd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d96bd81d-dbe8-486d-a849-54c80670f1dd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6a33171f-91d6-4242-9bb4-c5926b45b162' class='xr-var-data-in' type='checkbox'><label for='data-6a33171f-91d6-4242-9bb4-c5926b45b162' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2008-01-16T12:00:00.000000000&#x27;, &#x27;2008-02-15T12:00:00.000000000&#x27;,\n",
+       "    title:                      esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-b4a5416f-a78a-4a89-ae22-3eafa6f4adc4' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-b4a5416f-a78a-4a89-ae22-3eafa6f4adc4' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lat</span>: 4320</li><li><span class='xr-has-index'>lon</span>: 8640</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-d057cab3-19f9-4f90-aafe-f8e949984436' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d057cab3-19f9-4f90-aafe-f8e949984436' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.98 89.94 89.9 ... -89.94 -89.98</div><input id='attrs-fdea2251-613c-4a4b-af7b-71b7a7c2d997' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fdea2251-613c-4a4b-af7b-71b7a7c2d997' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2142f344-fa87-41d8-8d58-56a08d34fe57' class='xr-var-data-in' type='checkbox'><label for='data-2142f344-fa87-41d8-8d58-56a08d34fe57' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>chunk_sizes :</span></dt><dd>4320</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>4320</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[4320]</dd><dt><span>size :</span></dt><dd>4320</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_max :</span></dt><dd>89.979164</dd><dt><span>valid_min :</span></dt><dd>-89.979164</dd></dl></div><div class='xr-var-data'><pre>array([ 89.979164,  89.9375  ,  89.895836, ..., -89.895836, -89.9375  ,\n",
+       "       -89.979164], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-180.0 -179.9 ... 179.9 180.0</div><input id='attrs-cd457feb-843b-4858-983b-73372f4a5d53' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cd457feb-843b-4858-983b-73372f4a5d53' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0d4b3b38-d940-461d-b4d7-7869606e7521' class='xr-var-data-in' type='checkbox'><label for='data-0d4b3b38-d940-461d-b4d7-7869606e7521' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>chunk_sizes :</span></dt><dd>8640</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>8640</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[8640]</dd><dt><span>size :</span></dt><dd>8640</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_max :</span></dt><dd>179.97917</dd><dt><span>valid_min :</span></dt><dd>-179.97917</dd></dl></div><div class='xr-var-data'><pre>array([-179.97917, -179.9375 , -179.89583, ...,  179.89583,  179.9375 ,\n",
+       "        179.97917], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2008-01-16T12:00:00 ... 2008-07-...</div><input id='attrs-e807aa5a-9884-4a9a-ba6f-828eea010a90' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e807aa5a-9884-4a9a-ba6f-828eea010a90' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c0d94748-6432-4fff-822e-76348a3f38ab' class='xr-var-data-in' type='checkbox'><label for='data-c0d94748-6432-4fff-822e-76348a3f38ab' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2008-01-16T12:00:00.000000000&#x27;, &#x27;2008-02-15T12:00:00.000000000&#x27;,\n",
        "       &#x27;2008-03-16T12:00:00.000000000&#x27;, &#x27;2008-04-16T00:00:00.000000000&#x27;,\n",
        "       &#x27;2008-05-16T12:00:00.000000000&#x27;, &#x27;2008-06-16T00:00:00.000000000&#x27;,\n",
-       "       &#x27;2008-07-16T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(7, 2), meta=np.ndarray&gt;</div><input id='attrs-35651dd3-61c0-46ca-a25e-5755cf11e563' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-35651dd3-61c0-46ca-a25e-5755cf11e563' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-765d89e5-33b1-458c-9b4f-7fb741e26037' class='xr-var-data-in' type='checkbox'><label for='data-765d89e5-33b1-458c-9b4f-7fb741e26037' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2008-07-16T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(7, 2), meta=np.ndarray&gt;</div><input id='attrs-bddf38a1-db38-49a9-b2be-1166bd84071f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bddf38a1-db38-49a9-b2be-1166bd84071f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9b07e19f-e563-4e50-8598-60f01b550610' class='xr-var-data-in' type='checkbox'><label for='data-9b07e19f-e563-4e50-8598-60f01b550610' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -19945,7 +20320,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-f9f63889-0ba6-4126-9dfd-aa7257002592' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f9f63889-0ba6-4126-9dfd-aa7257002592' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>chlor_a</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-64bae6da-bc62-4f8f-b0f7-379d40291e74' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-64bae6da-bc62-4f8f-b0f7-379d40291e74' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-62335186-d9a1-49fb-8fea-cff96ca28473' class='xr-var-data-in' type='checkbox'><label for='data-62335186-d9a1-49fb-8fea-cff96ca28473' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>ancillary_variables :</span></dt><dd>chlor_a_log10_rmsd chlor_a_log10_bias</dd><dt><span>chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>9.96921e+36</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd><dt><span>long_name :</span></dt><dd>Chlorophyll-a concentration in seawater (not log-transformed), generated by SeaDAS using a blended combination of OCI (OC4v6 + Hu&#x27;s CI), OC3 and OC5, depending on water class memberships</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>parameter_vocab_uri :</span></dt><dd>http://vocab.nerc.ac.uk/collection/P04/current/</dd><dt><span>shape :</span></dt><dd>[7, 4320, 8640]</dd><dt><span>size :</span></dt><dd>261273600</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>units :</span></dt><dd>milligram m-3</dd><dt><span>units_nonstandard :</span></dt><dd>mg m^-3</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-d803c565-c152-4fc9-bb8d-727828359589' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d803c565-c152-4fc9-bb8d-727828359589' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>chlor_a</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-4e6cbb2f-bd61-4645-b9bf-fd1b0812a13d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4e6cbb2f-bd61-4645-b9bf-fd1b0812a13d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-09ef87eb-9722-424c-bcd7-92b05ed925e9' class='xr-var-data-in' type='checkbox'><label for='data-09ef87eb-9722-424c-bcd7-92b05ed925e9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>ancillary_variables :</span></dt><dd>chlor_a_log10_rmsd chlor_a_log10_bias</dd><dt><span>chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>9.96921e+36</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd><dt><span>long_name :</span></dt><dd>Chlorophyll-a concentration in seawater (not log-transformed), generated by SeaDAS using a blended combination of OCI (OC4v6 + Hu&#x27;s CI), OC3 and OC5, depending on water class memberships</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>parameter_vocab_uri :</span></dt><dd>http://vocab.nerc.ac.uk/collection/P04/current/</dd><dt><span>shape :</span></dt><dd>[7, 4320, 8640]</dd><dt><span>size :</span></dt><dd>261273600</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>units :</span></dt><dd>milligram m-3</dd><dt><span>units_nonstandard :</span></dt><dd>mg m^-3</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -20061,7 +20436,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6a5399c0-e679-4b81-b880-1c4eef0bfabf' class='xr-section-summary-in' type='checkbox'  ><label for='section-6a5399c0-e679-4b81-b880-1c4eef0bfabf' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:44:09.505830</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_params&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;time_range&#x27;: [&#x27;2008-01-01T00:00:00&#x27;, &#x27;2008-07-01T00:00:00&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube_cci.chunkstore.CciChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;chunks&#x27;: {&#x27;lat&#x27;: 1024, &#x27;lon&#x27;: 1024, &#x27;time&#x27;: 1}, &#x27;spatial_res&#x27;: 0.041666666666666664, &#x27;time_period&#x27;: &#x27;1M&#x27;, &#x27;time_range&#x27;: [&#x27;2008-01-01&#x27;, &#x27;2008-07-01&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L3S</dd><dt><span>time_coverage_duration :</span></dt><dd>P213DT0H0M0S</dd><dt><span>time_coverage_end :</span></dt><dd>2008-08-01T00:00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2008-01-01T00:00:00</dd><dt><span>title :</span></dt><dd>esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-platform.MERGED.3-1.geographic</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-f375d68d-89b5-4836-aa23-1ba4bbdeac9e' class='xr-section-summary-in' type='checkbox'  ><label for='section-f375d68d-89b5-4836-aa23-1ba4bbdeac9e' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-06-23T10:22:30.985526</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_params&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;time_range&#x27;: [&#x27;2008-01-01T00:00:00&#x27;, &#x27;2008-07-01T00:00:00&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube_cci.chunkstore.CciChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;chunks&#x27;: {&#x27;lat&#x27;: 1024, &#x27;lon&#x27;: 1024, &#x27;time&#x27;: 1}, &#x27;spatial_res&#x27;: 0.041666666666666664, &#x27;time_period&#x27;: &#x27;1M&#x27;, &#x27;time_range&#x27;: [&#x27;2008-01-01&#x27;, &#x27;2008-07-01&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L3S</dd><dt><span>time_coverage_duration :</span></dt><dd>P213DT0H0M0S</dd><dt><span>time_coverage_end :</span></dt><dd>2008-08-01T00:00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2008-01-01T00:00:00</dd><dt><span>title :</span></dt><dd>esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-platform.MERGED.3-1.geographic</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -20076,7 +20451,7 @@
        "    chlor_a    (time, lat, lon) float32 dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-06-23T08:44:09.505830\n",
+       "    date_created:               2022-06-23T10:22:30.985526\n",
        "    geospatial_bounds:          POLYGON((-180 -90, -180 90, 180 90, 180 -90, ...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         90\n",
@@ -20090,7 +20465,7 @@
        "    title:                      esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-..."
       ]
      },
-     "execution_count": 52,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20104,10 +20479,10 @@
    "id": "90264b60-8c97-4276-8b8f-fefaf1cf7928",
    "metadata": {
     "papermill": {
-     "duration": 0.133421,
-     "end_time": "2022-02-23T14:19:25.658478",
+     "duration": 0.093291,
+     "end_time": "2022-06-23T10:24:06.621370",
      "exception": false,
-     "start_time": "2022-02-23T14:19:25.525057",
+     "start_time": "2022-06-23T10:24:06.528079",
      "status": "completed"
     },
     "tags": []
@@ -20118,14 +20493,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 54,
    "id": "c5a23a54-f33a-4d83-b840-3d5eb94e2157",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-06-23T10:24:06.824293Z",
+     "iopub.status.busy": "2022-06-23T10:24:06.824020Z",
+     "iopub.status.idle": "2022-06-23T10:24:06.827049Z",
+     "shell.execute_reply": "2022-06-23T10:24:06.826448Z"
+    },
     "papermill": {
-     "duration": 0.141013,
-     "end_time": "2022-02-23T14:19:25.932665",
+     "duration": 0.112038,
+     "end_time": "2022-06-23T10:24:06.828622",
      "exception": false,
-     "start_time": "2022-02-23T14:19:25.791652",
+     "start_time": "2022-06-23T10:24:06.716584",
      "status": "completed"
     },
     "tags": []
@@ -20141,10 +20522,10 @@
    "id": "174bf3da-487f-45e6-abb1-526bbb107630",
    "metadata": {
     "papermill": {
-     "duration": 0.132967,
-     "end_time": "2022-02-23T14:19:26.203854",
+     "duration": 0.102945,
+     "end_time": "2022-06-23T10:24:07.037850",
      "exception": false,
-     "start_time": "2022-02-23T14:19:26.070887",
+     "start_time": "2022-06-23T10:24:06.934905",
      "status": "completed"
     },
     "tags": []
@@ -20173,14 +20554,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 556.623773,
-   "end_time": "2022-02-23T14:19:26.958061",
+   "duration": 484.20588,
+   "end_time": "2022-06-23T10:24:07.753043",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/tmp/tmpqaswznak",
-   "output_path": "/tmp/cur_notebook.ipynb",
+   "input_path": "/tmp/tmpae0z5lgu",
+   "output_path": "/tmp/notebook_output.ipynb",
    "parameters": {},
-   "start_time": "2022-02-23T14:10:10.334288",
+   "start_time": "2022-06-23T10:16:03.547163",
    "version": "2.3.3"
   },
   "properties": {

--- a/notebooks/curated/EDC_xcube_generator_service.ipynb
+++ b/notebooks/curated/EDC_xcube_generator_service.ipynb
@@ -122,15 +122,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "d0b57b19-ac46-4d62-9bc3-e632771255c3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:11.992509Z",
-     "iopub.status.busy": "2022-02-23T14:10:11.991850Z",
-     "iopub.status.idle": "2022-02-23T14:10:16.438306Z",
-     "shell.execute_reply": "2022-02-23T14:10:16.437592Z"
-    },
     "papermill": {
      "duration": 4.516794,
      "end_time": "2022-02-23T14:10:16.440564",
@@ -161,53 +155,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "ff099602-7c82-4efa-a0ca-019e017d55b2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:16.576790Z",
-     "iopub.status.busy": "2022-02-23T14:10:16.576269Z",
-     "iopub.status.idle": "2022-02-23T14:10:16.583927Z",
-     "shell.execute_reply": "2022-02-23T14:10:16.583237Z"
-    },
-    "papermill": {
-     "duration": 0.077554,
-     "end_time": "2022-02-23T14:10:16.585911",
-     "exception": false,
-     "start_time": "2022-02-23T14:10:16.508357",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "API credentials have automatically been injected for your active subscriptions.  \n",
-       "The following environment variables are now available:\n",
-       "\n",
-       "The following additional environment variables have been loaded from `~/custom.env`:\n",
-       "* `AWS_BUCKET`\n",
-       "* `DAPA_URL`\n",
-       "* `DB_HOST`, `DB_NAME`, `DB_PASSWORD`, `DB_USER`\n",
-       "* `OGC_EDC_URL`\n",
-       "* `REFERENCE_DATA`\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from edc import setup_environment_variables\n",
-    "setup_environment_variables()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "312a9878-cf69-4017-8a54-e5170a7e029f",
    "metadata": {
@@ -226,15 +173,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "a8369528-957d-485b-b727-ce359cbe5653",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:16.867370Z",
-     "iopub.status.busy": "2022-02-23T14:10:16.866940Z",
-     "iopub.status.idle": "2022-02-23T14:10:16.872339Z",
-     "shell.execute_reply": "2022-02-23T14:10:16.871538Z"
-    },
     "papermill": {
      "duration": 0.075691,
      "end_time": "2022-02-23T14:10:16.874232",
@@ -248,10 +189,10 @@
     {
      "data": {
       "text/plain": [
-       "'0.10.1'"
+       "'0.11.2'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,15 +221,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "afbbfb3a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:17.152158Z",
-     "iopub.status.busy": "2022-02-23T14:10:17.151432Z",
-     "iopub.status.idle": "2022-02-23T14:10:17.156077Z",
-     "shell.execute_reply": "2022-02-23T14:10:17.155200Z"
-    },
     "papermill": {
      "duration": 0.076175,
      "end_time": "2022-02-23T14:10:17.158193",
@@ -309,15 +244,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "918f5d38",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:17.317734Z",
-     "iopub.status.busy": "2022-02-23T14:10:17.317209Z",
-     "iopub.status.idle": "2022-02-23T14:10:17.325274Z",
-     "shell.execute_reply": "2022-02-23T14:10:17.324517Z"
-    },
     "papermill": {
      "duration": 0.098098,
      "end_time": "2022-02-23T14:10:17.327273",
@@ -368,15 +297,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "4ba8c114-1b18-43c6-bba5-eba72ddedc94",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:17.731498Z",
-     "iopub.status.busy": "2022-02-23T14:10:17.731026Z",
-     "iopub.status.idle": "2022-02-23T14:10:17.735882Z",
-     "shell.execute_reply": "2022-02-23T14:10:17.735016Z"
-    },
     "papermill": {
      "duration": 0.074534,
      "end_time": "2022-02-23T14:10:17.737772",
@@ -415,15 +338,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "c1bec9e7-4b6a-43d7-8737-4a757322e4bf",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:18.016174Z",
-     "iopub.status.busy": "2022-02-23T14:10:18.015486Z",
-     "iopub.status.idle": "2022-02-23T14:10:18.022793Z",
-     "shell.execute_reply": "2022-02-23T14:10:18.022108Z"
-    },
     "papermill": {
      "duration": 0.079784,
      "end_time": "2022-02-23T14:10:18.024896",
@@ -440,24 +357,24 @@
        "coordinates": [
         [
          [
-          11.0,
-          53.0
+          11,
+          53
          ],
          [
-          11.0,
-          55.0
+          11,
+          55
          ],
          [
-          7.0,
-          55.0
+          7,
+          55
          ],
          [
-          7.0,
-          53.0
+          7,
+          53
          ],
          [
-          11.0,
-          53.0
+          11,
+          53
          ]
         ]
        ],
@@ -541,15 +458,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "01906a83",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:18.447014Z",
-     "iopub.status.busy": "2022-02-23T14:10:18.446542Z",
-     "iopub.status.idle": "2022-02-23T14:10:18.452448Z",
-     "shell.execute_reply": "2022-02-23T14:10:18.451628Z"
-    },
     "papermill": {
      "duration": 0.0766,
      "end_time": "2022-02-23T14:10:18.454527",
@@ -583,15 +494,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "d22dfb04",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:18.607068Z",
-     "iopub.status.busy": "2022-02-23T14:10:18.606531Z",
-     "iopub.status.idle": "2022-02-23T14:10:18.611047Z",
-     "shell.execute_reply": "2022-02-23T14:10:18.610098Z"
-    },
     "papermill": {
      "duration": 0.082883,
      "end_time": "2022-02-23T14:10:18.612865",
@@ -629,15 +534,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "f3f74fab-dc02-4e92-932f-82713a63b988",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:18.890615Z",
-     "iopub.status.busy": "2022-02-23T14:10:18.889924Z",
-     "iopub.status.idle": "2022-02-23T14:10:18.894552Z",
-     "shell.execute_reply": "2022-02-23T14:10:18.893733Z"
-    },
     "papermill": {
      "duration": 0.074383,
      "end_time": "2022-02-23T14:10:18.896556",
@@ -654,15 +553,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "053e1fcc-7007-496d-9b0a-c50caf597df7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:19.037907Z",
-     "iopub.status.busy": "2022-02-23T14:10:19.037603Z",
-     "iopub.status.idle": "2022-02-23T14:10:27.884400Z",
-     "shell.execute_reply": "2022-02-23T14:10:27.883513Z"
-    },
     "papermill": {
      "duration": 8.916904,
      "end_time": "2022-02-23T14:10:27.886375",
@@ -677,10 +570,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-02-23 14:10:22 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-f0e51347-718b-4733.yaml.",
-        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-f0e51347-718b-4733.json",
-        "2022-02-23 14:10:26 XCUBE GEN END"
+        "2022-06-23 08:34:48 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-97806c7d-4866-4eb0.yaml.",
+        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-97806c7d-4866-4eb0.json",
+        "2022-06-23 08:34:52 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -690,10 +583,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          7.0,
-          53.0,
-          11.0,
-          55.0
+          7,
+          53,
+          11,
+          55
          ],
          "crs": "WGS84",
          "data_id": "SH_demo.zarr",
@@ -752,10 +645,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7f84cc6fe130>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff35ac33a00>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -783,15 +676,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "bb136bf0",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:10:28.177172Z",
-     "iopub.status.busy": "2022-02-23T14:10:28.176741Z",
-     "iopub.status.idle": "2022-02-23T14:11:28.146752Z",
-     "shell.execute_reply": "2022-02-23T14:11:28.145578Z"
-    },
     "papermill": {
      "duration": 60.113048,
      "end_time": "2022-02-23T14:11:28.220937",
@@ -801,37 +688,16 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - ...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - done.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "0a50db04-9d2b-4671-b5c6-b97a5cce0887",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:28.368098Z",
-     "iopub.status.busy": "2022-02-23T14:11:28.367668Z",
-     "iopub.status.idle": "2022-02-23T14:11:28.381763Z",
-     "shell.execute_reply": "2022-02-23T14:11:28.380807Z"
-    },
     "papermill": {
      "duration": 0.088492,
      "end_time": "2022-02-23T14:11:28.383649",
@@ -845,12 +711,12 @@
     {
      "data": {
       "application/json": {
-       "message": "Cube generated successfully after 45.24 seconds",
+       "message": "Cube generated successfully after 35.59 seconds",
        "output": [
-        "2022-02-23 14:10:37 XCUBE GEN START",
+        "2022-06-23 08:35:12 XCUBE GEN START",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/pandas/core/tools/timedeltas.py:148: FutureWarning: Units 'M', 'Y' and 'y' do not represent unambiguous timedelta values and will be removed in a future version.",
         "  return _coerce_scalar_to_timedelta_type(arg, unit=unit, errors=errors)",
-        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-ad9f8dbf-b362-433d.yaml.",
+        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-5d0702a8-5118-467e.yaml.",
         "Generating cube - ...",
         "Generating cube - 0.0%: reading cube - ...",
         "Generating cube - 2.4%: reading cube - 33.3%",
@@ -1392,8 +1258,8 @@
         "Generating cube - 99.1%: writing cube - 99.8%",
         "Generating cube - 99.1%: writing cube - done.",
         "Generating cube - done.",
-        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-ad9f8dbf-b362-433d.json",
-        "2022-02-23 14:11:26 XCUBE GEN END"
+        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-5d0702a8-5118-467e.json",
+        "2022-06-23 08:35:54 XCUBE GEN END"
        ],
        "result": {
         "data_id": "SH_demo.zarr"
@@ -1402,10 +1268,10 @@
        "status_code": 201
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7f8598e76df0>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff35ac33670>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1433,15 +1299,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "0523fd2e",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:28.692772Z",
-     "iopub.status.busy": "2022-02-23T14:11:28.692142Z",
-     "iopub.status.idle": "2022-02-23T14:11:28.742439Z",
-     "shell.execute_reply": "2022-02-23T14:11:28.741746Z"
-    },
     "papermill": {
      "duration": 0.125014,
      "end_time": "2022-02-23T14:11:28.744668",
@@ -1458,15 +1318,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "1703da74",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:28.895504Z",
-     "iopub.status.busy": "2022-02-23T14:11:28.894981Z",
-     "iopub.status.idle": "2022-02-23T14:11:29.035081Z",
-     "shell.execute_reply": "2022-02-23T14:11:29.034398Z"
-    },
     "papermill": {
      "duration": 0.214667,
      "end_time": "2022-02-23T14:11:29.037230",
@@ -1483,15 +1337,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "baf12155-4656-4ef1-a09f-55053b7a5e0e",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:29.198901Z",
-     "iopub.status.busy": "2022-02-23T14:11:29.198351Z",
-     "iopub.status.idle": "2022-02-23T14:11:29.204441Z",
-     "shell.execute_reply": "2022-02-23T14:11:29.203561Z"
-    },
     "papermill": {
      "duration": 0.096944,
      "end_time": "2022-02-23T14:11:29.206135",
@@ -1505,18 +1353,10 @@
     {
      "data": {
       "text/plain": [
-       "['COP_demo_v2.zarr',\n",
-       " 'SH_demo.zarr',\n",
-       " 'cci-chlor_a.zarr',\n",
-       " 'ccizarr-swe.zarr',\n",
-       " 'cds-volumetric_surface_soil_moisture.zarr',\n",
-       " 'cop-services-OC-ATL_CHL.zarr',\n",
-       " 'cop-services-OC-BAL_CHL.zarr',\n",
-       " 'sh-S1GRD_VV.zarr',\n",
-       " 'volumetric_surface_soil_moisture.zarr']"
+       "['SH_demo.zarr', 'sh-S2L2A_BYOA.zarr']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1544,15 +1384,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "55c221ab",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:29.519350Z",
-     "iopub.status.busy": "2022-02-23T14:11:29.518664Z",
-     "iopub.status.idle": "2022-02-23T14:11:29.791994Z",
-     "shell.execute_reply": "2022-02-23T14:11:29.791389Z"
-    },
     "papermill": {
      "duration": 0.350804,
      "end_time": "2022-02-23T14:11:29.794929",
@@ -1930,7 +1764,7 @@
        "    B05        (time, lat, lon) float32 dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-02-23T14:10:40.369713\n",
+       "    date_created:               2022-06-23T08:35:16.830469\n",
        "    geospatial_bounds:          POLYGON((7 53, 7 55.048, 11.096 55.048, 11.09...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         55.048\n",
@@ -1941,9 +1775,9 @@
        "    time_coverage_duration:     P3DT23H40M56S\n",
        "    time_coverage_end:          2021-03-05T10:36:25+00:00\n",
        "    time_coverage_start:        2021-03-01T10:55:29+00:00\n",
-       "    title:                      S2L2A Data Cube Subset</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-906409c7-510c-4356-b3fa-555154733053' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-906409c7-510c-4356-b3fa-555154733053' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 4</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 4096</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-64ae36e6-25ad-4ef3-9d72-af5b37e46842' class='xr-section-summary-in' type='checkbox'  checked><label for='section-64ae36e6-25ad-4ef3-9d72-af5b37e46842' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>55.05 55.05 55.05 ... 53.0 53.0</div><input id='attrs-7c16a5f3-c275-41e6-8a46-a8f6571249c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7c16a5f3-c275-41e6-8a46-a8f6571249c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-109bccd8-8c07-4d60-8333-590b7d78bde8' class='xr-var-data-in' type='checkbox'><label for='data-109bccd8-8c07-4d60-8333-590b7d78bde8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([55.0475, 55.0465, 55.0455, ..., 53.0025, 53.0015, 53.0005])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>7.0 7.002 7.002 ... 11.09 11.1</div><input id='attrs-276c2ae9-f82a-48fd-9f71-4232997e665a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-276c2ae9-f82a-48fd-9f71-4232997e665a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-de18e40d-e12d-4907-a877-d695006b8761' class='xr-var-data-in' type='checkbox'><label for='data-de18e40d-e12d-4907-a877-d695006b8761' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([ 7.0005,  7.0015,  7.0025, ..., 11.0935, 11.0945, 11.0955])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2021-03-01T10:55:53 ... 2021-03-...</div><input id='attrs-d2733e65-7cd9-4f34-a04e-76d569e63b28' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d2733e65-7cd9-4f34-a04e-76d569e63b28' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-24434b7d-6962-43ed-9b56-2d9d7e6041ed' class='xr-var-data-in' type='checkbox'><label for='data-24434b7d-6962-43ed-9b56-2d9d7e6041ed' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2021-03-01T10:55:53.000000000&#x27;, &#x27;2021-03-02T10:25:53.000000000&#x27;,\n",
+       "    title:                      S2L2A Data Cube Subset</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-cdf7198d-5d89-4736-b07d-ce17d770f358' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-cdf7198d-5d89-4736-b07d-ce17d770f358' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 4</li><li><span class='xr-has-index'>lat</span>: 2048</li><li><span class='xr-has-index'>lon</span>: 4096</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-7801716a-329f-418e-853c-09611f61df89' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7801716a-329f-418e-853c-09611f61df89' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>55.05 55.05 55.05 ... 53.0 53.0</div><input id='attrs-49fa6cd1-e25f-4276-8b82-abd7b4a521e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-49fa6cd1-e25f-4276-8b82-abd7b4a521e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-10d6a1b0-d5f2-43f2-8e23-b665c7bdcc4f' class='xr-var-data-in' type='checkbox'><label for='data-10d6a1b0-d5f2-43f2-8e23-b665c7bdcc4f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([55.0475, 55.0465, 55.0455, ..., 53.0025, 53.0015, 53.0005])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>7.0 7.002 7.002 ... 11.09 11.1</div><input id='attrs-bd736ac6-3933-49c0-b31d-a24ca5d571fa' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bd736ac6-3933-49c0-b31d-a24ca5d571fa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8af02625-1bc8-4bd7-9442-ea2ccb01421d' class='xr-var-data-in' type='checkbox'><label for='data-8af02625-1bc8-4bd7-9442-ea2ccb01421d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>decimal_degrees</dd></dl></div><div class='xr-var-data'><pre>array([ 7.0005,  7.0015,  7.0025, ..., 11.0935, 11.0945, 11.0955])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2021-03-01T10:55:53 ... 2021-03-...</div><input id='attrs-06c0b320-e989-4a0a-b3d7-8eacf5e75136' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06c0b320-e989-4a0a-b3d7-8eacf5e75136' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a399a657-525d-47a2-84e4-3ac70437c299' class='xr-var-data-in' type='checkbox'><label for='data-a399a657-525d-47a2-84e4-3ac70437c299' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2021-03-01T10:55:53.000000000&#x27;, &#x27;2021-03-02T10:25:53.000000000&#x27;,\n",
        "       &#x27;2021-03-03T10:45:53.000000000&#x27;, &#x27;2021-03-05T10:35:56.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(4, 2), meta=np.ndarray&gt;</div><input id='attrs-83677ab8-5aa0-4ca9-aec0-a424343906c6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-83677ab8-5aa0-4ca9-aec0-a424343906c6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cef2a4d5-957f-46d1-853b-93930c8e062e' class='xr-var-data-in' type='checkbox'><label for='data-cef2a4d5-957f-46d1-853b-93930c8e062e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(4, 2), meta=np.ndarray&gt;</div><input id='attrs-dd33c3ba-a40b-47b1-88cd-1ca0048175fa' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dd33c3ba-a40b-47b1-88cd-1ca0048175fa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-67ba2750-487a-4afe-b133-179b88d08b3f' class='xr-var-data-in' type='checkbox'><label for='data-67ba2750-487a-4afe-b133-179b88d08b3f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2000,7 +1834,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-7b4b5c1f-ca0f-4fe4-9a5c-61d6bb1e68ae' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7b4b5c1f-ca0f-4fe4-9a5c-61d6bb1e68ae' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-834bc95c-04ac-4d50-aa23-0c9bae40575c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-834bc95c-04ac-4d50-aa23-0c9bae40575c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7062bdc0-ed02-4370-9323-fbe747555b43' class='xr-var-data-in' type='checkbox'><label for='data-7062bdc0-ed02-4370-9323-fbe747555b43' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-0bbdcce8-b7d4-4912-9071-0d9f46ecf52a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0bbdcce8-b7d4-4912-9071-0d9f46ecf52a' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-5b878594-6a86-4b9d-b910-d065bfa82f1c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5b878594-6a86-4b9d-b910-d065bfa82f1c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6addeda-f95f-4269-9c81-bd47e3736aee' class='xr-var-data-in' type='checkbox'><label for='data-e6addeda-f95f-4269-9c81-bd47e3736aee' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>31.0</dd><dt><span>bandwidth_a :</span></dt><dd>31</dd><dt><span>bandwidth_b :</span></dt><dd>31</dd><dt><span>resolution :</span></dt><dd>10</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>664.75</dd><dt><span>wavelength_a :</span></dt><dd>664.6</dd><dt><span>wavelength_b :</span></dt><dd>664.9</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2106,7 +1940,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-7d0e9e89-ed63-4b3b-81dc-f3707ac98a2c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7d0e9e89-ed63-4b3b-81dc-f3707ac98a2c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-764d8826-9e72-48b2-9678-bb450af7d963' class='xr-var-data-in' type='checkbox'><label for='data-764d8826-9e72-48b2-9678-bb450af7d963' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B05</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-56cb0706-a4de-4776-b71b-33dfb8524f11' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-56cb0706-a4de-4776-b71b-33dfb8524f11' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f57c79f3-9b32-400d-a030-40eeae37a6ca' class='xr-var-data-in' type='checkbox'><label for='data-f57c79f3-9b32-400d-a030-40eeae37a6ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bandwidth :</span></dt><dd>15.5</dd><dt><span>bandwidth_a :</span></dt><dd>15</dd><dt><span>bandwidth_b :</span></dt><dd>16</dd><dt><span>resolution :</span></dt><dd>20</dd><dt><span>sample_type :</span></dt><dd>FLOAT32</dd><dt><span>units :</span></dt><dd>reflectance</dd><dt><span>wavelength :</span></dt><dd>703.95</dd><dt><span>wavelength_a :</span></dt><dd>704.1</dd><dt><span>wavelength_b :</span></dt><dd>703.8</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -2212,7 +2046,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-c485f699-8189-40db-9f08-3730fe471e46' class='xr-section-summary-in' type='checkbox'  ><label for='section-c485f699-8189-40db-9f08-3730fe471e46' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:10:40.369713</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((7 53, 7 55.048, 11.096 55.048, 11.096 53, 7 53))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>55.048</dd><dt><span>geospatial_lat_min :</span></dt><dd>53</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.096</dd><dt><span>geospatial_lon_min :</span></dt><dd>7</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_config&#x27;: {&#x27;band_fill_values&#x27;: None, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;], &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;bbox&#x27;: [7.0, 53.0, 11.096, 55.048], &#x27;collection_id&#x27;: None, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;four_d&#x27;: False, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: None, &#x27;time_range&#x27;: [&#x27;2021-03-01T00:00:00+00:00&#x27;, &#x27;2021-03-06T00:00:00+00:00&#x27;], &#x27;time_tolerance&#x27;: &#x27;0 days 00:10:00&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;}, &#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [7.0, 53.0, 11.0, 55.0], &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2021-03-01&#x27;, &#x27;2021-03-06&#x27;], &#x27;variable_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.1&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L2A</dd><dt><span>time_coverage_duration :</span></dt><dd>P3DT23H40M56S</dd><dt><span>time_coverage_end :</span></dt><dd>2021-03-05T10:36:25+00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2021-03-01T10:55:29+00:00</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-4fa5f3d4-1954-42cf-8c3b-b3e80017632b' class='xr-section-summary-in' type='checkbox'  ><label for='section-4fa5f3d4-1954-42cf-8c3b-b3e80017632b' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:35:16.830469</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((7 53, 7 55.048, 11.096 55.048, 11.096 53, 7 53))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>55.048</dd><dt><span>geospatial_lat_min :</span></dt><dd>53</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>11.096</dd><dt><span>geospatial_lon_min :</span></dt><dd>7</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.001</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_config&#x27;: {&#x27;band_fill_values&#x27;: None, &#x27;band_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;], &#x27;band_sample_types&#x27;: None, &#x27;band_units&#x27;: None, &#x27;bbox&#x27;: [7.0, 53.0, 11.096, 55.048], &#x27;collection_id&#x27;: None, &#x27;crs&#x27;: &#x27;WGS84&#x27;, &#x27;dataset_name&#x27;: &#x27;S2L2A&#x27;, &#x27;downsampling&#x27;: &#x27;NEAREST&#x27;, &#x27;four_d&#x27;: False, &#x27;mosaicking_order&#x27;: &#x27;mostRecent&#x27;, &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: None, &#x27;time_range&#x27;: [&#x27;2021-03-01T00:00:00+00:00&#x27;, &#x27;2021-03-06T00:00:00+00:00&#x27;], &#x27;time_tolerance&#x27;: &#x27;0 days 00:10:00&#x27;, &#x27;upsampling&#x27;: &#x27;NEAREST&#x27;}, &#x27;program&#x27;: &#x27;xcube_sh.chunkstore.SentinelHubChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [7.0, 53.0, 11.0, 55.0], &#x27;spatial_res&#x27;: 0.001, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2021-03-01&#x27;, &#x27;2021-03-06&#x27;], &#x27;variable_names&#x27;: [&#x27;B04&#x27;, &#x27;B05&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L2A</dd><dt><span>time_coverage_duration :</span></dt><dd>P3DT23H40M56S</dd><dt><span>time_coverage_end :</span></dt><dd>2021-03-05T10:36:25+00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2021-03-01T10:55:29+00:00</dd><dt><span>title :</span></dt><dd>S2L2A Data Cube Subset</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2228,7 +2062,7 @@
        "    B05        (time, lat, lon) float32 dask.array<chunksize=(1, 512, 512), meta=np.ndarray>\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-02-23T14:10:40.369713\n",
+       "    date_created:               2022-06-23T08:35:16.830469\n",
        "    geospatial_bounds:          POLYGON((7 53, 7 55.048, 11.096 55.048, 11.09...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         55.048\n",
@@ -2242,7 +2076,7 @@
        "    title:                      S2L2A Data Cube Subset"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2271,15 +2105,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "55a0ba76",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:30.096251Z",
-     "iopub.status.busy": "2022-02-23T14:11:30.095570Z",
-     "iopub.status.idle": "2022-02-23T14:11:40.798871Z",
-     "shell.execute_reply": "2022-02-23T14:11:40.798165Z"
-    },
     "papermill": {
      "duration": 10.788239,
      "end_time": "2022-02-23T14:11:40.807185",
@@ -2293,10 +2121,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f84cab3a250>"
+       "<matplotlib.collections.QuadMesh at 0x7ff35862d040>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2363,15 +2191,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "f5fd0289-5b14-4671-ad77-e697d274c832",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:41.330510Z",
-     "iopub.status.busy": "2022-02-23T14:11:41.329668Z",
-     "iopub.status.idle": "2022-02-23T14:11:41.335714Z",
-     "shell.execute_reply": "2022-02-23T14:11:41.335068Z"
-    },
     "papermill": {
      "duration": 0.094111,
      "end_time": "2022-02-23T14:11:41.337615",
@@ -2406,15 +2228,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "id": "d58453b0-08b9-4324-9665-cf04b9762ef5",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:41.518642Z",
-     "iopub.status.busy": "2022-02-23T14:11:41.518089Z",
-     "iopub.status.idle": "2022-02-23T14:11:41.522586Z",
-     "shell.execute_reply": "2022-02-23T14:11:41.521846Z"
-    },
     "papermill": {
      "duration": 0.094478,
      "end_time": "2022-02-23T14:11:41.524593",
@@ -2435,15 +2251,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "id": "8565a1c1-19d7-4bca-9f48-d0b96e23e92f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:41.701722Z",
-     "iopub.status.busy": "2022-02-23T14:11:41.701318Z",
-     "iopub.status.idle": "2022-02-23T14:11:41.705628Z",
-     "shell.execute_reply": "2022-02-23T14:11:41.704839Z"
-    },
     "papermill": {
      "duration": 0.091608,
      "end_time": "2022-02-23T14:11:41.707538",
@@ -2460,15 +2270,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "id": "226cb89b-1589-4097-9050-e9f2592481c8",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:41.884706Z",
-     "iopub.status.busy": "2022-02-23T14:11:41.884170Z",
-     "iopub.status.idle": "2022-02-23T14:11:51.807076Z",
-     "shell.execute_reply": "2022-02-23T14:11:51.806267Z"
-    },
     "papermill": {
      "duration": 10.011616,
      "end_time": "2022-02-23T14:11:51.809171",
@@ -2483,10 +2287,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-02-23 14:11:45 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-efd307f2-3456-4c6b.yaml.",
-        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-efd307f2-3456-4c6b.json",
-        "2022-02-23 14:11:50 XCUBE GEN END"
+        "2022-06-23 08:36:41 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-ab26f2e4-ea5e-4bb6.yaml.",
+        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-ab26f2e4-ea5e-4bb6.json",
+        "2022-06-23 08:36:47 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -2496,10 +2300,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          0.0,
-          35.0,
-          10.0,
-          45.0
+          0,
+          35,
+          10,
+          45
          ],
          "crs": "WGS84",
          "data_id": "COP_demo_v2.zarr",
@@ -2549,10 +2353,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7f84c817e9d0>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff3584c13a0>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2563,15 +2367,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "id": "6dd8fb94-02d2-4b4d-aa51-220eb537ff03",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:11:51.983484Z",
-     "iopub.status.busy": "2022-02-23T14:11:51.982784Z",
-     "iopub.status.idle": "2022-02-23T14:15:07.817121Z",
-     "shell.execute_reply": "2022-02-23T14:15:07.815960Z"
-    },
     "papermill": {
      "duration": 196.036289,
      "end_time": "2022-02-23T14:15:07.930177",
@@ -2581,39 +2379,16 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - ...\n",
-      "Generating cube - ...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - done.\n",
-      "Generating cube - done.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "id": "53e17d61-cafa-47eb-acf0-a31faeaf4d00",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:08.133044Z",
-     "iopub.status.busy": "2022-02-23T14:15:08.132461Z",
-     "iopub.status.idle": "2022-02-23T14:15:08.290899Z",
-     "shell.execute_reply": "2022-02-23T14:15:08.290108Z"
-    },
     "papermill": {
      "duration": 0.269853,
      "end_time": "2022-02-23T14:15:08.303726",
@@ -2627,10 +2402,10 @@
     {
      "data": {
       "application/json": {
-       "message": "Cube generated successfully after 181.17 seconds",
+       "message": "Cube generated successfully after 128.71 seconds",
        "output": [
-        "2022-02-23 14:12:01 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-7f102c99-2b5c-4e39.yaml.",
+        "2022-06-23 08:37:01 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-c0d377a6-62fe-48f7.yaml.",
         "Generating cube - ...",
         "Generating cube - 0.0%: reading cube - ...",
         "Generating cube - 2.4%: reading cube - 33.3%",
@@ -16608,8 +16383,8 @@
         "Generating cube - 99.3%: writing cube - 100.0%",
         "Generating cube - 99.3%: writing cube - done.",
         "Generating cube - done.",
-        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-7f102c99-2b5c-4e39.json",
-        "2022-02-23 14:15:06 XCUBE GEN END"
+        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-c0d377a6-62fe-48f7.json",
+        "2022-06-23 08:39:15 XCUBE GEN END"
        ],
        "result": {
         "data_id": "COP_demo_v2.zarr"
@@ -16618,10 +16393,10 @@
        "status_code": 201
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7f84c818b760>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff3584844c0>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16632,15 +16407,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "id": "5ec47967",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:08.548494Z",
-     "iopub.status.busy": "2022-02-23T14:15:08.547577Z",
-     "iopub.status.idle": "2022-02-23T14:15:08.554746Z",
-     "shell.execute_reply": "2022-02-23T14:15:08.553954Z"
-    },
     "papermill": {
      "duration": 0.125932,
      "end_time": "2022-02-23T14:15:08.557102",
@@ -16657,7 +16426,7 @@
        "'COP_demo_v2.zarr'"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16668,15 +16437,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "84924427-0ede-4acc-bfe5-535a51b1210f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:08.832662Z",
-     "iopub.status.busy": "2022-02-23T14:15:08.832178Z",
-     "iopub.status.idle": "2022-02-23T14:15:08.846899Z",
-     "shell.execute_reply": "2022-02-23T14:15:08.845961Z"
-    },
     "papermill": {
      "duration": 0.152138,
      "end_time": "2022-02-23T14:15:08.849369",
@@ -16693,15 +16456,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "id": "9057c983-4f8f-44d3-a91c-b229bd636e6b",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:09.089381Z",
-     "iopub.status.busy": "2022-02-23T14:15:09.088936Z",
-     "iopub.status.idle": "2022-02-23T14:15:09.161136Z",
-     "shell.execute_reply": "2022-02-23T14:15:09.160202Z"
-    },
     "papermill": {
      "duration": 0.189529,
      "end_time": "2022-02-23T14:15:09.163575",
@@ -16715,18 +16472,10 @@
     {
      "data": {
       "text/plain": [
-       "['COP_demo_v2.zarr',\n",
-       " 'SH_demo.zarr',\n",
-       " 'cci-chlor_a.zarr',\n",
-       " 'ccizarr-swe.zarr',\n",
-       " 'cds-volumetric_surface_soil_moisture.zarr',\n",
-       " 'cop-services-OC-ATL_CHL.zarr',\n",
-       " 'cop-services-OC-BAL_CHL.zarr',\n",
-       " 'sh-S1GRD_VV.zarr',\n",
-       " 'volumetric_surface_soil_moisture.zarr']"
+       "['COP_demo_v2.zarr', 'SH_demo.zarr', 'sh-S2L2A_BYOA.zarr']"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16738,15 +16487,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "id": "83137f7b",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:09.402236Z",
-     "iopub.status.busy": "2022-02-23T14:15:09.401527Z",
-     "iopub.status.idle": "2022-02-23T14:15:09.551557Z",
-     "shell.execute_reply": "2022-02-23T14:15:09.550823Z"
-    },
     "papermill": {
      "duration": 0.27143,
      "end_time": "2022-02-23T14:15:09.553565",
@@ -16763,15 +16506,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "id": "4c404c39",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:09.786425Z",
-     "iopub.status.busy": "2022-02-23T14:15:09.785752Z",
-     "iopub.status.idle": "2022-02-23T14:15:09.812175Z",
-     "shell.execute_reply": "2022-02-23T14:15:09.811281Z"
-    },
     "papermill": {
      "duration": 0.150455,
      "end_time": "2022-02-23T14:15:09.813968",
@@ -17157,11 +16894,11 @@
        "    stop_date:                  2021-03-15\n",
        "    stop_time:                  14:00:00 UTC\n",
        "    title:                      dataset-oc-med-chl-multi-l4-interp_1km_daily-...\n",
-       "    westernmost_longitude:      -6.0</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-e852d2d6-d85e-48b4-9b1c-7843c6857bf1' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-e852d2d6-d85e-48b4-9b1c-7843c6857bf1' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 206</li><li><span class='xr-has-index'>lat</span>: 779</li><li><span class='xr-has-index'>lon</span>: 779</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-7c35e2a1-f3fb-4d6a-9feb-4344ac1a2d43' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7c35e2a1-f3fb-4d6a-9feb-4344ac1a2d43' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.01 35.02 35.03 ... 44.98 45.0</div><input id='attrs-798bd0ea-920e-4a5a-b76f-d06ff5c866f5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-798bd0ea-920e-4a5a-b76f-d06ff5c866f5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bf701c01-a846-4292-beab-4bc157ce996c' class='xr-var-data-in' type='checkbox'><label for='data-bf701c01-a846-4292-beab-4bc157ce996c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([35.00642, 35.01926, 35.0321 , ..., 44.97026, 44.9831 , 44.99594])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.00642 0.01926 ... 9.983 9.996</div><input id='attrs-523df508-284c-4850-b045-48e7a0478482' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-523df508-284c-4850-b045-48e7a0478482' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d75ba11e-a538-4ff4-b5b1-779210be6991' class='xr-var-data-in' type='checkbox'><label for='data-d75ba11e-a538-4ff4-b5b1-779210be6991' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([6.42000e-03, 1.92600e-02, 3.21000e-02, ..., 9.97026e+00, 9.98310e+00,\n",
-       "       9.99594e+00])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-06-01 ... 2020-01-01</div><input id='attrs-2488acc1-f132-498a-bfb7-b1d1c3730a61' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2488acc1-f132-498a-bfb7-b1d1c3730a61' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-77dc48d9-e11d-4cf1-9fa7-ccd66786fe48' class='xr-var-data-in' type='checkbox'><label for='data-77dc48d9-e11d-4cf1-9fa7-ccd66786fe48' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>T</dd><dt><span>long_name :</span></dt><dd>reference time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-06-01T00:00:00.000000000&#x27;, &#x27;2019-06-02T00:00:00.000000000&#x27;,\n",
+       "    westernmost_longitude:      -6.0</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a90ba2c1-08d4-4806-92cb-3f7498f54ac7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a90ba2c1-08d4-4806-92cb-3f7498f54ac7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 206</li><li><span class='xr-has-index'>lat</span>: 779</li><li><span class='xr-has-index'>lon</span>: 779</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0bc125b1-0e11-4472-ad09-9713e2f7668b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0bc125b1-0e11-4472-ad09-9713e2f7668b' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.01 35.02 35.03 ... 44.98 45.0</div><input id='attrs-3b9464a7-a014-4e5c-a1dd-bec97bf318cd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3b9464a7-a014-4e5c-a1dd-bec97bf318cd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8d4e4c27-bb6e-49bc-b2ed-dd06e549c660' class='xr-var-data-in' type='checkbox'><label for='data-8d4e4c27-bb6e-49bc-b2ed-dd06e549c660' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([35.00642, 35.01926, 35.0321 , ..., 44.97026, 44.9831 , 44.99594])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.00642 0.01926 ... 9.983 9.996</div><input id='attrs-c86346e8-c231-4398-b886-cc9b7672c9f1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c86346e8-c231-4398-b886-cc9b7672c9f1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1dd553ab-1e2d-4558-98b9-1fc640cc6280' class='xr-var-data-in' type='checkbox'><label for='data-1dd553ab-1e2d-4558-98b9-1fc640cc6280' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([6.42000e-03, 1.92600e-02, 3.21000e-02, ..., 9.97026e+00, 9.98310e+00,\n",
+       "       9.99594e+00])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2019-06-01 ... 2020-01-01</div><input id='attrs-963f454a-97ff-44eb-8e7b-9a6df69b25e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-963f454a-97ff-44eb-8e7b-9a6df69b25e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d57bb9de-0ac4-4228-88a2-f28d4883c706' class='xr-var-data-in' type='checkbox'><label for='data-d57bb9de-0ac4-4228-88a2-f28d4883c706' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>T</dd><dt><span>long_name :</span></dt><dd>reference time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2019-06-01T00:00:00.000000000&#x27;, &#x27;2019-06-02T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-06-03T00:00:00.000000000&#x27;, ..., &#x27;2019-12-30T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-12-31T00:00:00.000000000&#x27;, &#x27;2020-01-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ed57974c-e6cc-43fe-9c6d-0e84ef469677' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ed57974c-e6cc-43fe-9c6d-0e84ef469677' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>CHL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-8809c426-da82-425b-bea8-03055c384e80' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8809c426-da82-425b-bea8-03055c384e80' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1d6b6601-3ceb-41df-b30c-60df63bf5d49' class='xr-var-data-in' type='checkbox'><label for='data-1d6b6601-3ceb-41df-b30c-60df63bf5d49' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Multi-sensor, multi water-type, interpolated Chlorophyll a concentration</dd><dt><span>source :</span></dt><dd>MODISA Aqua - Level2,VIIRSN Suomi-NPP - Level2</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>type :</span></dt><dd>surface</dd><dt><span>units :</span></dt><dd>milligram m^-3</dd><dt><span>valid_max :</span></dt><dd>100.0</dd><dt><span>valid_min :</span></dt><dd>0.009999999776482582</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-82980698-4a0e-4126-b4e0-1e1ecd5cb285' class='xr-section-summary-in' type='checkbox'  checked><label for='section-82980698-4a0e-4126-b4e0-1e1ecd5cb285' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>CHL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-ef1456b1-bccf-4136-aced-477b51f2b053' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ef1456b1-bccf-4136-aced-477b51f2b053' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fde790ad-8774-4475-adee-8132a9b3cdc2' class='xr-var-data-in' type='checkbox'><label for='data-fde790ad-8774-4475-adee-8132a9b3cdc2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Multi-sensor, multi water-type, interpolated Chlorophyll a concentration</dd><dt><span>source :</span></dt><dd>MODISA Aqua - Level2,VIIRSN Suomi-NPP - Level2</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>type :</span></dt><dd>surface</dd><dt><span>units :</span></dt><dd>milligram m^-3</dd><dt><span>valid_max :</span></dt><dd>100.0</dd><dt><span>valid_min :</span></dt><dd>0.009999999776482582</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -17281,7 +17018,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-880a665e-6883-4fc5-8c9c-3b86fed1ea76' class='xr-section-summary-in' type='checkbox'  ><label for='section-880a665e-6883-4fc5-8c9c-3b86fed1ea76' class='xr-section-summary' >Attributes: <span>(52)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>citation :</span></dt><dd> </dd><dt><span>cmems_product_id :</span></dt><dd>OCEANCOLOUR_MED_CHL_L4_NRT_OBSERVATIONS_009_041</dd><dt><span>cmems_production_unit :</span></dt><dd>OC-CNR-ROMA-IT</dd><dt><span>comment :</span></dt><dd>r=log10(max([rrs443,rrs490,rrs510])/rrs555) ; chlcase1=10^[0.4567-4.2484r+2.0171r^2+2.6202r^3-2.8978r^4] ; r=log10(rrs490/rrs555) ; chlcase2=10.^[0.091-2.620r-1.148r^2-4.949r^3]. Interpolation is made via iterative EOF using the climatology as first guess. WTM and SENSORMASK fields provide the original data coverage.</dd><dt><span>contact :</span></dt><dd>technical@gos.artov.isac.cnr.it</dd><dt><span>creation_date :</span></dt><dd>Thu Apr 08 2021</dd><dt><span>creation_time :</span></dt><dd>06:04:30 UTC</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:12:58.396435</dd><dt><span>days_in_the_future :</span></dt><dd> 5</dd><dt><span>days_in_the_past :</span></dt><dd> 10</dd><dt><span>distribution_statement :</span></dt><dd>See CMEMS Data License</dd><dt><span>easternmost_longitude :</span></dt><dd>36.5</dd><dt><span>file_quality_index :</span></dt><dd>0</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((0 35, 0 45.00236, 10.002360000000001 45.00236, 10.002360000000001 35, 0 35))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>45.00236</dd><dt><span>geospatial_lat_min :</span></dt><dd>35</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.002360000000001</dd><dt><span>geospatial_lon_min :</span></dt><dd>0</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>grid_mapping :</span></dt><dd>Equirectangular</dd><dt><span>grid_resolution :</span></dt><dd>  1 Km</dd><dt><span>history :</span></dt><dd>[&#x27; &#x27;, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [0.0, 35.0, 10.0, 45.0], &#x27;spatial_res&#x27;: 0.01284, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: &#x27;1D&#x27;, &#x27;time_range&#x27;: [&#x27;2019-06-01&#x27;, &#x27;2019-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;CHL&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.1&#x27;}]</dd><dt><span>institution :</span></dt><dd>CNR-GOS</dd><dt><span>naming_authority :</span></dt><dd>CMEMS</dd><dt><span>netcdf_version :</span></dt><dd>v4</dd><dt><span>northernmost_latitude :</span></dt><dd>46.0</dd><dt><span>parameter :</span></dt><dd>chlorophyll-a concentration</dd><dt><span>parameter_code :</span></dt><dd>CHL</dd><dt><span>platform :</span></dt><dd>Aqua,JPSS-1,Sentinel-3a,Suomi-NPP</dd><dt><span>product_level :</span></dt><dd>L4</dd><dt><span>product_version :</span></dt><dd>v02QL</dd><dt><span>references :</span></dt><dd>1) Volpe, G., Colella, S., Brando, V., Forneris, V., La Padula, F., Di Cicco, A., Sammartino, M., Bracaglia, M., Artuso, F., and Santoleri, R. (2019). The Mediterranean Ocean Colour Level 3 Operational Multi-Sensor Processing, Ocean Sci., 15, 127–146, https://doi.org/10.5194/os-15-127-2019. - 2) Berthon, J. F., and G. Zibordi (2004), Bio-optical relationships for the northern Adriatic Sea, International Journal of Remote Sensing, 25, 7-8, 1527-1532. - 3) Volpe, G., Buongiorno Nardelli, B., Colella, S., Pisano, A. and Santoleri, R. (2018). An Operational Interpolated Ocean Colour Product in the Mediterranean Sea, in New Frontiers in Operational Oceanography, edited by E. P. Chassignet, A. Pascual, J. Tintorè, and J. Verron, pp. 227–244</dd><dt><span>sensor :</span></dt><dd>MODISA Moderate Resolution Imaging Spectroradiometer,VIIRSJ Visible Infrared Imaging Radiometer Suite,OLCI Ocean and Land Colour Instrument,VIIRSN Visible Infrared Imaging Radiometer Suite</dd><dt><span>sensor_name :</span></dt><dd>MODISA,VIIRSJ,OLCI,VIIRSN</dd><dt><span>site_name :</span></dt><dd>MED</dd><dt><span>software_name :</span></dt><dd>GOS Processing chain</dd><dt><span>software_version :</span></dt><dd>v3.0</dd><dt><span>source :</span></dt><dd>surface observation</dd><dt><span>source_files :</span></dt><dd>X2021065-chl-med-hr.nc X2021066-chl-med-hr.nc X2021067-chl-med-hr.nc X2021068-chl-med-hr.nc X2021069-chl-med-hr.nc X2021070-chl-med-hr.nc X2021071-chl-med-hr.nc X2021072-chl-med-hr.nc X2021073-chl-med-hr.nc X2021074-chl-med-hr.nc X2021075-chl-med-hr.nc X2021076-chl-med-hr.nc X2021077-chl-med-hr.nc X2021078-chl-med-hr.nc</dd><dt><span>southernmost_latitude :</span></dt><dd>30.0</dd><dt><span>st_location :</span></dt><dd> 4  0</dd><dt><span>start_date :</span></dt><dd>2021-03-15</dd><dt><span>start_time :</span></dt><dd>08:00:00 UTC</dd><dt><span>stop_date :</span></dt><dd>2021-03-15</dd><dt><span>stop_time :</span></dt><dd>14:00:00 UTC</dd><dt><span>title :</span></dt><dd>dataset-oc-med-chl-multi-l4-interp_1km_daily-rt-v02</dd><dt><span>westernmost_longitude :</span></dt><dd>-6.0</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6b24059b-63a7-4bb0-8564-e8f674bd588e' class='xr-section-summary-in' type='checkbox'  ><label for='section-6b24059b-63a7-4bb0-8564-e8f674bd588e' class='xr-section-summary' >Attributes: <span>(52)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>citation :</span></dt><dd> </dd><dt><span>cmems_product_id :</span></dt><dd>OCEANCOLOUR_MED_CHL_L4_NRT_OBSERVATIONS_009_041</dd><dt><span>cmems_production_unit :</span></dt><dd>OC-CNR-ROMA-IT</dd><dt><span>comment :</span></dt><dd>r=log10(max([rrs443,rrs490,rrs510])/rrs555) ; chlcase1=10^[0.4567-4.2484r+2.0171r^2+2.6202r^3-2.8978r^4] ; r=log10(rrs490/rrs555) ; chlcase2=10.^[0.091-2.620r-1.148r^2-4.949r^3]. Interpolation is made via iterative EOF using the climatology as first guess. WTM and SENSORMASK fields provide the original data coverage.</dd><dt><span>contact :</span></dt><dd>technical@gos.artov.isac.cnr.it</dd><dt><span>creation_date :</span></dt><dd>Thu Apr 08 2021</dd><dt><span>creation_time :</span></dt><dd>06:04:30 UTC</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:37:37.767616</dd><dt><span>days_in_the_future :</span></dt><dd> 5</dd><dt><span>days_in_the_past :</span></dt><dd> 10</dd><dt><span>distribution_statement :</span></dt><dd>See CMEMS Data License</dd><dt><span>easternmost_longitude :</span></dt><dd>36.5</dd><dt><span>file_quality_index :</span></dt><dd>0</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((0 35, 0 45.00236, 10.002360000000001 45.00236, 10.002360000000001 35, 0 35))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>45.00236</dd><dt><span>geospatial_lat_min :</span></dt><dd>35</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>10.002360000000001</dd><dt><span>geospatial_lon_min :</span></dt><dd>0</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.01284</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>grid_mapping :</span></dt><dd>Equirectangular</dd><dt><span>grid_resolution :</span></dt><dd>  1 Km</dd><dt><span>history :</span></dt><dd>[&#x27; &#x27;, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [0.0, 35.0, 10.0, 45.0], &#x27;spatial_res&#x27;: 0.01284, &#x27;tile_size&#x27;: [512, 512], &#x27;time_period&#x27;: &#x27;1D&#x27;, &#x27;time_range&#x27;: [&#x27;2019-06-01&#x27;, &#x27;2019-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;CHL&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>institution :</span></dt><dd>CNR-GOS</dd><dt><span>naming_authority :</span></dt><dd>CMEMS</dd><dt><span>netcdf_version :</span></dt><dd>v4</dd><dt><span>northernmost_latitude :</span></dt><dd>46.0</dd><dt><span>parameter :</span></dt><dd>chlorophyll-a concentration</dd><dt><span>parameter_code :</span></dt><dd>CHL</dd><dt><span>platform :</span></dt><dd>Aqua,JPSS-1,Sentinel-3a,Suomi-NPP</dd><dt><span>product_level :</span></dt><dd>L4</dd><dt><span>product_version :</span></dt><dd>v02QL</dd><dt><span>references :</span></dt><dd>1) Volpe, G., Colella, S., Brando, V., Forneris, V., La Padula, F., Di Cicco, A., Sammartino, M., Bracaglia, M., Artuso, F., and Santoleri, R. (2019). The Mediterranean Ocean Colour Level 3 Operational Multi-Sensor Processing, Ocean Sci., 15, 127–146, https://doi.org/10.5194/os-15-127-2019. - 2) Berthon, J. F., and G. Zibordi (2004), Bio-optical relationships for the northern Adriatic Sea, International Journal of Remote Sensing, 25, 7-8, 1527-1532. - 3) Volpe, G., Buongiorno Nardelli, B., Colella, S., Pisano, A. and Santoleri, R. (2018). An Operational Interpolated Ocean Colour Product in the Mediterranean Sea, in New Frontiers in Operational Oceanography, edited by E. P. Chassignet, A. Pascual, J. Tintorè, and J. Verron, pp. 227–244</dd><dt><span>sensor :</span></dt><dd>MODISA Moderate Resolution Imaging Spectroradiometer,VIIRSJ Visible Infrared Imaging Radiometer Suite,OLCI Ocean and Land Colour Instrument,VIIRSN Visible Infrared Imaging Radiometer Suite</dd><dt><span>sensor_name :</span></dt><dd>MODISA,VIIRSJ,OLCI,VIIRSN</dd><dt><span>site_name :</span></dt><dd>MED</dd><dt><span>software_name :</span></dt><dd>GOS Processing chain</dd><dt><span>software_version :</span></dt><dd>v3.0</dd><dt><span>source :</span></dt><dd>surface observation</dd><dt><span>source_files :</span></dt><dd>X2021065-chl-med-hr.nc X2021066-chl-med-hr.nc X2021067-chl-med-hr.nc X2021068-chl-med-hr.nc X2021069-chl-med-hr.nc X2021070-chl-med-hr.nc X2021071-chl-med-hr.nc X2021072-chl-med-hr.nc X2021073-chl-med-hr.nc X2021074-chl-med-hr.nc X2021075-chl-med-hr.nc X2021076-chl-med-hr.nc X2021077-chl-med-hr.nc X2021078-chl-med-hr.nc</dd><dt><span>southernmost_latitude :</span></dt><dd>30.0</dd><dt><span>st_location :</span></dt><dd> 4  0</dd><dt><span>start_date :</span></dt><dd>2021-03-15</dd><dt><span>start_time :</span></dt><dd>08:00:00 UTC</dd><dt><span>stop_date :</span></dt><dd>2021-03-15</dd><dt><span>stop_time :</span></dt><dd>14:00:00 UTC</dd><dt><span>title :</span></dt><dd>dataset-oc-med-chl-multi-l4-interp_1km_daily-rt-v02</dd><dt><span>westernmost_longitude :</span></dt><dd>-6.0</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -17308,7 +17045,7 @@
        "    westernmost_longitude:      -6.0"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17319,15 +17056,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "id": "7375f4cb-37a9-48db-9d18-7996b2ac6689",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:10.065440Z",
-     "iopub.status.busy": "2022-02-23T14:15:10.065023Z",
-     "iopub.status.idle": "2022-02-23T14:15:11.400988Z",
-     "shell.execute_reply": "2022-02-23T14:15:11.400198Z"
-    },
     "papermill": {
      "duration": 1.465683,
      "end_time": "2022-02-23T14:15:11.403592",
@@ -17341,10 +17072,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f84c8054e20>"
+       "<matplotlib.collections.QuadMesh at 0x7ff35832f6a0>"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -17367,15 +17098,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "id": "3bbb1d0a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:11.647509Z",
-     "iopub.status.busy": "2022-02-23T14:15:11.646755Z",
-     "iopub.status.idle": "2022-02-23T14:15:20.159809Z",
-     "shell.execute_reply": "2022-02-23T14:15:20.158987Z"
-    },
     "papermill": {
      "duration": 8.638378,
      "end_time": "2022-02-23T14:15:20.162144",
@@ -17389,10 +17114,10 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7f84bbdb1ca0>]"
+       "[<matplotlib.lines.Line2D at 0x7ff35826a2b0>]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -17451,15 +17176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "id": "32efee83-7e63-49af-b281-8c34f9832043",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:20.960183Z",
-     "iopub.status.busy": "2022-02-23T14:15:20.959772Z",
-     "iopub.status.idle": "2022-02-23T14:15:20.965950Z",
-     "shell.execute_reply": "2022-02-23T14:15:20.965243Z"
-    },
     "papermill": {
      "duration": 0.124513,
      "end_time": "2022-02-23T14:15:20.967787",
@@ -17492,15 +17211,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "id": "29d072ae-73fe-4fc8-9767-d6885fdacbc4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:21.206817Z",
-     "iopub.status.busy": "2022-02-23T14:15:21.206125Z",
-     "iopub.status.idle": "2022-02-23T14:15:21.210978Z",
-     "shell.execute_reply": "2022-02-23T14:15:21.209906Z"
-    },
     "papermill": {
      "duration": 0.12625,
      "end_time": "2022-02-23T14:15:21.212950",
@@ -17521,15 +17234,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 33,
    "id": "570dca46-4f6f-4a5a-b9db-4231d7db3f13",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:21.458977Z",
-     "iopub.status.busy": "2022-02-23T14:15:21.458729Z",
-     "iopub.status.idle": "2022-02-23T14:15:29.033480Z",
-     "shell.execute_reply": "2022-02-23T14:15:29.032732Z"
-    },
     "papermill": {
      "duration": 7.693573,
      "end_time": "2022-02-23T14:15:29.035226",
@@ -17544,10 +17251,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-02-23 14:15:23 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-5536d168-459f-4301.yaml.",
-        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-5536d168-459f-4301.json",
-        "2022-02-23 14:15:26 XCUBE GEN END"
+        "2022-06-23 08:39:45 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-8481c262-f103-4ec9.yaml.",
+        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-8481c262-f103-4ec9.json",
+        "2022-06-23 08:39:51 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -17557,10 +17264,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          -180.0,
-          -90.0,
-          180.0,
-          90.0
+          -180,
+          -90,
+          180,
+          90
          ],
          "crs": "WGS84",
          "data_id": "volumetric_surface_soil_moisture.zarr",
@@ -17610,10 +17317,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7f84ccedd490>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff3582c3e80>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17624,15 +17331,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 34,
    "id": "90de43bb-e669-4eea-bccf-b026d7828153",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:29.274144Z",
-     "iopub.status.busy": "2022-02-23T14:15:29.273848Z",
-     "iopub.status.idle": "2022-02-23T14:15:29.278403Z",
-     "shell.execute_reply": "2022-02-23T14:15:29.277699Z"
-    },
     "papermill": {
      "duration": 0.123631,
      "end_time": "2022-02-23T14:15:29.280174",
@@ -17649,15 +17350,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 35,
    "id": "a5f493c2-b6d5-4467-a4e0-3776bb516a74",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:15:29.519871Z",
-     "iopub.status.busy": "2022-02-23T14:15:29.519263Z",
-     "iopub.status.idle": "2022-02-23T14:16:48.105332Z",
-     "shell.execute_reply": "2022-02-23T14:16:48.104392Z"
-    },
     "papermill": {
      "duration": 78.823121,
      "end_time": "2022-02-23T14:16:48.224150",
@@ -17667,41 +17362,16 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - ...\n",
-      "Generating cube - ...\n",
-      "Generating cube - ...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - done.\n",
-      "Generating cube - done.\n",
-      "Generating cube - done.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 36,
    "id": "960ddf7c-2921-4f27-8059-cf5fd501c421",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:48.467506Z",
-     "iopub.status.busy": "2022-02-23T14:16:48.466939Z",
-     "iopub.status.idle": "2022-02-23T14:16:48.482632Z",
-     "shell.execute_reply": "2022-02-23T14:16:48.481810Z"
-    },
     "papermill": {
      "duration": 0.136563,
      "end_time": "2022-02-23T14:16:48.484753",
@@ -17715,24 +17385,20 @@
     {
      "data": {
       "application/json": {
-       "message": "Cube generated successfully after 63.69 seconds",
+       "message": "Cube generated successfully after 64.35 seconds",
        "output": [
-        "2022-02-23 14:15:40 XCUBE GEN START",
+        "2022-06-23 08:40:07 XCUBE GEN START",
         "xcube-cds version 0.9.1",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-02-23 14:15:43,086 INFO Welcome to the CDS",
-        "2022-02-23 14:15:43,086 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/satellite-soil-moisture",
+        "2022-06-23 08:40:11,511 INFO Welcome to the CDS",
+        "2022-06-23 08:40:11,511 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/satellite-soil-moisture",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-02-23 14:15:43,190 INFO Request is queued",
+        "2022-06-23 08:40:11,558 INFO Request is queued",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-02-23 14:15:44,233 INFO Request is running",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
-        "  warnings.warn(",
+        "2022-06-23 08:40:12,581 INFO Request is running",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
@@ -17741,23 +17407,29 @@
         "  warnings.warn(",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-02-23 14:16:15,792 INFO Request is completed",
-        "2022-02-23 14:16:15,792 INFO Downloading https://download-0014.copernicus-climate.eu/cache-compute-0014/cache/data4/dataset-satellite-soil-moisture-b8a8fdf9-c77c-4e52-aef1-287c56f3bbbe.tar.gz to /tmp/tmpbyd5qehd/tmpjs7bh4rl/data (9.1M)",
-        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'download-0014.copernicus-climate.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
+        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-40cc12ed-dcd8-4336.yaml.",
+        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
+        "  warnings.warn(",
+        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
+        "  warnings.warn(",
+        "2022-06-23 08:41:01,107 INFO Request is completed",
+        "2022-06-23 08:41:01,108 INFO Downloading https://download-0010-clone.copernicus-climate.eu/cache-compute-0010/cache/data6/dataset-satellite-soil-moisture-6f9d0a9b-2dd5-4c8f-bee5-a4ccd2538a04.tar.gz to /tmp/tmpppjfkdv_/tmpuoosxaut/data (9.1M)",
+        "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'download-0010-clone.copernicus-climate.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
+        "  warnings.warn(",
+        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-c4f97203-fdcc-4097.yaml.",
         "Generating cube - ...",
         "Generating cube - 0.0%: reading cube - ...",
         "Generating cube - 2.4%: reading cube - 33.3%",
         "",
         "  0%|          | 0.00/9.11M [00:00<?, ?B/s]",
-        " 17%|█▋        | 1.51M/9.11M [00:00<00:00, 15.8MB/s]",
-        " 85%|████████▌ | 7.79M/9.11M [00:00<00:00, 45.2MB/s]",
+        "  8%|▊         | 705k/9.11M [00:00<00:01, 7.22MB/s]",
+        " 62%|██████▏   | 5.62M/9.11M [00:00<00:00, 33.4MB/s]",
         "                                                    ",
-        "2022-02-23 14:16:16,133 INFO Download rate 26.8M/s",
+        "2022-06-23 08:41:01,584 INFO Download rate 19.1M/s",
         "/opt/conda/envs/xcube/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings",
         "  warnings.warn(",
-        "2022-02-23 14:16:16,720 INFO Found credentials in environment variables.",
+        "2022-06-23 08:41:02,442 INFO Found credentials in environment variables.",
         "Generating cube - 4.9%: reading cube - 66.7%",
         "Generating cube - 7.3%: reading cube - 100.0%",
         "Generating cube - 7.3%: reading cube - done.",
@@ -18456,8 +18128,8 @@
         "Generating cube - 99.2%: writing cube - 99.9%",
         "Generating cube - 99.2%: writing cube - done.",
         "Generating cube - done.",
-        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-40cc12ed-dcd8-4336.json",
-        "2022-02-23 14:16:47 XCUBE GEN END"
+        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-c4f97203-fdcc-4097.json",
+        "2022-06-23 08:41:16 XCUBE GEN END"
        ],
        "result": {
         "data_id": "volumetric_surface_soil_moisture.zarr"
@@ -18466,10 +18138,10 @@
        "status_code": 201
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7f84ccdb3a90>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff35851fd00>"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18480,15 +18152,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 37,
    "id": "210f154f-e897-4631-8f08-50a3f8b8f96a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:48.753943Z",
-     "iopub.status.busy": "2022-02-23T14:16:48.753084Z",
-     "iopub.status.idle": "2022-02-23T14:16:48.763418Z",
-     "shell.execute_reply": "2022-02-23T14:16:48.762511Z"
-    },
     "papermill": {
      "duration": 0.157695,
      "end_time": "2022-02-23T14:16:48.766006",
@@ -18505,15 +18171,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 38,
    "id": "28ebcef2-6b2c-4ddc-b0c2-c3edf586531f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:49.020465Z",
-     "iopub.status.busy": "2022-02-23T14:16:49.019808Z",
-     "iopub.status.idle": "2022-02-23T14:16:49.095672Z",
-     "shell.execute_reply": "2022-02-23T14:16:49.094987Z"
-    },
     "papermill": {
      "duration": 0.201407,
      "end_time": "2022-02-23T14:16:49.097951",
@@ -18530,15 +18190,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 39,
    "id": "3c8eaa3d-88a9-437a-a04d-609f5edf8c01",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:49.336879Z",
-     "iopub.status.busy": "2022-02-23T14:16:49.336300Z",
-     "iopub.status.idle": "2022-02-23T14:16:49.346870Z",
-     "shell.execute_reply": "2022-02-23T14:16:49.346100Z"
-    },
     "papermill": {
      "duration": 0.133884,
      "end_time": "2022-02-23T14:16:49.348794",
@@ -18554,16 +18208,11 @@
       "text/plain": [
        "['COP_demo_v2.zarr',\n",
        " 'SH_demo.zarr',\n",
-       " 'cci-chlor_a.zarr',\n",
-       " 'ccizarr-swe.zarr',\n",
-       " 'cds-volumetric_surface_soil_moisture.zarr',\n",
-       " 'cop-services-OC-ATL_CHL.zarr',\n",
-       " 'cop-services-OC-BAL_CHL.zarr',\n",
-       " 'sh-S1GRD_VV.zarr',\n",
+       " 'sh-S2L2A_BYOA.zarr',\n",
        " 'volumetric_surface_soil_moisture.zarr']"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18574,15 +18223,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 40,
    "id": "d1a38dad-ef4f-480d-a936-cd69491ca742",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:49.592838Z",
-     "iopub.status.busy": "2022-02-23T14:16:49.592399Z",
-     "iopub.status.idle": "2022-02-23T14:16:49.815082Z",
-     "shell.execute_reply": "2022-02-23T14:16:49.814349Z"
-    },
     "papermill": {
      "duration": 0.344825,
      "end_time": "2022-02-23T14:16:49.817205",
@@ -18599,15 +18242,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 41,
    "id": "9e39f6ec-86c8-4c51-bf3f-8b11614b0cfa",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:50.058432Z",
-     "iopub.status.busy": "2022-02-23T14:16:50.057875Z",
-     "iopub.status.idle": "2022-02-23T14:16:50.097728Z",
-     "shell.execute_reply": "2022-02-23T14:16:50.097013Z"
-    },
     "papermill": {
      "duration": 0.162581,
      "end_time": "2022-02-23T14:16:50.099990",
@@ -18996,15 +18633,15 @@
        "    time_coverage_resolution:   P1D\n",
        "    time_coverage_start:        2014-12-31T12:00:00Z\n",
        "    title:                      C3S Surface Soil Moisture merged COMBINED Pro...\n",
-       "    tracking_id:                4d788889-b8c0-43b3-a622-f61b22adfc51</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-d36ace77-2e47-4a7c-922b-79ee9273f35b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d36ace77-2e47-4a7c-922b-79ee9273f35b' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>lat</span>: 720</li><li><span class='xr-has-index'>lon</span>: 1440</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-41775db8-dc93-418b-a387-f63baee8c1cd' class='xr-section-summary-in' type='checkbox'  checked><label for='section-41775db8-dc93-418b-a387-f63baee8c1cd' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.88 89.62 89.38 ... -89.62 -89.88</div><input id='attrs-3ef153cc-e499-47c0-8362-923d9583dcf5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3ef153cc-e499-47c0-8362-923d9583dcf5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e3f4e63a-2eb3-4041-9d99-1abc36ca4d5a' class='xr-var-data-in' type='checkbox'><label for='data-e3f4e63a-2eb3-4041-9d99-1abc36ca4d5a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_range :</span></dt><dd>[-90.0, 90.0]</dd></dl></div><div class='xr-var-data'><pre>array([ 89.875,  89.625,  89.375, ..., -89.375, -89.625, -89.875],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-179.9 -179.6 ... 179.6 179.9</div><input id='attrs-4b509413-362f-4ebc-b6e0-23adf28f39cf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4b509413-362f-4ebc-b6e0-23adf28f39cf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c98c98fc-11e9-4fbe-b13d-b54d2e5236c0' class='xr-var-data-in' type='checkbox'><label for='data-c98c98fc-11e9-4fbe-b13d-b54d2e5236c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_range :</span></dt><dd>[-180.0, 180.0]</dd></dl></div><div class='xr-var-data'><pre>array([-179.875, -179.625, -179.375, ...,  179.375,  179.625,  179.875],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2015-01-01 ... 2015-12-01</div><input id='attrs-b9fa72f3-d903-4c97-a4b8-5d3ed91df52d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b9fa72f3-d903-4c97-a4b8-5d3ed91df52d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-aa5da1ca-e01f-42bb-86cc-1f8b6154f2cc' class='xr-var-data-in' type='checkbox'><label for='data-aa5da1ca-e01f-42bb-86cc-1f8b6154f2cc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2015-01-01T00:00:00.000000000&#x27;, &#x27;2015-02-01T00:00:00.000000000&#x27;,\n",
+       "    tracking_id:                4d788889-b8c0-43b3-a622-f61b22adfc51</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-127ed7f3-801a-4451-b7d2-0d1348488ae5' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-127ed7f3-801a-4451-b7d2-0d1348488ae5' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>lat</span>: 720</li><li><span class='xr-has-index'>lon</span>: 1440</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-e3715adc-3cf3-42e2-97d3-5e790ad214ba' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e3715adc-3cf3-42e2-97d3-5e790ad214ba' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.88 89.62 89.38 ... -89.62 -89.88</div><input id='attrs-9f50685e-7e0b-45bc-856c-d52c322086b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9f50685e-7e0b-45bc-856c-d52c322086b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0cee7c1f-3e10-4515-99e0-6500f26ccc6c' class='xr-var-data-in' type='checkbox'><label for='data-0cee7c1f-3e10-4515-99e0-6500f26ccc6c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_range :</span></dt><dd>[-90.0, 90.0]</dd></dl></div><div class='xr-var-data'><pre>array([ 89.875,  89.625,  89.375, ..., -89.375, -89.625, -89.875],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-179.9 -179.6 ... 179.6 179.9</div><input id='attrs-61dc2e72-cd46-48d8-90a0-543af073311b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-61dc2e72-cd46-48d8-90a0-543af073311b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7ba1e4d6-314c-4f78-a045-2323c6ac3057' class='xr-var-data-in' type='checkbox'><label for='data-7ba1e4d6-314c-4f78-a045-2323c6ac3057' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_range :</span></dt><dd>[-180.0, 180.0]</dd></dl></div><div class='xr-var-data'><pre>array([-179.875, -179.625, -179.375, ...,  179.375,  179.625,  179.875],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2015-01-01 ... 2015-12-01</div><input id='attrs-335d9ff0-c980-418a-94db-335232acb737' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-335d9ff0-c980-418a-94db-335232acb737' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-00e9c4da-009b-4e2d-9b72-bfa918e2253c' class='xr-var-data-in' type='checkbox'><label for='data-00e9c4da-009b-4e2d-9b72-bfa918e2253c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Time</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2015-01-01T00:00:00.000000000&#x27;, &#x27;2015-02-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-03-01T00:00:00.000000000&#x27;, &#x27;2015-04-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-05-01T00:00:00.000000000&#x27;, &#x27;2015-06-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-07-01T00:00:00.000000000&#x27;, &#x27;2015-08-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-09-01T00:00:00.000000000&#x27;, &#x27;2015-10-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2015-11-01T00:00:00.000000000&#x27;, &#x27;2015-12-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-de6ecd5a-0847-4a44-8866-db0f764daacf' class='xr-section-summary-in' type='checkbox'  checked><label for='section-de6ecd5a-0847-4a44-8866-db0f764daacf' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>freqbandID</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-bde4e5f1-5109-4902-8044-232aca2b9568' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bde4e5f1-5109-4902-8044-232aca2b9568' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e13ed63d-4748-4c57-a662-a8df28502cf3' class='xr-var-data-in' type='checkbox'><label for='data-e13ed63d-4748-4c57-a662-a8df28502cf3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN L14 C53 L14+C53 C66 C68 L14+C68 C53+C68 L14+C53+C68 C69 L14+C69 C53+C69 L14+C53+C69 C68+C69 L14+C68+C69 C53+C68+C69 L14+C53+C68+C69 C73 L14+C73 C53+C73 L14+C53+C73 X107 L14+X107 C53+X107 L14+C53+X107 C68+X107 L14+C68+X107 C53+C68+X107 L14+C53+C68+X107 C69+X107 L14+C69+X107 C53+C69+X107 L14+C53+C69+X107 K194 C53+K194</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 3, 4, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27, 32, 33, 34, 35, 64, 65, 66, 67, 72, 73, 74, 75, 80, 81, 82, 83, 128, 130]</dd><dt><span>long_name :</span></dt><dd>Frequency Band Identification</dd></dl></div><div class='xr-var-data'><table>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d749560e-221b-4b6e-9b60-bfef5c98f860' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d749560e-221b-4b6e-9b60-bfef5c98f860' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>freqbandID</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-b0f1250a-ce04-445b-a35d-6c2a7009cdbd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b0f1250a-ce04-445b-a35d-6c2a7009cdbd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-778a0eed-519b-4af7-88f0-a4bd4e0d8e49' class='xr-var-data-in' type='checkbox'><label for='data-778a0eed-519b-4af7-88f0-a4bd4e0d8e49' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN L14 C53 L14+C53 C66 C68 L14+C68 C53+C68 L14+C53+C68 C69 L14+C69 C53+C69 L14+C53+C69 C68+C69 L14+C68+C69 C53+C68+C69 L14+C53+C68+C69 C73 L14+C73 C53+C73 L14+C53+C73 X107 L14+X107 C53+X107 L14+C53+X107 C68+X107 L14+C68+X107 C53+C68+X107 L14+C53+C68+X107 C69+X107 L14+C69+X107 C53+C69+X107 L14+C53+C69+X107 K194 C53+K194</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 3, 4, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27, 32, 33, 34, 35, 64, 65, 66, 67, 72, 73, 74, 75, 80, 81, 82, 83, 128, 130]</dd><dt><span>long_name :</span></dt><dd>Frequency Band Identification</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -19112,7 +18749,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>nobs</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-4a6fbcf2-c438-4c3a-8a91-824b25d21bbd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4a6fbcf2-c438-4c3a-8a91-824b25d21bbd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1f3de632-841f-4d67-864e-a1e4816525f8' class='xr-var-data-in' type='checkbox'><label for='data-1f3de632-841f-4d67-864e-a1e4816525f8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Number of valid observation</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>nobs</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-c6b60131-d6c3-40aa-9da1-cd68e19ec70a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c6b60131-d6c3-40aa-9da1-cd68e19ec70a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5101b185-0e93-4372-9230-03e81f551405' class='xr-var-data-in' type='checkbox'><label for='data-5101b185-0e93-4372-9230-03e81f551405' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Number of valid observation</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -19220,7 +18857,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sensor</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-026d19ba-c71f-429a-951b-06bb3e338d93' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-026d19ba-c71f-429a-951b-06bb3e338d93' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f35e9b01-92c5-4629-a0fd-aaa661bf4a36' class='xr-var-data-in' type='checkbox'><label for='data-f35e9b01-92c5-4629-a0fd-aaa661bf4a36' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN SMMR SSMI TMI AMSRE WindSat AMSRE+WindSat AMSR2 AMSRE+AMSR2 WindSat+AMSR2 AMSRE+WindSat+AMSR2 AMIWS SSMI+AMIWS TMI+AMIWS AMSRE+AMIWS ASCATA AMSRE+ASCATA WindSat+ASCATA AMSRE+WindSat+ASCATA AMSR2+ASCATA AMSRE+AMSR2+ASCATA WindSat+AMSR2+ASCATA AMSRE+WindSat+AMSR2+ASCATA ASCATB AMSR2+ASCATB ASCATA+ASCATB AMSR2+ASCATA+ASCATB</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 128, 130, 132, 136, 256, 264, 272, 280, 288, 296, 304, 312, 512, 544, 768, 800]</dd><dt><span>long_name :</span></dt><dd>Sensor</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sensor</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-7be8e1a0-3962-4fff-884a-af327ba97911' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7be8e1a0-3962-4fff-884a-af327ba97911' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f0fb2254-adb3-4faf-b4b8-e4a57a2c310f' class='xr-var-data-in' type='checkbox'><label for='data-f0fb2254-adb3-4faf-b4b8-e4a57a2c310f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>flag_meanings :</span></dt><dd>NaN SMMR SSMI TMI AMSRE WindSat AMSRE+WindSat AMSR2 AMSRE+AMSR2 WindSat+AMSR2 AMSRE+WindSat+AMSR2 AMIWS SSMI+AMIWS TMI+AMIWS AMSRE+AMIWS ASCATA AMSRE+ASCATA WindSat+ASCATA AMSRE+WindSat+ASCATA AMSR2+ASCATA AMSRE+AMSR2+ASCATA WindSat+AMSR2+ASCATA AMSRE+WindSat+AMSR2+ASCATA ASCATB AMSR2+ASCATB ASCATA+ASCATB AMSR2+ASCATA+ASCATB</dd><dt><span>flag_values :</span></dt><dd>[0, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 128, 130, 132, 136, 256, 264, 272, 280, 288, 296, 304, 312, 512, 544, 768, 800]</dd><dt><span>long_name :</span></dt><dd>Sensor</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -19328,7 +18965,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sm</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-4ea3444f-fefa-4f85-a811-0c1ae155ae9b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4ea3444f-fefa-4f85-a811-0c1ae155ae9b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a3322812-0532-4333-b4a5-592b0c9fb3c5' class='xr-var-data-in' type='checkbox'><label for='data-a3322812-0532-4333-b4a5-592b0c9fb3c5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Volumetric Soil Moisture</dd><dt><span>units :</span></dt><dd>m3 m-3</dd><dt><span>valid_range :</span></dt><dd>[0.0, 1.0]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sm</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 512, 512), meta=np.ndarray&gt;</div><input id='attrs-cd75ad82-1913-4be0-904c-757068dac31c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cd75ad82-1913-4be0-904c-757068dac31c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dab62a61-b578-442d-8201-818939248960' class='xr-var-data-in' type='checkbox'><label for='data-dab62a61-b578-442d-8201-818939248960' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxes :</span></dt><dd>time lat lon</dd><dt><span>long_name :</span></dt><dd>Volumetric Soil Moisture</dd><dt><span>units :</span></dt><dd>m3 m-3</dd><dt><span>valid_range :</span></dt><dd>[0.0, 1.0]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -19436,7 +19073,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-0ae0a18e-ff6f-4492-bb97-2af869d8a494' class='xr-section-summary-in' type='checkbox'  ><label for='section-0ae0a18e-ff6f-4492-bb97-2af869d8a494' class='xr-section-summary' >Attributes: <span>(42)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>cdm_data_type :</span></dt><dd>Grid</dd><dt><span>comment :</span></dt><dd>These data were produced as part of the Copernicus Climate Change Service. Service Contract No 2018/C3S_312b_LOT4_EODC/SC2</dd><dt><span>contact :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_email :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_name :</span></dt><dd>Earth Observation Data Center (EODC)</dd><dt><span>creator_url :</span></dt><dd>https://www.eodc.eu</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:16:16.690889</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>geospatial_vertical_max :</span></dt><dd>0.0</dd><dt><span>geospatial_vertical_min :</span></dt><dd>0.0</dd><dt><span>history :</span></dt><dd>[&#x27;2020-05-13T12:34:34.419747 mean calculated&#x27;, {&#x27;cube_config&#x27;: {&#x27;spatial_res&#x27;: 0.25, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2015-01-01&#x27;, &#x27;2015-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;volumetric_surface_soil_moisture&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.1&#x27;}]</dd><dt><span>id :</span></dt><dd>C3S-SOILMOISTURE-L3S-SSMV-COMBINED-MONTHLY-20150101000000-TCDR-v201912.0.0.nc</dd><dt><span>institution :</span></dt><dd>EODC (AUT); TU Wien (AUT); VanderSat B.V. (NL)</dd><dt><span>keywords :</span></dt><dd>Soil Moisture/Water Content</dd><dt><span>keywords_vocabulary :</span></dt><dd>NASA Global Change Master Directory (GCMD) Science Keywords</dd><dt><span>license :</span></dt><dd>Copernicus Data License</dd><dt><span>naming_authority :</span></dt><dd>EODC</dd><dt><span>platform :</span></dt><dd>Nimbus 7, DMSP, TRMM, AQUA, Coriolis, GCOM-W1, SMOS; ERS-1, ERS-2, METOP-A, METOP-B</dd><dt><span>product_version :</span></dt><dd>v201912.0.0</dd><dt><span>project :</span></dt><dd>Copernicus Climate Change Service.</dd><dt><span>references :</span></dt><dd>http://www.esa-soilmoisture-cci.org; Liu, Y.Y., Dorigo, W.A., Parinussa, R.M., de Jeu, R.A.M. , Wagner, W., McCabe, M.F., Evans, J.P., van Dijk, A.I.J.M. (2012). Trend-preserving blending of passive and active microwave soil moisture retrievals, Remote Sensing of Environment, 123, 280-297, doi: 10.1016/j.rse.2012.03.014.; Liu, Y.Y., Parinussa, R.M., Dorigo, W.A., De Jeu, R.A.M., Wagner, W., van Dijk, A.I.J.M., McCabe, M.F., &amp; Evans, J.P. (2011). Developing an improved soil moisture dataset by blending passive and active microwave satellite based retrievals. Hydrology and Earth System Sciences, 15, 425-436.; Wagner, W., W. Dorigo, R. de Jeu, D. Fernandez, J. Benveniste, E. Haas, M. Ertl (2012). Fusion of active and passive microwave observations to create an Essential Climate Variable data record on soil moisture. ISPRS Annals of the Photogrammetry, Remote Sensing and Spatial Information Sciences, Volume I-7, 2012. XXII ISPRS Congress, 25 August - 01 September 2012, Melbourne, Australia.; Gruber, A., Dorigo, W. Crow, W., &amp; Wagner, W. (2017). Triple collocation-based merging of satellite soil moisture retrievals. IEEE Transactions on Geoscience and Remote Sensing, 1-13.; Dorigo, W.A., Wagner, W., Albergel, C., Albrecht, F., Balsamo, G., Brocca, L., Chung, D., Ertl, M., Forkel, M., Gruber, A., Haas, E., Hamer, P. D., Hirschi, M., Ikonen, J., de Jeu, R., Kidd, R., Lahoz, W., Liu, Y. Y.,Miralles, D., Mistelbauer, T., Nicolai-Shaw, N., Parinussa, R., Pratola, C., Reimer, C., van der Schalie, R., Seneviratne, S. I. Smolander, T., Lecomte, P. (2017). ESA CCI Soil Moisture for improved Earth system understanding: State-of-the art and future directions, Remote Sensing of Environment. https://doi.org/10.1016/j.rse.2017.07.001.</dd><dt><span>sensor :</span></dt><dd>SMMR, SSM/I, TMI, AMSR-E, WindSat, AMSR2, MIRAS; AMI-WS, AMI-WS, ASCAT-A, ASCAT-B</dd><dt><span>source :</span></dt><dd>WARP 5.5R1.1/AMI-WS/ERS12 Level 2 Soil Moisture; WARP 5.4R1.0/AMI-WS/ERS2 Level 2 Soil Moisture; ASCSMR02/ASCAT/MetOp-A SSM Swath Grid 12.5 km sampling; ASCSMR02/ASCAT/MetOp-B SSM Swath Grid 12.5 km sampling; LPRMv05/SMMR/Nimbus 7 L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/SSMI/F08, F11, F13 DMSP L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/TMI/TRMM L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR-E/Aqua L2B Surface Soil Moisture, Ancillary Params, and QC; LPRMv05/WINDSAT/CORIOLIS L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR2/GCOM-W1 L3 Surface Soil Moisture, Ancillary Params; LPRMv06/SMOS/MIRAS L3 Surface Soil Moisture, CATDS Level 3 Brightness Temperatures (L3TB) version 300 RE03 &amp; RE04;</dd><dt><span>spatial_resolution :</span></dt><dd>25km</dd><dt><span>standard_name_vocabulary :</span></dt><dd>NetCDF Climate and Forecast (CF) Metadata Convention</dd><dt><span>summary :</span></dt><dd>The data set was produced with funding from the Copernicus Climate Change Service.</dd><dt><span>time_coverage_duration :</span></dt><dd>P1M</dd><dt><span>time_coverage_end :</span></dt><dd>2015-12-31T12:00:00Z</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1D</dd><dt><span>time_coverage_start :</span></dt><dd>2014-12-31T12:00:00Z</dd><dt><span>title :</span></dt><dd>C3S Surface Soil Moisture merged COMBINED Product</dd><dt><span>tracking_id :</span></dt><dd>4d788889-b8c0-43b3-a622-f61b22adfc51</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-e282490f-fdf2-4a1e-bb77-5e91ce9fc8c8' class='xr-section-summary-in' type='checkbox'  ><label for='section-e282490f-fdf2-4a1e-bb77-5e91ce9fc8c8' class='xr-section-summary' >Attributes: <span>(42)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>cdm_data_type :</span></dt><dd>Grid</dd><dt><span>comment :</span></dt><dd>These data were produced as part of the Copernicus Climate Change Service. Service Contract No 2018/C3S_312b_LOT4_EODC/SC2</dd><dt><span>contact :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_email :</span></dt><dd>C3S_SM_Science@eodc.eu</dd><dt><span>creator_name :</span></dt><dd>Earth Observation Data Center (EODC)</dd><dt><span>creator_url :</span></dt><dd>https://www.eodc.eu</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:41:02.408660</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.25</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>geospatial_vertical_max :</span></dt><dd>0.0</dd><dt><span>geospatial_vertical_min :</span></dt><dd>0.0</dd><dt><span>history :</span></dt><dd>[&#x27;2020-05-13T12:34:34.419747 mean calculated&#x27;, {&#x27;cube_config&#x27;: {&#x27;spatial_res&#x27;: 0.25, &#x27;tile_size&#x27;: [512, 512], &#x27;time_range&#x27;: [&#x27;2015-01-01&#x27;, &#x27;2015-12-31&#x27;], &#x27;variable_names&#x27;: [&#x27;volumetric_surface_soil_moisture&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>id :</span></dt><dd>C3S-SOILMOISTURE-L3S-SSMV-COMBINED-MONTHLY-20150101000000-TCDR-v201912.0.0.nc</dd><dt><span>institution :</span></dt><dd>EODC (AUT); TU Wien (AUT); VanderSat B.V. (NL)</dd><dt><span>keywords :</span></dt><dd>Soil Moisture/Water Content</dd><dt><span>keywords_vocabulary :</span></dt><dd>NASA Global Change Master Directory (GCMD) Science Keywords</dd><dt><span>license :</span></dt><dd>Copernicus Data License</dd><dt><span>naming_authority :</span></dt><dd>EODC</dd><dt><span>platform :</span></dt><dd>Nimbus 7, DMSP, TRMM, AQUA, Coriolis, GCOM-W1, SMOS; ERS-1, ERS-2, METOP-A, METOP-B</dd><dt><span>product_version :</span></dt><dd>v201912.0.0</dd><dt><span>project :</span></dt><dd>Copernicus Climate Change Service.</dd><dt><span>references :</span></dt><dd>http://www.esa-soilmoisture-cci.org; Liu, Y.Y., Dorigo, W.A., Parinussa, R.M., de Jeu, R.A.M. , Wagner, W., McCabe, M.F., Evans, J.P., van Dijk, A.I.J.M. (2012). Trend-preserving blending of passive and active microwave soil moisture retrievals, Remote Sensing of Environment, 123, 280-297, doi: 10.1016/j.rse.2012.03.014.; Liu, Y.Y., Parinussa, R.M., Dorigo, W.A., De Jeu, R.A.M., Wagner, W., van Dijk, A.I.J.M., McCabe, M.F., &amp; Evans, J.P. (2011). Developing an improved soil moisture dataset by blending passive and active microwave satellite based retrievals. Hydrology and Earth System Sciences, 15, 425-436.; Wagner, W., W. Dorigo, R. de Jeu, D. Fernandez, J. Benveniste, E. Haas, M. Ertl (2012). Fusion of active and passive microwave observations to create an Essential Climate Variable data record on soil moisture. ISPRS Annals of the Photogrammetry, Remote Sensing and Spatial Information Sciences, Volume I-7, 2012. XXII ISPRS Congress, 25 August - 01 September 2012, Melbourne, Australia.; Gruber, A., Dorigo, W. Crow, W., &amp; Wagner, W. (2017). Triple collocation-based merging of satellite soil moisture retrievals. IEEE Transactions on Geoscience and Remote Sensing, 1-13.; Dorigo, W.A., Wagner, W., Albergel, C., Albrecht, F., Balsamo, G., Brocca, L., Chung, D., Ertl, M., Forkel, M., Gruber, A., Haas, E., Hamer, P. D., Hirschi, M., Ikonen, J., de Jeu, R., Kidd, R., Lahoz, W., Liu, Y. Y.,Miralles, D., Mistelbauer, T., Nicolai-Shaw, N., Parinussa, R., Pratola, C., Reimer, C., van der Schalie, R., Seneviratne, S. I. Smolander, T., Lecomte, P. (2017). ESA CCI Soil Moisture for improved Earth system understanding: State-of-the art and future directions, Remote Sensing of Environment. https://doi.org/10.1016/j.rse.2017.07.001.</dd><dt><span>sensor :</span></dt><dd>SMMR, SSM/I, TMI, AMSR-E, WindSat, AMSR2, MIRAS; AMI-WS, AMI-WS, ASCAT-A, ASCAT-B</dd><dt><span>source :</span></dt><dd>WARP 5.5R1.1/AMI-WS/ERS12 Level 2 Soil Moisture; WARP 5.4R1.0/AMI-WS/ERS2 Level 2 Soil Moisture; ASCSMR02/ASCAT/MetOp-A SSM Swath Grid 12.5 km sampling; ASCSMR02/ASCAT/MetOp-B SSM Swath Grid 12.5 km sampling; LPRMv05/SMMR/Nimbus 7 L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/SSMI/F08, F11, F13 DMSP L3 Surface Soil Moisture, Ancillary Params, and quality flags; LPRMv05/TMI/TRMM L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR-E/Aqua L2B Surface Soil Moisture, Ancillary Params, and QC; LPRMv05/WINDSAT/CORIOLIS L2 Surface Soil Moisture, Ancillary Params, and QC; LPRMv06/AMSR2/GCOM-W1 L3 Surface Soil Moisture, Ancillary Params; LPRMv06/SMOS/MIRAS L3 Surface Soil Moisture, CATDS Level 3 Brightness Temperatures (L3TB) version 300 RE03 &amp; RE04;</dd><dt><span>spatial_resolution :</span></dt><dd>25km</dd><dt><span>standard_name_vocabulary :</span></dt><dd>NetCDF Climate and Forecast (CF) Metadata Convention</dd><dt><span>summary :</span></dt><dd>The data set was produced with funding from the Copernicus Climate Change Service.</dd><dt><span>time_coverage_duration :</span></dt><dd>P1M</dd><dt><span>time_coverage_end :</span></dt><dd>2015-12-31T12:00:00Z</dd><dt><span>time_coverage_resolution :</span></dt><dd>P1D</dd><dt><span>time_coverage_start :</span></dt><dd>2014-12-31T12:00:00Z</dd><dt><span>title :</span></dt><dd>C3S Surface Soil Moisture merged COMBINED Product</dd><dt><span>tracking_id :</span></dt><dd>4d788889-b8c0-43b3-a622-f61b22adfc51</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -19466,7 +19103,7 @@
        "    tracking_id:                4d788889-b8c0-43b3-a622-f61b22adfc51"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19477,15 +19114,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 42,
    "id": "0d49174a-ddd6-4607-9ebd-f43c987ee04a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:50.352738Z",
-     "iopub.status.busy": "2022-02-23T14:16:50.352489Z",
-     "iopub.status.idle": "2022-02-23T14:16:55.039352Z",
-     "shell.execute_reply": "2022-02-23T14:16:55.038660Z"
-    },
     "papermill": {
      "duration": 4.816474,
      "end_time": "2022-02-23T14:16:55.046600",
@@ -19499,10 +19130,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f84bbe501c0>"
+       "<matplotlib.collections.QuadMesh at 0x7ff358098d30>"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -19561,15 +19192,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 43,
    "id": "f29aff1b-d619-4bcc-8857-6d4fc8436405",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:55.859693Z",
-     "iopub.status.busy": "2022-02-23T14:16:55.859072Z",
-     "iopub.status.idle": "2022-02-23T14:16:55.864954Z",
-     "shell.execute_reply": "2022-02-23T14:16:55.864151Z"
-    },
     "papermill": {
      "duration": 0.14125,
      "end_time": "2022-02-23T14:16:55.866838",
@@ -19607,15 +19232,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 44,
    "id": "8b104198-54f3-4848-96b0-bf33fd860c23",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:56.134877Z",
-     "iopub.status.busy": "2022-02-23T14:16:56.134287Z",
-     "iopub.status.idle": "2022-02-23T14:16:56.138714Z",
-     "shell.execute_reply": "2022-02-23T14:16:56.137898Z"
-    },
     "papermill": {
      "duration": 0.142735,
      "end_time": "2022-02-23T14:16:56.145916",
@@ -19636,15 +19255,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 45,
    "id": "041b458e-6aa9-4451-b532-c691c16d7aa3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:56.416813Z",
-     "iopub.status.busy": "2022-02-23T14:16:56.416559Z",
-     "iopub.status.idle": "2022-02-23T14:16:56.420908Z",
-     "shell.execute_reply": "2022-02-23T14:16:56.420159Z"
-    },
     "papermill": {
      "duration": 0.141617,
      "end_time": "2022-02-23T14:16:56.422646",
@@ -19661,15 +19274,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 46,
    "id": "74dc014b-50c0-4573-b96d-68f203be8a02",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:16:56.690346Z",
-     "iopub.status.busy": "2022-02-23T14:16:56.689897Z",
-     "iopub.status.idle": "2022-02-23T14:17:10.375034Z",
-     "shell.execute_reply": "2022-02-23T14:17:10.374315Z"
-    },
     "papermill": {
      "duration": 13.821138,
      "end_time": "2022-02-23T14:17:10.376966",
@@ -19684,10 +19291,10 @@
      "data": {
       "application/json": {
        "output": [
-        "2022-02-23 14:17:00 XCUBE GEN START",
-        "Cube generator request loaded from /data/user-code/afe36e3e76ff3e2e6bebd5a3f85498c78-c164d824-4561-4169.yaml.",
-        "Result written to /data/results/afe36e3e76ff3e2e6bebd5a3f85498c78-c164d824-4561-4169.json",
-        "2022-02-23 14:17:07 XCUBE GEN END"
+        "2022-06-23 08:43:37 XCUBE GEN START",
+        "Cube generator request loaded from /data/user-code/ad63ccfbbbf39389de5bdb7871fc7e70a-e927215e-cd74-498c.yaml.",
+        "Result written to /data/results/ad63ccfbbbf39389de5bdb7871fc7e70a-e927215e-cd74-498c.json",
+        "2022-06-23 08:43:46 XCUBE GEN END"
        ],
        "result": {
         "cost_estimation": {
@@ -19697,10 +19304,10 @@
         },
         "dataset_descriptor": {
          "bbox": [
-          -180.0,
-          -90.0,
-          180.0,
-          90.0
+          -180,
+          -90,
+          180,
+          90
          ],
          "crs": "OGC:CRS84",
          "data_id": "cci-chlor_a.zarr",
@@ -19750,10 +19357,10 @@
        "status_code": 200
       },
       "text/plain": [
-       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7f84bbd69490>"
+       "<xcube.core.gen2.response.make_cube_generator_result_class.<locals>.SpecificCubeGeneratorResult at 0x7ff358083850>"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19764,15 +19371,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 47,
    "id": "76cca29d-6be4-46af-a92f-857468d65f26",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:17:10.646275Z",
-     "iopub.status.busy": "2022-02-23T14:17:10.645648Z",
-     "iopub.status.idle": "2022-02-23T14:19:23.457718Z",
-     "shell.execute_reply": "2022-02-23T14:19:23.456961Z"
-    },
     "papermill": {
      "duration": 133.195956,
      "end_time": "2022-02-23T14:19:23.706505",
@@ -19782,43 +19383,16 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - ...\n",
-      "Generating cube - ...\n",
-      "Generating cube - ...\n",
-      "Generating cube - ...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating cube - done.\n",
-      "Generating cube - done.\n",
-      "Generating cube - done.\n",
-      "Generating cube - done.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = generator_service.generate_cube(request)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 48,
    "id": "0491e72d-28c9-425d-ad74-24b12a42c095",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:19:23.978714Z",
-     "iopub.status.busy": "2022-02-23T14:19:23.977975Z",
-     "iopub.status.idle": "2022-02-23T14:19:23.983623Z",
-     "shell.execute_reply": "2022-02-23T14:19:23.982854Z"
-    },
     "papermill": {
      "duration": 0.139177,
      "end_time": "2022-02-23T14:19:23.985676",
@@ -19835,7 +19409,7 @@
        "'cci-chlor_a.zarr'"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19846,15 +19420,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 49,
    "id": "84eecdf5-a597-4678-8397-8df5d4762056",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:19:24.256737Z",
-     "iopub.status.busy": "2022-02-23T14:19:24.256005Z",
-     "iopub.status.idle": "2022-02-23T14:19:24.264458Z",
-     "shell.execute_reply": "2022-02-23T14:19:24.263360Z"
-    },
     "papermill": {
      "duration": 0.142771,
      "end_time": "2022-02-23T14:19:24.266364",
@@ -19871,15 +19439,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 50,
    "id": "25c5a1e3-696c-4e32-923a-8881e061e293",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:19:24.535938Z",
-     "iopub.status.busy": "2022-02-23T14:19:24.535254Z",
-     "iopub.status.idle": "2022-02-23T14:19:24.616544Z",
-     "shell.execute_reply": "2022-02-23T14:19:24.615795Z"
-    },
     "papermill": {
      "duration": 0.219796,
      "end_time": "2022-02-23T14:19:24.618772",
@@ -19896,15 +19458,11 @@
        "['COP_demo_v2.zarr',\n",
        " 'SH_demo.zarr',\n",
        " 'cci-chlor_a.zarr',\n",
-       " 'ccizarr-swe.zarr',\n",
-       " 'cds-volumetric_surface_soil_moisture.zarr',\n",
-       " 'cop-services-OC-ATL_CHL.zarr',\n",
-       " 'cop-services-OC-BAL_CHL.zarr',\n",
-       " 'sh-S1GRD_VV.zarr',\n",
+       " 'sh-S2L2A_BYOA.zarr',\n",
        " 'volumetric_surface_soil_moisture.zarr']"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19916,15 +19474,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 51,
    "id": "3b93f23c-8a6d-4f9a-afd8-d4cee1120c0b",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:19:24.893437Z",
-     "iopub.status.busy": "2022-02-23T14:19:24.892716Z",
-     "iopub.status.idle": "2022-02-23T14:19:25.066932Z",
-     "shell.execute_reply": "2022-02-23T14:19:25.066269Z"
-    },
     "papermill": {
      "duration": 0.314181,
      "end_time": "2022-02-23T14:19:25.068904",
@@ -19941,15 +19493,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 52,
    "id": "9de93352-7ac1-47f1-9b27-c597422fb445",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:19:25.347228Z",
-     "iopub.status.busy": "2022-02-23T14:19:25.346595Z",
-     "iopub.status.idle": "2022-02-23T14:19:25.378328Z",
-     "shell.execute_reply": "2022-02-23T14:19:25.377607Z"
-    },
     "papermill": {
      "duration": 0.166707,
      "end_time": "2022-02-23T14:19:25.380519",
@@ -20326,7 +19872,7 @@
        "    chlor_a    (time, lat, lon) float32 dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-02-23T14:17:29.750967\n",
+       "    date_created:               2022-06-23T08:44:09.505830\n",
        "    geospatial_bounds:          POLYGON((-180 -90, -180 90, 180 90, 180 -90, ...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         90\n",
@@ -20337,12 +19883,12 @@
        "    time_coverage_duration:     P213DT0H0M0S\n",
        "    time_coverage_end:          2008-08-01T00:00:00\n",
        "    time_coverage_start:        2008-01-01T00:00:00\n",
-       "    title:                      esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-075d76fb-adb4-4746-9d48-54cf541c56fc' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-075d76fb-adb4-4746-9d48-54cf541c56fc' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lat</span>: 4320</li><li><span class='xr-has-index'>lon</span>: 8640</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-48cdf8b6-6e2c-4c67-9860-7281e7b0e6cf' class='xr-section-summary-in' type='checkbox'  checked><label for='section-48cdf8b6-6e2c-4c67-9860-7281e7b0e6cf' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.98 89.94 89.9 ... -89.94 -89.98</div><input id='attrs-ecdeb25a-f23b-46a7-8be1-be153ccd6c14' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ecdeb25a-f23b-46a7-8be1-be153ccd6c14' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-84aa8d39-4fb4-4e8a-8151-0e17e0658081' class='xr-var-data-in' type='checkbox'><label for='data-84aa8d39-4fb4-4e8a-8151-0e17e0658081' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>chunk_sizes :</span></dt><dd>4320</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>4320</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[4320]</dd><dt><span>size :</span></dt><dd>4320</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_max :</span></dt><dd>89.979164</dd><dt><span>valid_min :</span></dt><dd>-89.979164</dd></dl></div><div class='xr-var-data'><pre>array([ 89.979164,  89.9375  ,  89.895836, ..., -89.895836, -89.9375  ,\n",
-       "       -89.979164], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-180.0 -179.9 ... 179.9 180.0</div><input id='attrs-bc3dcf78-69d0-4d9e-8f79-4b77320aab8b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bc3dcf78-69d0-4d9e-8f79-4b77320aab8b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-92944637-f73a-43a3-a807-e36b3967b2e2' class='xr-var-data-in' type='checkbox'><label for='data-92944637-f73a-43a3-a807-e36b3967b2e2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>chunk_sizes :</span></dt><dd>8640</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>8640</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[8640]</dd><dt><span>size :</span></dt><dd>8640</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_max :</span></dt><dd>179.97917</dd><dt><span>valid_min :</span></dt><dd>-179.97917</dd></dl></div><div class='xr-var-data'><pre>array([-179.97917, -179.9375 , -179.89583, ...,  179.89583,  179.9375 ,\n",
-       "        179.97917], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2008-01-16T12:00:00 ... 2008-07-...</div><input id='attrs-5f3a6dd5-d16b-4645-b645-7017e9f89b25' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5f3a6dd5-d16b-4645-b645-7017e9f89b25' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5015b769-2943-470f-a00c-6029c77a6326' class='xr-var-data-in' type='checkbox'><label for='data-5015b769-2943-470f-a00c-6029c77a6326' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2008-01-16T12:00:00.000000000&#x27;, &#x27;2008-02-15T12:00:00.000000000&#x27;,\n",
+       "    title:                      esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a49ea0bd-a506-460b-9f43-5d79383cad92' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a49ea0bd-a506-460b-9f43-5d79383cad92' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lat</span>: 4320</li><li><span class='xr-has-index'>lon</span>: 8640</li><li><span>bnds</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-62f3002f-08e6-4233-ab94-ab3a41e81a89' class='xr-section-summary-in' type='checkbox'  checked><label for='section-62f3002f-08e6-4233-ab94-ab3a41e81a89' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>89.98 89.94 89.9 ... -89.94 -89.98</div><input id='attrs-eb71ad8c-3ffd-4369-a859-d6dd9c22fe31' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eb71ad8c-3ffd-4369-a859-d6dd9c22fe31' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fc5d43e8-670a-4abd-8646-e63afadb57a6' class='xr-var-data-in' type='checkbox'><label for='data-fc5d43e8-670a-4abd-8646-e63afadb57a6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>chunk_sizes :</span></dt><dd>4320</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>4320</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lat&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[4320]</dd><dt><span>size :</span></dt><dd>4320</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>valid_max :</span></dt><dd>89.979164</dd><dt><span>valid_min :</span></dt><dd>-89.979164</dd></dl></div><div class='xr-var-data'><pre>array([ 89.979164,  89.9375  ,  89.895836, ..., -89.895836, -89.9375  ,\n",
+       "       -89.979164], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-180.0 -179.9 ... 179.9 180.0</div><input id='attrs-e7c438c7-fb10-45b3-9f4b-392f71aa18e0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e7c438c7-fb10-45b3-9f4b-392f71aa18e0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-89458fc8-0c6e-41b3-9615-75ad2a374019' class='xr-var-data-in' type='checkbox'><label for='data-89458fc8-0c6e-41b3-9615-75ad2a374019' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>chunk_sizes :</span></dt><dd>8640</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>8640</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>nan</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>shape :</span></dt><dd>[8640]</dd><dt><span>size :</span></dt><dd>8640</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>valid_max :</span></dt><dd>179.97917</dd><dt><span>valid_min :</span></dt><dd>-179.97917</dd></dl></div><div class='xr-var-data'><pre>array([-179.97917, -179.9375 , -179.89583, ...,  179.89583,  179.9375 ,\n",
+       "        179.97917], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2008-01-16T12:00:00 ... 2008-07-...</div><input id='attrs-d96bd81d-dbe8-486d-a849-54c80670f1dd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d96bd81d-dbe8-486d-a849-54c80670f1dd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6a33171f-91d6-4242-9bb4-c5926b45b162' class='xr-var-data-in' type='checkbox'><label for='data-6a33171f-91d6-4242-9bb4-c5926b45b162' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>standard_name :</span></dt><dd>time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2008-01-16T12:00:00.000000000&#x27;, &#x27;2008-02-15T12:00:00.000000000&#x27;,\n",
        "       &#x27;2008-03-16T12:00:00.000000000&#x27;, &#x27;2008-04-16T00:00:00.000000000&#x27;,\n",
        "       &#x27;2008-05-16T12:00:00.000000000&#x27;, &#x27;2008-06-16T00:00:00.000000000&#x27;,\n",
-       "       &#x27;2008-07-16T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(7, 2), meta=np.ndarray&gt;</div><input id='attrs-39cd40d1-475f-4cdc-bfb5-69dcf63cf7dc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-39cd40d1-475f-4cdc-bfb5-69dcf63cf7dc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-61f7fa59-94f1-4dd7-a0df-a5d0f2cc1bdc' class='xr-var-data-in' type='checkbox'><label for='data-61f7fa59-94f1-4dd7-a0df-a5d0f2cc1bdc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2008-07-16T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(7, 2), meta=np.ndarray&gt;</div><input id='attrs-35651dd3-61c0-46ca-a25e-5755cf11e563' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-35651dd3-61c0-46ca-a25e-5755cf11e563' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-765d89e5-33b1-458c-9b4f-7fb741e26037' class='xr-var-data-in' type='checkbox'><label for='data-765d89e5-33b1-458c-9b4f-7fb741e26037' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time_bnds</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -20399,7 +19945,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-aec1e209-f719-41cc-9d26-a7a0a8bd1c03' class='xr-section-summary-in' type='checkbox'  checked><label for='section-aec1e209-f719-41cc-9d26-a7a0a8bd1c03' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>chlor_a</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-c1a66773-ebf8-46ad-adc0-af2ac4f0b83a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c1a66773-ebf8-46ad-adc0-af2ac4f0b83a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bccd2daa-56ee-40ca-821a-78aa00975df3' class='xr-var-data-in' type='checkbox'><label for='data-bccd2daa-56ee-40ca-821a-78aa00975df3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>ancillary_variables :</span></dt><dd>chlor_a_log10_rmsd chlor_a_log10_bias</dd><dt><span>chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>9.96921e+36</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd><dt><span>long_name :</span></dt><dd>Chlorophyll-a concentration in seawater (not log-transformed), generated by SeaDAS using a blended combination of OCI (OC4v6 + Hu&#x27;s CI), OC3 and OC5, depending on water class memberships</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>parameter_vocab_uri :</span></dt><dd>http://vocab.nerc.ac.uk/collection/P04/current/</dd><dt><span>shape :</span></dt><dd>[7, 4320, 8640]</dd><dt><span>size :</span></dt><dd>261273600</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>units :</span></dt><dd>milligram m-3</dd><dt><span>units_nonstandard :</span></dt><dd>mg m^-3</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-f9f63889-0ba6-4126-9dfd-aa7257002592' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f9f63889-0ba6-4126-9dfd-aa7257002592' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>chlor_a</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-64bae6da-bc62-4f8f-b0f7-379d40291e74' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-64bae6da-bc62-4f8f-b0f7-379d40291e74' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-62335186-d9a1-49fb-8fea-cff96ca28473' class='xr-var-data-in' type='checkbox'><label for='data-62335186-d9a1-49fb-8fea-cff96ca28473' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>ancillary_variables :</span></dt><dd>chlor_a_log10_rmsd chlor_a_log10_bias</dd><dt><span>chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>data_type :</span></dt><dd>float32</dd><dt><span>dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>file_chunk_sizes :</span></dt><dd>[1, 540, 1080]</dd><dt><span>file_dimensions :</span></dt><dd>[&#x27;time&#x27;, &#x27;lat&#x27;, &#x27;lon&#x27;]</dd><dt><span>fill_value :</span></dt><dd>9.96921e+36</dd><dt><span>grid_mapping :</span></dt><dd>crs</dd><dt><span>long_name :</span></dt><dd>Chlorophyll-a concentration in seawater (not log-transformed), generated by SeaDAS using a blended combination of OCI (OC4v6 + Hu&#x27;s CI), OC3 and OC5, depending on water class memberships</dd><dt><span>orig_data_type :</span></dt><dd>float32</dd><dt><span>parameter_vocab_uri :</span></dt><dd>http://vocab.nerc.ac.uk/collection/P04/current/</dd><dt><span>shape :</span></dt><dd>[7, 4320, 8640]</dd><dt><span>size :</span></dt><dd>261273600</dd><dt><span>standard_name :</span></dt><dd>mass_concentration_of_chlorophyll_a_in_sea_water</dd><dt><span>units :</span></dt><dd>milligram m-3</dd><dt><span>units_nonstandard :</span></dt><dd>mg m^-3</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table>\n",
@@ -20515,7 +20061,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-afefac16-3779-4f4e-9b1b-02b0a5467649' class='xr-section-summary-in' type='checkbox'  ><label for='section-afefac16-3779-4f4e-9b1b-02b0a5467649' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-02-23T14:17:29.750967</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_params&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;time_range&#x27;: [&#x27;2008-01-01T00:00:00&#x27;, &#x27;2008-07-01T00:00:00&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube_cci.chunkstore.CciChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;chunks&#x27;: {&#x27;lat&#x27;: 1024, &#x27;lon&#x27;: 1024, &#x27;time&#x27;: 1}, &#x27;spatial_res&#x27;: 0.041666666666666664, &#x27;time_period&#x27;: &#x27;1M&#x27;, &#x27;time_range&#x27;: [&#x27;2008-01-01&#x27;, &#x27;2008-07-01&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.1&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L3S</dd><dt><span>time_coverage_duration :</span></dt><dd>P213DT0H0M0S</dd><dt><span>time_coverage_end :</span></dt><dd>2008-08-01T00:00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2008-01-01T00:00:00</dd><dt><span>title :</span></dt><dd>esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-platform.MERGED.3-1.geographic</dd></dl></div></li></ul></div></div>"
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6a5399c0-e679-4b81-b880-1c4eef0bfabf' class='xr-section-summary-in' type='checkbox'  ><label for='section-6a5399c0-e679-4b81-b880-1c4eef0bfabf' class='xr-section-summary' >Attributes: <span>(18)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.7</dd><dt><span>date_created :</span></dt><dd>2022-06-23T08:44:09.505830</dd><dt><span>geospatial_bounds :</span></dt><dd>POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))</dd><dt><span>geospatial_bounds_crs :</span></dt><dd>CRS84</dd><dt><span>geospatial_lat_max :</span></dt><dd>90</dd><dt><span>geospatial_lat_min :</span></dt><dd>-90</dd><dt><span>geospatial_lat_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lat_units :</span></dt><dd>degrees_north</dd><dt><span>geospatial_lon_max :</span></dt><dd>180</dd><dt><span>geospatial_lon_min :</span></dt><dd>-180</dd><dt><span>geospatial_lon_resolution :</span></dt><dd>0.041666666666666664</dd><dt><span>geospatial_lon_units :</span></dt><dd>degrees_east</dd><dt><span>history :</span></dt><dd>[{&#x27;cube_params&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;time_range&#x27;: [&#x27;2008-01-01T00:00:00&#x27;, &#x27;2008-07-01T00:00:00&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube_cci.chunkstore.CciChunkStore&#x27;}, {&#x27;cube_config&#x27;: {&#x27;bbox&#x27;: [-180.0, -90.0, 180.0, 90.0], &#x27;chunks&#x27;: {&#x27;lat&#x27;: 1024, &#x27;lon&#x27;: 1024, &#x27;time&#x27;: 1}, &#x27;spatial_res&#x27;: 0.041666666666666664, &#x27;time_period&#x27;: &#x27;1M&#x27;, &#x27;time_range&#x27;: [&#x27;2008-01-01&#x27;, &#x27;2008-07-01&#x27;], &#x27;variable_names&#x27;: [&#x27;chlor_a&#x27;]}, &#x27;program&#x27;: &#x27;xcube gen2, version 0.10.2&#x27;}]</dd><dt><span>processing_level :</span></dt><dd>L3S</dd><dt><span>time_coverage_duration :</span></dt><dd>P213DT0H0M0S</dd><dt><span>time_coverage_end :</span></dt><dd>2008-08-01T00:00:00</dd><dt><span>time_coverage_start :</span></dt><dd>2008-01-01T00:00:00</dd><dt><span>title :</span></dt><dd>esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-platform.MERGED.3-1.geographic</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -20530,7 +20076,7 @@
        "    chlor_a    (time, lat, lon) float32 dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
        "Attributes: (12/18)\n",
        "    Conventions:                CF-1.7\n",
-       "    date_created:               2022-02-23T14:17:29.750967\n",
+       "    date_created:               2022-06-23T08:44:09.505830\n",
        "    geospatial_bounds:          POLYGON((-180 -90, -180 90, 180 90, 180 -90, ...\n",
        "    geospatial_bounds_crs:      CRS84\n",
        "    geospatial_lat_max:         90\n",
@@ -20544,7 +20090,7 @@
        "    title:                      esacci.OC.mon.L3S.CHLOR_A.multi-sensor.multi-..."
       ]
      },
-     "execution_count": 54,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20572,15 +20118,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 53,
    "id": "c5a23a54-f33a-4d83-b840-3d5eb94e2157",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-02-23T14:19:25.927247Z",
-     "iopub.status.busy": "2022-02-23T14:19:25.926636Z",
-     "iopub.status.idle": "2022-02-23T14:19:25.930795Z",
-     "shell.execute_reply": "2022-02-23T14:19:25.929819Z"
-    },
     "papermill": {
      "duration": 0.141013,
      "end_time": "2022-02-23T14:19:25.932665",
@@ -20615,7 +20155,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "EDC 2021.12 (Python3)",
+   "display_name": "EDC 2022.02 (Python3)",
    "language": "python",
    "name": "edc"
   },


### PR DESCRIPTION
Update of xcube notebooks to use `bbox` instead of `geometry` in requests. This way the user does not get warnings about deprecated parameter `geometry` anymore.